### PR TITLE
Set the charset on the HttpEntity to UTF-8 as well ...

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/session/request/DefaultRequest.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/session/request/DefaultRequest.java
@@ -51,7 +51,7 @@ public class DefaultRequest implements Neo4jRequest<String> {
             LOGGER.info("POST " + url + ", request: " + cypherQuery);
 
             HttpPost request = new HttpPost(url);
-            HttpEntity entity = new StringEntity(cypherQuery);
+            HttpEntity entity = new StringEntity(cypherQuery,"UTF-8");
 
             request.setHeader(new BasicHeader(HTTP.CONTENT_TYPE,"application/json;charset=UTF-8"));
             request.setHeader(new BasicHeader("Accept", "application/json;charset=UTF-8"));

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
@@ -142,4 +142,18 @@ public class CineastsIntegrationTest extends IntegrationTest {
 
     }
 
+    @Test
+    public void saveAndRetrieveUserWithDifferentCharset() {
+        User user = new User();
+        user.setLogin("aki");
+        user.setName("Aki Kaurismäki");
+        user.setPassword("aki");
+        session.save(user);
+
+        Collection<User> users = session.loadByProperty(User.class,new Property<String, Object>("login","aki"));
+        assertEquals(1,users.size());
+        User vince = users.iterator().next();
+        assertEquals("Aki Kaurismäki", vince.getName());
+
+    }
 }


### PR DESCRIPTION
...to fix NPE when a Cypher statement with another charset is executed (java.lang.NullPointerException: null at org.neo4j.server.rest.transactional.TransactionHandle.commit(TransactionHandle.java:120) ~[neo4j-server-2.1.7.jar:2.1.7])