### PR TITLE
Fix to use the annotated relationship type if defined for a relationship entity

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/EntityGraphMapper.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/EntityGraphMapper.java
@@ -310,6 +310,7 @@ public class EntityGraphMapper implements EntityToGraphMapper {
             relationshipBuilder = relId != null
                     ? cypherBuilder.existingRelationship(relId)
                     : cypherBuilder.newRelationship();
+            relationshipBuilder.type(relationshipType); //Should this be set only if relId==null?
         } else {
             relationshipBuilder = cypherBuilder.newRelationship().type(relationshipType);
         }
@@ -336,7 +337,9 @@ public class EntityGraphMapper implements EntityToGraphMapper {
         logger.debug("mapping relationshipEntity {}", relEntityClassInfo.name());
 
         AnnotationInfo annotation = relEntityClassInfo.annotationsInfo().get(RelationshipEntity.CLASS);
-        relationshipBuilder.type(annotation.get(RelationshipEntity.TYPE, relEntityClassInfo.name()));
+        if(relationshipBuilder.getType()==null) {
+            relationshipBuilder.type(annotation.get(RelationshipEntity.TYPE, relEntityClassInfo.name()));
+        }
 
         // if the RE is new, register it in the context so that we can
         // set its ID correctly when it is created,

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Actor.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Actor.java
@@ -1,16 +1,41 @@
 package org.neo4j.ogm.domain.cineasts.annotated;
 
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.HashSet;
 import java.util.Set;
 
 public class Actor {
 
-    private String id;
+    private Long id;
     private String name;
     private Set<Movie> filmography;
 
-    public Role playedIn(Movie movie, String role) {
-        return null;
+    @Relationship(type="ACTS_IN", direction="OUTGOING")
+    private Set<Role> roles;
+
+    private Set<Nomination> nominations;
+
+    public Actor(String name) {
+        this.name = name;
     }
 
+    public Role playedIn(Movie movie, String roleName) {
+        if(roles==null) {
+            roles = new HashSet<>();
+        }
+        Role role = new Role(movie,this,roleName);
+        roles.add(role);
+        return role;
+    }
+
+    public Nomination nominatedFor(Movie movie, String nominationName, int year) {
+        if(nominations==null) {
+            nominations = new HashSet<>();
+        }
+        Nomination nomination = new Nomination(movie,this,nominationName,year);
+        nominations.add(nomination);
+        return nomination;
+    }
 
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Movie.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Movie.java
@@ -9,9 +9,13 @@ public class Movie {
     Long id;
     String title;
     int year;
-    Set<Role> cast;
 
+    @Relationship(type="ACTS_IN", direction="INCOMING")
+    Set<Role> cast;
     Set<Rating> ratings;
+
+    Set<Nomination> nominations;
+
 
     public Long getId() {
         return id;
@@ -52,5 +56,13 @@ public class Movie {
     @Relationship(type="RATED", direction=Relationship.INCOMING)
     public void setRatings(Set<Rating> ratings) {
         this.ratings = ratings;
+    }
+
+    public Set<Nomination> getNominations() {
+        return nominations;
+    }
+
+    public void setNominations(Set<Nomination> nominations) {
+        this.nominations = nominations;
     }
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Nomination.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Nomination.java
@@ -5,17 +5,20 @@ import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.annotation.StartNode;
 
 @RelationshipEntity
-public class Role {
-    Long id;
-    @EndNode Movie movie;
-    @StartNode Actor actor;
-    String role;
+public class Nomination {
 
-    public Role(Movie movie, Actor actor, String role) {
+    Long id;
+    @EndNode
+    Movie movie;
+    @StartNode
+    Actor actor;
+    String name;
+    int year;
+
+    public Nomination(Movie movie, Actor actor, String name, int year) {
         this.movie = movie;
         this.actor = actor;
-        this.role = role;
+        this.name = name;
+        this.year = year;
     }
-
-
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/RelationshipEntityMappingTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/RelationshipEntityMappingTest.java
@@ -1,0 +1,43 @@
+package org.neo4j.ogm.unit.mapper;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.domain.cineasts.annotated.Actor;
+import org.neo4j.ogm.domain.cineasts.annotated.Movie;
+import org.neo4j.ogm.domain.cineasts.annotated.Role;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RelationshipEntityMappingTest extends MappingTest {
+
+    @BeforeClass
+    public static void setUp() {
+        MappingTest.setUp("org.neo4j.ogm.domain.cineasts.annotated");
+    }
+
+    @Test
+    public void testThatAnnotatedRelationshipOnRelationshipEntityCreatesTheCorrectRelationshipTypeInTheGraph() {
+        Movie hp = new Movie();
+        hp.setTitle("Goblet of Fire");
+        hp.setYear(2005);
+
+        Actor daniel = new Actor("Daniel Radcliffe");
+        daniel.playedIn(hp, "Harry Potter");
+        saveAndVerify(daniel, "CREATE (m:Movie {title : 'Goblet of Fire',year:2005 } ) create (a:Actor {name:'Daniel Radcliffe'}) create (a)-[:ACTS_IN {role:'Harry Potter'}]->(m)");
+
+    }
+
+    @Test
+    public void testThatRelationshipEntityNameIsUsedAsRelationshipTypeWhenTypeIsNotDefined() {
+        Movie hp = new Movie();
+        hp.setTitle("Goblet of Fire");
+        hp.setYear(2005);
+
+        Actor daniel = new Actor("Daniel Radcliffe");
+        daniel.nominatedFor(hp, "Saturn Award", 2005);
+        saveAndVerify(daniel, "CREATE (m:Movie {title : 'Goblet of Fire',year:2005 } ) create (a:Actor {name:'Daniel Radcliffe'}) create (a)-[:NOMINATIONS {name:'Saturn Award', year:2005}]->(m)");
+        //Not quite sure if the relationship type should be the field name or the RelationshipEntity class name?
+    }
+
+}

--- a/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/End2EndIntegrationTest.java
+++ b/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/End2EndIntegrationTest.java
@@ -521,7 +521,7 @@ public class End2EndIntegrationTest extends WrappingServerIntegrationTest
 
         userRepository.findByProperty( "name", "Michal" ).iterator().next();
 
-        assertSameGraph( getDatabase(), "CREATE (u:User {name:'Michal'})-[:Rating {stars:5, " +
+        assertSameGraph( getDatabase(), "CREATE (u:User {name:'Michal'})-[:RATED {stars:5, " +
                 "comment:'Best movie ever'}]->(m:Movie {title:'Pulp Fiction'})" );
     }
 


### PR DESCRIPTION
Falls back to using the field name of a relationship entity defined in the start/end node as the relationship type only if the field is not annotated with a specification of the relationship type.
