### PR TITLE
also override GraphRepositoryFactory.getQueryLookupStrategy(key)

### DIFF
--- a/neo4j-spring/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactory.java
+++ b/neo4j-spring/src/main/java/org/springframework/data/neo4j/repository/support/GraphRepositoryFactory.java
@@ -45,5 +45,10 @@ public class GraphRepositoryFactory extends RepositoryFactorySupport
     {
         return new GraphQueryLookupStrategy(session, key, evaluationContextProvider);
     }
+    @Override
+    protected QueryLookupStrategy getQueryLookupStrategy(QueryLookupStrategy.Key key)
+    {
+        return new GraphQueryLookupStrategy(session, key, null);
+    }
 
 }


### PR DESCRIPTION
`GraphRepositoryFactory.getQueryLookupStrategy(QueryLookupStrategy.Key)` to compensate shortcoming in sd-commons