### PR TITLE
Fix: When a property of type collection of Enum or array of Enum with a ...

### DIFF
--- a/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/GraphEntityMapper.java
+++ b/neo4j-ogm/src/main/java/org/neo4j/ogm/mapper/GraphEntityMapper.java
@@ -132,9 +132,8 @@ public class GraphEntityMapper implements GraphToEntityMapper<GraphModel> {
                 PropertyReader reader = entityAccessStrategy.getPropertyReader(classInfo, property.getKey().toString());
                 if (reader != null) {
                     Object currentValue = reader.read(instance);
+                    Class paramType = determineParamType(classInfo, property, writer, currentValue);
 
-                    //Determine the type of property to merge using the read type(possibly converted) instead of the declared field type
-                    Class paramType = currentValue==null ? writer.type():currentValue.getClass();
                     if (paramType.isArray()) {
                         value = EntityAccess.merge(paramType, (Iterable<?>) value, (Object[]) currentValue);
                     } else {
@@ -144,6 +143,26 @@ public class GraphEntityMapper implements GraphToEntityMapper<GraphModel> {
             }
             writer.write(instance, value);
         }
+    }
+
+    /**
+     * Determine the param type of the attribute to merge.
+     * If the current value of the property (possibly converted) exists, use that type.
+     * Otherwise, if the property has a converter, use the return type of toGraphProperty.
+     */
+    private Class determineParamType(ClassInfo classInfo, Property property, PropertyWriter writer, Object currentValue) {
+        Class paramType = writer.type();
+        if (currentValue != null) {
+            paramType = currentValue.getClass(); //Determine the param type from the current value (possibly converted) of the property
+        } else if (classInfo.fieldsInfo().get(property.getKey().toString()).converter() != null) {
+            //If the field has a converter, then use the return type of toGraphProperty
+            try {
+                paramType = classInfo.fieldsInfo().get(property.getKey().toString()).converter().getClass().getDeclaredMethod("toGraphProperty", writer.type()).getReturnType();
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return paramType;
     }
 
     private boolean tryMappingAsSingleton(Object source, Object parameter, RelationshipModel edge) {

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
@@ -152,8 +152,8 @@ public class CineastsIntegrationTest extends IntegrationTest {
 
         Collection<User> users = session.loadByProperty(User.class,new Property<String, Object>("login","aki"));
         assertEquals(1,users.size());
-        User vince = users.iterator().next();
-        assertEquals("Aki Kaurismäki", vince.getName());
+        User aki = users.iterator().next();
+        assertEquals("Aki Kaurismäki", aki.getName());
 
     }
 }

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/model/cineasts/annotated/UserRequest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/model/cineasts/annotated/UserRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2015 "GraphAware"
+ *
+ * GraphAware Ltd
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.neo4j.ogm.unit.mapper.model.cineasts.annotated;
+
+import org.neo4j.ogm.RequestProxy;
+
+public class UserRequest extends RequestProxy {
+
+    public String[] getResponse() {
+        return jsonModel;
+    }
+
+    private static String[] jsonModel = {
+            "{\"graph\": { " +
+                    "\"nodes\" :[ " +
+                    "{\"id\" : \"15\",\"labels\" : [ \"User\"],    \"properties\" : {\"login\" : \"luanne\", \"securityRoles\" : [\"USER\",\"ADMIN\"]}}" +
+                    "]} }"
+    };
+}

--- a/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/model/cineasts/annotated/UserTest.java
+++ b/neo4j-ogm/src/test/java/org/neo4j/ogm/unit/mapper/model/cineasts/annotated/UserTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014-2015 "GraphAware"
+ *
+ * GraphAware Ltd
+ *
+ * This file is part of Neo4j-OGM.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package org.neo4j.ogm.unit.mapper.model.cineasts.annotated;
+
+import org.junit.Test;
+import org.neo4j.ogm.domain.cineasts.annotated.User;
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.SessionFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+public class UserTest {
+
+    @Test
+    public void testDeserialiseUserWithArrayOfEnums() {
+
+        UserRequest userRequest = new UserRequest();
+
+        SessionFactory sessionFactory = new SessionFactory("org.neo4j.ogm.domain.cineasts.annotated");
+        Neo4jSession session = ((Neo4jSession) sessionFactory.openSession("dummy-url"));
+        session.setRequest(userRequest);
+
+        User user = session.load(User.class, 15L, 1);
+
+        assertEquals("luanne", user.getLogin());
+        assertNotNull(user.getSecurityRoles());
+        assertEquals(2, user.getSecurityRoles().length);
+    }
+}


### PR DESCRIPTION
...converter is loaded use the converter to determine the type if the value of the property on the existing instance is null.