### PR TITLE
Fixed issue where a property of type collection of Enum or array of Enum with a converter, could not be loaded.

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/GraphEntityMapper.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/GraphEntityMapper.java
@@ -21,7 +21,15 @@
 package org.neo4j.ogm.mapper;
 
 import org.neo4j.ogm.annotation.Relationship;
-import org.neo4j.ogm.entityaccess.*;
+import org.neo4j.ogm.entityaccess.DefaultEntityAccessStrategy;
+import org.neo4j.ogm.entityaccess.EntityAccess;
+import org.neo4j.ogm.entityaccess.EntityAccessStrategy;
+import org.neo4j.ogm.entityaccess.EntityFactory;
+import org.neo4j.ogm.entityaccess.FieldWriter;
+import org.neo4j.ogm.entityaccess.PropertyReader;
+import org.neo4j.ogm.entityaccess.PropertyWriter;
+import org.neo4j.ogm.entityaccess.RelationalReader;
+import org.neo4j.ogm.entityaccess.RelationalWriter;
 import org.neo4j.ogm.metadata.MappingException;
 import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.metadata.info.ClassInfo;
@@ -33,8 +41,11 @@ import org.neo4j.ogm.model.RelationshipModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 public class GraphEntityMapper implements GraphToEntityMapper<GraphModel> {
 
@@ -123,10 +134,13 @@ public class GraphEntityMapper implements GraphToEntityMapper<GraphModel> {
                 PropertyReader reader = entityAccessStrategy.getPropertyReader(classInfo, property.getKey().toString());
                 if (reader != null) {
                     Object currentValue = reader.read(instance);
-                    if (writer.type().isArray()) {
-                        value = EntityAccess.merge(writer.type(), (Iterable<?>) value, (Object[]) currentValue);
+
+                    //Determine the type of property to merge using the read type(possibly converted) instead of the declared field type
+                    Class paramType = currentValue==null ? writer.type():currentValue.getClass();
+                    if (paramType.isArray()) {
+                        value = EntityAccess.merge(paramType, (Iterable<?>) value, (Object[]) currentValue);
                     } else {
-                        value = EntityAccess.merge(writer.type(), (Iterable<?>) value, (Iterable<?>) currentValue);
+                        value = EntityAccess.merge(paramType, (Iterable<?>) value, (Iterable<?>) currentValue);
                     }
                 }
             }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/SecurityRole.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/SecurityRole.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Neo4j-OGM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.ogm.domain.cineasts.annotated;
+
+public enum SecurityRole {
+    USER,
+    ADMIN
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/SecurityRoleConverter.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/SecurityRoleConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Neo4j-OGM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.ogm.domain.cineasts.annotated;
+
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+
+public class SecurityRoleConverter implements AttributeConverter<SecurityRole[],String[]> {
+
+    @Override
+    public String[] toGraphProperty(SecurityRole[] value) {
+        if(value==null) {
+            return null;
+        }
+        String[] values = new String[(value.length)];
+        int i=0;
+        for(SecurityRole securityRole : value) {
+            values[i++]=securityRole.name();
+        }
+        return values;
+    }
+
+    @Override
+    public SecurityRole[] toEntityAttribute(String[] value) {
+        SecurityRole[] roles =new SecurityRole[value.length];
+        int i=0;
+        for(String role : value) {
+            roles[i++] = SecurityRole.valueOf(role);
+        }
+        return roles;
+    }
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Title.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Title.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Neo4j-OGM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.ogm.domain.cineasts.annotated;
+
+public enum Title {
+    MR,
+    MRS,
+    MS,
+    DR
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/TitleConverter.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/TitleConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2015 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Neo4j-OGM is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.neo4j.ogm.domain.cineasts.annotated;
+
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TitleConverter implements AttributeConverter<List<Title>,String[]> {
+
+    @Override
+    public String[] toGraphProperty(List<Title> value) {
+        if(value==null) {
+            return null;
+        }
+        String[] values = new String[(value.size())];
+        int i=0;
+        for(Title title : value) {
+            values[i++]=title.name();
+        }
+        return values;
+    }
+
+    @Override
+    public List<Title> toEntityAttribute(String[] value) {
+        List<Title> titles = new ArrayList<>(value.length);
+        for(String role : value) {
+           titles.add(Title.valueOf(role));
+        }
+        return titles;
+    }
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/User.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/User.java
@@ -20,6 +20,9 @@
 
 package org.neo4j.ogm.domain.cineasts.annotated;
 
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+
+import java.util.List;
 import java.util.Set;
 
 public class User {
@@ -31,6 +34,11 @@ public class User {
 
     Set<Rating> ratings;
     Set<User> friends;
+
+    @Convert(SecurityRoleConverter.class)
+    SecurityRole[] securityRoles;
+    @Convert(TitleConverter.class)
+    List<Title> titles;
 
     Rating rate(Movie movie, int stars, String comment) {
         return null;
@@ -85,5 +93,21 @@ public class User {
 
     public void setFriends(Set<User> friends) {
         this.friends = friends;
+    }
+
+    public SecurityRole[] getSecurityRoles() {
+        return securityRoles;
+    }
+
+    public void setSecurityRoles(SecurityRole[] securityRoles) {
+        this.securityRoles = securityRoles;
+    }
+
+    public List<Title> getTitles() {
+        return titles;
+    }
+
+    public void setTitles(List<Title> titles) {
+        this.titles = titles;
     }
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
@@ -20,19 +20,25 @@
 
 package org.neo4j.ogm.integration.cineasts.annotated;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.util.Collection;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.ogm.domain.cineasts.annotated.Movie;
 import org.neo4j.ogm.domain.cineasts.annotated.Rating;
+import org.neo4j.ogm.domain.cineasts.annotated.SecurityRole;
+import org.neo4j.ogm.domain.cineasts.annotated.Title;
 import org.neo4j.ogm.domain.cineasts.annotated.User;
 import org.neo4j.ogm.integration.IntegrationTest;
 import org.neo4j.ogm.model.Property;
 import org.neo4j.ogm.session.SessionFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Simple integration test based on cineasts that exercises relationship entities.
@@ -101,6 +107,41 @@ public class CineastsIntegrationTest extends IntegrationTest {
             assertNotNull("The user start node should've been mapped", rating.getUser());
             assertSame("The wrong film was mapped to the rating", film, rating.getMovie());
         }
+    }
+
+    @Test
+    public void saveAndRetrieveUserWithSecurityRoles() {
+        User user = new User();
+        user.setLogin("daniela");
+        user.setName("Daniela");
+        user.setPassword("daniela");
+        user.setSecurityRoles(new SecurityRole[]{SecurityRole.USER});
+        session.save(user);
+
+        Collection<User> users = session.loadByProperty(User.class,new Property<String, Object>("login","daniela"));
+        assertEquals(1,users.size());
+        User daniela = users.iterator().next();
+        assertEquals("Daniela", daniela.getName());
+        assertEquals(1,daniela.getSecurityRoles().length);
+        assertEquals(SecurityRole.USER,daniela.getSecurityRoles()[0]);
+    }
+
+    @Test
+    public void saveAndRetrieveUserWithTitles() {
+        User user = new User();
+        user.setLogin("vince");
+        user.setName("Vince");
+        user.setPassword("vince");
+        user.setTitles(Arrays.asList(Title.MR));
+        session.save(user);
+
+        Collection<User> users = session.loadByProperty(User.class,new Property<String, Object>("login","vince"));
+        assertEquals(1,users.size());
+        User vince = users.iterator().next();
+        assertEquals("Vince", vince.getName());
+        assertEquals(1, vince.getTitles().size());
+        assertEquals(Title.MR,vince.getTitles().get(0));
+
     }
 
 }


### PR DESCRIPTION
With a converter for a collection/array of Enums->String[], the property could not be merged since the collections being merged were of the converted type whereas the resulting collection type was expected to be the defined field type for the property.

Original exception for this bug- 
Caused by: java.lang.IllegalArgumentException: array element type mismatch
	at java.lang.reflect.Array.set(Native Method)
	at org.neo4j.ogm.entityaccess.EntityAccess.merge(EntityAccess.java:58)
	at org.neo4j.ogm.entityaccess.EntityAccess.merge(EntityAccess.java:32)
	at org.neo4j.ogm.mapper.GraphEntityMapper.writeProperty(GraphEntityMapper.java:127)
