### PR TITLE
Fix for NPE when a relationship entity is saved with a new start node and existing end node.

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/EntityGraphMapper.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/EntityGraphMapper.java
@@ -361,7 +361,7 @@ public class EntityGraphMapper implements EntityToGraphMapper {
         if (mappingContext.isDirty(relationshipEntity)) {
             ClassInfo targetInfo = metaData.classInfo(targetEntity);
             Long tgtIdentity = (Long) entityAccessStrategy.getIdentityPropertyReader(targetInfo).read(targetEntity);
-            if (tgtIdentity != null) {
+            if (tgtIdentity != null && srcIdentity!=null) {
                 logger.debug("RE in the database is stale");
                 MappedRelationship mappedRelationship = createMappedRelationship(srcIdentity, relationshipBuilder, tgtIdentity);
                 if (mappingContext.mappedRelationships().remove(mappedRelationship)) {

--- a/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/End2EndIntegrationTest.java
+++ b/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/End2EndIntegrationTest.java
@@ -23,7 +23,11 @@ import org.springframework.data.neo4j.integration.movies.domain.Movie;
 import org.springframework.data.neo4j.integration.movies.domain.ReleasedMovie;
 import org.springframework.data.neo4j.integration.movies.domain.TempMovie;
 import org.springframework.data.neo4j.integration.movies.domain.User;
-import org.springframework.data.neo4j.integration.movies.repo.*;
+import org.springframework.data.neo4j.integration.movies.repo.AbstractAnnotatedEntityRepository;
+import org.springframework.data.neo4j.integration.movies.repo.AbstractEntityRepository;
+import org.springframework.data.neo4j.integration.movies.repo.CinemaRepository;
+import org.springframework.data.neo4j.integration.movies.repo.TempMovieRepository;
+import org.springframework.data.neo4j.integration.movies.repo.UserRepository;
 import org.springframework.data.neo4j.integration.movies.service.UserService;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -35,7 +39,10 @@ import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.WrappingServerIntegrationTest;
 import org.neo4j.tooling.GlobalGraphOperations;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.ogm.testutil.GraphTestUtils.assertSameGraph;
 
 @ContextConfiguration(classes = {PersistenceContext.class})

--- a/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/repo/TempMovieRepository.java
+++ b/neo4j-spring/src/test/java/org/springframework/data/neo4j/integration/movies/repo/TempMovieRepository.java
@@ -1,0 +1,8 @@
+package org.springframework.data.neo4j.integration.movies.repo;
+
+import org.springframework.data.neo4j.integration.movies.domain.TempMovie;
+import org.springframework.data.neo4j.repository.GraphRepository;
+
+
+public interface TempMovieRepository extends GraphRepository<TempMovie> {
+}


### PR DESCRIPTION
An NPE (below) was thrown when the start node of a relationship entity is new but the end node exists.
The fix to EntityGraphMapper.mapRelationshipEntity involves a null check for srcIdentity (if srcIdentity doesn't exist, there shouldn't be an existing relationship entity anyway)

java.lang.NullPointerException
	at org.neo4j.ogm.mapper.EntityGraphMapper.createMappedRelationship(EntityGraphMapper.java:380)
	at org.neo4j.ogm.mapper.EntityGraphMapper.mapRelationshipEntity(EntityGraphMapper.java:367)
	at org.neo4j.ogm.mapper.EntityGraphMapper.link(EntityGraphMapper.java:282)
	at org.neo4j.ogm.mapper.EntityGraphMapper.mapEntityReferences(EntityGraphMapper.java:235)
	at org.neo4j.ogm.mapper.EntityGraphMapper.mapEntity(EntityGraphMapper.java:148)
	at org.neo4j.ogm.mapper.EntityGraphMapper.map(EntityGraphMapper.java:78)
	at org.neo4j.ogm.session.Neo4jSession.save(Neo4jSession.java:358)
	at org.neo4j.ogm.session.Neo4jSession.save(Neo4jSession.java:322)