### PR TITLE
Add paging and sorting support for custom queries.

### DIFF
--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/Clause.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/Clause.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Abstract representation of a cypher-query clause.
+ *
+ * @author Rene Richter
+ */
+public abstract class Clause  {
+
+    private String content;
+    private List<String> aliases = new ArrayList<>();
+
+    protected Clause(String content) {
+        this.content = content;
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
+    }
+
+    /**
+     * Takes clause content and parses its aliases.
+     * @return A list of aliases.
+     */
+    public abstract List<String> parseAliases();
+
+    /**
+     * Creates a new WithClause.
+     *
+     * The newly created WithClause gets parsed by calling the parseAliases method.
+     * Use this method instead of the new operator.
+     *
+     * @param content The clause content.
+     * @return A new WithClause instance.
+     */
+    public static WithClause newWithClause(String content) {
+        WithClause clause = new WithClause(content);
+        clause.setAliases(clause.parseAliases());
+        return clause;
+    }
+
+    /**
+     * Creates a new ReturnClause.
+     *
+     * The newly created ReturnClause gets parsed by calling the parseAliases method.
+     * Use this method instead of the new operator.
+     *
+     * @param content The clause content.
+     * @return A new ReturnClause instance.
+     */
+    public static ReturnClause newReturnClause(String content) {
+        ReturnClause returnClause = new ReturnClause(content);
+        returnClause.setAliases(returnClause.parseAliases());
+        return returnClause;
+
+    }
+
+    /**
+     * Creates a new MatchClause.
+     *
+     * The newly created MatchClause gets parsed by calling the parseAliases method.
+     * Use this method instead of the new operator.
+     *
+     * @param content The clause content.
+     * @return A new MatchClause instance.
+     */
+    public static MatchClause newMatchClause(String content) {
+        MatchClause matchClause = new MatchClause(content);
+        matchClause.setAliases(matchClause.parseAliases());
+        return matchClause;
+    }
+}

--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/MatchClause.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/MatchClause.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+import static org.neo4j.ogm.cypher.statement.parser.ParseUtils.lookFor;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class MatchClause extends Clause {
+
+    private static final Pattern extractMatchAliasesPattern = Pattern.compile(
+            "(?<=\\()\\s*\\w+\\s*(?=(:|\\)))"       //Match aliases for nodes
+          + "|"
+          + "(?<=\\[)\\s*\\w+\\s*(?=(:|\\]))"       //Match aliases for relationships
+          + "|"
+          + "(?<=\\>|-)\\s*\\w+\\s*(?=($|\\z|-|<))" //Match aliases after > or -
+          + "|"
+          + "(?<=MATCH|=)\\s*\\w+\\s*(?=($|\\z|-|<))" //Match aliases after MATCH-keyword or equals-sign.
+            ,Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern extractPathAliasPattern = Pattern.compile(
+            "\\s*\\w+\\s*(?==)"  //Match everything that is followed by an = sign.
+            ,Pattern.CASE_INSENSITIVE);
+
+
+    private boolean matchesPath;
+
+    public MatchClause(String content) {
+        super(content);
+    }
+
+    /**
+     * Indicates whether or not this MatchClause contains a path alias.
+     * @return true, if it contains a path alias.
+     */
+    public boolean isPathMatch() {
+        return matchesPath;
+    }
+
+    @Override
+    public List<String> parseAliases() {
+        List<String> aliases = lookFor(extractMatchAliasesPattern, getContent());
+        List<String> pathAliases = lookFor(extractPathAliasPattern,getContent());
+        this.matchesPath = !pathAliases.isEmpty();
+        aliases.addAll(pathAliases);
+        return aliases;
+    }
+}

--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/ParseUtils.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/ParseUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class ParseUtils {
+
+    //Helpermethod to collect matches.
+    public static List<String> lookFor(Pattern pattern,String text) {
+        Matcher m = pattern.matcher(text);
+        List<String> returnValues = new LinkedList<>();
+        while(m.find()) {
+            returnValues.add(m.group().trim());
+        }
+        return returnValues;
+    }
+}

--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/ReturnClause.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/ReturnClause.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+import static org.neo4j.ogm.cypher.statement.parser.ParseUtils.lookFor;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class ReturnClause  extends  Clause {
+
+    private static final Pattern extractReturnAliasesPattern = Pattern.compile(
+            "\\s*[\\w\\.]+\\b\\s*(?=(\\)|,|\\.|\\z|$))" //everything that is a word followed by either ".",")", ",", "end of line" or "end of string"
+            ,Pattern.CASE_INSENSITIVE);
+
+    public ReturnClause(String content) {
+        super(content);
+    }
+
+    @Override
+    public List<String> parseAliases() {
+        List<String> aliases = new LinkedList<>();
+        String dirtyAliasesString =  lookFor(extractReturnAliasesPattern, getContent()).get(0);
+        for(String alias : lookFor(extractReturnAliasesPattern, getContent())) {
+            //in some cases, the aliases have also properties. Eg: a.firstname.
+            aliases.add(alias.split("\\.")[0]);
+        }
+        return aliases;
+    }
+}

--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/StatementParser.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/StatementParser.java
@@ -1,0 +1,56 @@
+
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+
+import static org.neo4j.ogm.cypher.statement.parser.ParseUtils.lookFor;
+
+import java.util.LinkedList;
+import java.util.regex.Pattern;
+
+/**
+ * A parser for cypher queries to extract key-components of a query.
+ * @author Rene Richter
+ */
+public class StatementParser {
+
+    //precompiled pattern should boost performance.
+    private static final Pattern extractClausesPattern = Pattern.compile(
+            "(WITH.*?(?=($|MATCH|ORDER|RETURN|SKIP|LIMIT)))"
+          + "|"
+          + "(MATCH.*?(?=($|WHERE|RETURN|WITH)))"
+          + "|"
+          + "(RETURN.*?(\\z|$))"
+            ,Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Parses the statement and extracts MATCH,WITH and RETURN-clauses.
+     * @param statement The statement that should get parsed.
+     * @return A LinkedList containing all matched clauses.
+     */
+    public LinkedList<Clause> parseStatement(String statement) {
+        LinkedList<Clause> result = new LinkedList<>();
+        for (String clauseString : lookFor(extractClausesPattern, statement)) {
+            clauseString = clauseString.trim();
+            if(clauseString.toLowerCase().startsWith("with")) {
+                result.add(Clause.newWithClause(clauseString));
+            } else if (clauseString.toLowerCase().startsWith("match")) {
+                result.add(Clause.newMatchClause(clauseString));
+            } else {
+                result.add(Clause.newReturnClause(clauseString));
+            }
+        }
+        return  result;
+    }
+}

--- a/src/main/java/org/neo4j/ogm/cypher/statement/parser/WithClause.java
+++ b/src/main/java/org/neo4j/ogm/cypher/statement/parser/WithClause.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.cypher.statement.parser;
+
+import static org.neo4j.ogm.cypher.statement.parser.ParseUtils.lookFor;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class WithClause extends Clause {
+
+    private static final Pattern extractWithAliasesPattern = Pattern.compile(
+            "(?<!\\[)\\s*[\\w\\.]+\\b\\s*(?=(,|\\z|$))" // Match aliases after WITH.
+            ,Pattern.CASE_INSENSITIVE);
+
+
+    public WithClause(String content) {
+        super(content);
+    }
+
+    @Override
+    public List<String> parseAliases() {
+        return lookFor(extractWithAliasesPattern, getContent());
+    }
+}

--- a/src/main/java/org/neo4j/ogm/session/Capability.java
+++ b/src/main/java/org/neo4j/ogm/session/Capability.java
@@ -11,15 +11,15 @@
  */
 package org.neo4j.ogm.session;
 
-import java.util.Collection;
-import java.util.Map;
-
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
 import org.neo4j.ogm.cypher.query.Pagination;
 import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.session.result.QueryStatistics;
 import org.neo4j.ogm.session.transaction.Transaction;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * @author Vince Bickers
@@ -172,6 +172,7 @@ public interface Capability {
          */
         <T> T queryForObject(Class<T> objectType, String cypher,  Map<String, ?> parameters);
 
+
         /**
          * Given a non modifying cypher statement this method will return a collection of domain objects that is hydrated to
          * the level specified in the given cypher query or a collection of scalars (depending on the parametrized type).
@@ -185,6 +186,35 @@ public interface Capability {
          * @return A collection of domain objects or scalars as prescribed by the parametrized type.
          */
         <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters);
+
+        /**
+         * Given a non modifying cypher statement this method will return a sorted collection of domain objects that is hydrated to
+         * the level specified in the given cypher query or a collection of scalars (depending on the parametrized type).
+         * The sorting depends on the query layout.
+         *
+         * If the query is intended for node- or relationship entities, the first RETURN alias will be the anchor for sorting.
+         *
+         * If the query asks for a path and has a with clause right before the path,
+         * the with-clause will be used for sorting and pagination to narrow down the path.
+         *
+         * If no previous with-clause is present, one will be generated after the
+         * path-match with node and relationship aliases. The first alias found
+         * will be used for sorting.
+         *
+         * @param objectType The type that should be returned from the query.
+         * @param cypher The parametrizable cypher to execute.
+         * @param parameters Any parameters to attach to the cypher.
+         * @param sortOrder The sort operation.
+         *
+         * @param <T> A domain object or scalar.
+         *
+         * @return A sorted collection of domain objects or scalars as prescribed by the parametrized type.
+         */
+        <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters,SortOrder sortOrder);
+        <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters, Pagination pagination);
+        <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters,SortOrder sortOrder, Pagination pagination);
+
+
 
         /**
          * Given a non modifying cypher statement this method will return a collection of Map's which represent Neo4j

--- a/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -330,6 +330,21 @@ public class Neo4jSession implements Session {
     }
 
     @Override
+    public <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters, Pagination pagination) {
+        return executeQueriesDelegate.query(objectType,cypher,parameters,pagination);
+    }
+
+    @Override
+    public <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters, SortOrder sortOrder) {
+        return executeQueriesDelegate.query(objectType,cypher,parameters,sortOrder);
+    }
+
+    @Override
+    public <T> Iterable<T> query(Class<T> objectType, String cypher, Map<String, ?> parameters, SortOrder sortOrder, Pagination pagination) {
+        return executeQueriesDelegate.query(objectType,cypher,parameters,sortOrder,pagination);
+    }
+
+    @Override
     public long countEntitiesOfType(Class<?> entity) {
         return executeQueriesDelegate.countEntitiesOfType(entity);
     }

--- a/src/main/java/org/neo4j/ogm/session/request/strategy/VariableDepthRelationshipQuery.java
+++ b/src/main/java/org/neo4j/ogm/session/request/strategy/VariableDepthRelationshipQuery.java
@@ -32,7 +32,7 @@ public class VariableDepthRelationshipQuery implements QueryStatements {
         int max = max(depth);
         int min = min(max);
         if (max > 0) {
-            String qry = String.format("MATCH (n)-[r]->() WHERE ID(r) = { id } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN collect(distinct p)", min, max);
+            String qry = String.format("MATCH (n)-[r]->() WHERE ID(r) = { id } WITH n,r MATCH p=(n)-[*%d..%d]-(m) RETURN collect(distinct p)", min, max);
             return new GraphModelQuery(qry, Utils.map("id", id));
         } else {
             throw new InvalidDepthException("Cannot load a relationship entity with depth 0 i.e. no start or end node");
@@ -44,7 +44,7 @@ public class VariableDepthRelationshipQuery implements QueryStatements {
         int max = max(depth);
         int min = min(max);
         if (max > 0) {
-            String qry=String.format("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN collect(distinct p)", min, max);
+            String qry=String.format("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH r,n MATCH p=(n)-[*%d..%d]-(m) RETURN collect(distinct p)", min, max);
             return new GraphModelQuery(qry, Utils.map("ids", ids));
         } else {
             throw new InvalidDepthException("Cannot load a relationship entity with depth 0 i.e. no start or end node");
@@ -75,7 +75,7 @@ public class VariableDepthRelationshipQuery implements QueryStatements {
 		if (max > 0) {
 			Map<String, Object> properties = new HashMap<>();
             StringBuilder query = constructQuery(type, parameters, properties);
-			query.append(String.format("WITH n,r MATCH p=(n)-[*%d..%d]-() RETURN collect(distinct p), ID(r)", min, max));
+			query.append(String.format("WITH r,n MATCH p=(n)-[*%d..%d]-() RETURN collect(distinct p), ID(r)", min, max));
 			return new GraphRowModelQuery(query.toString(), properties);
 		} else {
 			throw new InvalidDepthException("Cannot load a relationship entity with depth 0 i.e. no start or end node");

--- a/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Actor.java
+++ b/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Actor.java
@@ -12,10 +12,10 @@
 
 package org.neo4j.ogm.domain.cineasts.annotated;
 
+import org.neo4j.ogm.annotation.Relationship;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import org.neo4j.ogm.annotation.Relationship;
 
 /**
  * @author Vince Bickers
@@ -86,6 +86,10 @@ public class Actor {
         this.nominations = nominations;
     }
 
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -103,10 +107,6 @@ public class Actor {
     @Override
     public int hashCode() {
         return name != null ? name.hashCode() : 0;
-    }
-
-    public Set<Role> getRoles() {
-        return roles;
     }
 
     public void setRoles(Set<Role> roles) {

--- a/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Role.java
+++ b/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/Role.java
@@ -58,4 +58,11 @@ public class Role {
     public void setRole(String role) {
         this.role = role;
     }
+
+    @Override
+    public String toString() {
+        return "Role{" +
+                "role='" + role + '\'' +
+                '}';
+    }
 }

--- a/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
+++ b/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsIntegrationTest.java
@@ -12,22 +12,38 @@
 
 package org.neo4j.ogm.integration.cineasts.annotated;
 
-import static org.junit.Assert.*;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.ogm.cypher.Filter;
-import org.neo4j.ogm.domain.cineasts.annotated.*;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.SortOrder;
+import org.neo4j.ogm.domain.cineasts.annotated.Actor;
+import org.neo4j.ogm.domain.cineasts.annotated.Movie;
+import org.neo4j.ogm.domain.cineasts.annotated.Rating;
+import org.neo4j.ogm.domain.cineasts.annotated.SecurityRole;
+import org.neo4j.ogm.domain.cineasts.annotated.Title;
+import org.neo4j.ogm.domain.cineasts.annotated.User;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.Neo4jIntegrationTestRule;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Simple integration test based on cineasts that exercises relationship entities.
@@ -181,7 +197,7 @@ public class CineastsIntegrationTest {
         assertNotNull("The entities weren't loaded", actors);
         assertTrue("The entity wasn't loaded", actors.iterator().hasNext());
         for (Actor actor : actors) {
-            assertTrue("Shouldn't've loaded " + actor.getName(), actor.getName().equals("John") || actor.getName().equals("Jeff"));
+            assertTrue("Shouldn't've loaded " + actor.getName(), actor.getName().startsWith("J"));
         }
     }
 
@@ -196,6 +212,29 @@ public class CineastsIntegrationTest {
                 Collections.<String, Object>singletonMap("param", alec.getId()));
         assertNotNull("The entity wasn't loaded", loadedActor);
         assertEquals("Alec Baldwin", loadedActor.getName());
+    }
+
+    @Test
+    public void shouldQueryForActorUsingCypherQueryAndPagination() {
+        session.save(new Actor("Helen Mirren"));
+        session.save(new Actor("Alec Baldwin"));
+        session.save(new Actor("Matt Damon"));
+        session.save(new Actor("Johnny Depp"));
+        session.save(new Actor("Til Schweiger"));
+        session.save(new Actor("Bruce Willis"));
+
+        Pagination pagination = new Pagination(2,2);
+        SortOrder sortOrder = new SortOrder();
+        sortOrder.add("id");
+        Map<String,Object> parameters = new HashMap<>();
+        Iterable<Actor> loadedActors = session.query(Actor.class, "MATCH (a:Actor) RETURN a",parameters,sortOrder,pagination);
+
+        List<Actor> result = new ArrayList<>();
+        for(Actor actor : loadedActors) {
+            result.add(actor);
+        }
+
+        assertEquals(2,result.size());
     }
 
 }

--- a/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/src/test/java/org/neo4j/ogm/integration/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -23,6 +23,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.domain.cineasts.annotated.*;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/CustomQueryPagingAndSortingTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/CustomQueryPagingAndSortingTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.Query;
+import org.neo4j.ogm.cypher.query.RowModelQuery;
+import org.neo4j.ogm.cypher.query.SortOrder;
+
+import java.util.HashMap;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class CustomQueryPagingAndSortingTest {
+    @Test
+    public void itShouldTakeTheFirstReturnAliasForSorting() {
+        String cypher = "match (u)->[a:HAS_MANY]->(t:Tupel{id:2}) RETURN u";
+        Query query = new RowModelQuery(cypher,new HashMap<String,Object>());
+        query.setPagination(new Pagination(0, 2));
+        query.setSortOrder(new SortOrder().add("firstname").add("lastname"));
+
+        check("match (u)->[a:HAS_MANY]->(t:Tupel{id:2}) WITH u,a,t ORDER BY u.firstname,u.lastname SKIP 0 LIMIT 2 RETURN u",query.getStatement());
+    }
+
+    @Test
+    public void ifLastMatchContainsWithClauseItShouldNotGenerateANewWithClause() {
+        String cypher = "match (u)->[a:HAS_MANY]->(t:Tupel{id:2}) WITH distinct u RETURN u";
+        Query query = new RowModelQuery(cypher,new HashMap<String,Object>());
+        query.setPagination(new Pagination(0, 2));
+        query.setSortOrder(new SortOrder().add("firstname").add("lastname"));
+
+        check("match (u)->[a:HAS_MANY]->(t:Tupel{id:2}) WITH distinct u ORDER BY u.firstname,u.lastname SKIP 0 LIMIT 2 RETURN u",query.getStatement());
+    }
+
+
+    @Test
+    public void itShouldTakeRelationshipAliasIfFirstReturnAliasIsRelationshipAlias() {
+        String cypher = "match ()->[a:HAS_MANY]->(t:Tupel{id:2}) RETURN a";
+        Query query = new RowModelQuery(cypher,new HashMap<String,Object>());
+        query.setPagination(new Pagination(0, 2));
+        query.setSortOrder(new SortOrder().add("date"));
+        check("match ()->[a:HAS_MANY]->(t:Tupel{id:2}) WITH a,t ORDER BY a.date SKIP 0 LIMIT 2 RETURN a",query.getStatement());
+    }
+
+    @Test
+    public void sortingShouldGetResolvedByMatchIfLastMatchStatementContainsAPathAlias() {
+        String cypher = "match p=()->[a:HAS_MANY]->(t:Tupel{id:2}) RETURN collect(distinct p)";
+        Query query = new RowModelQuery(cypher,new HashMap<String,Object>());
+        query.setPagination(new Pagination(0, 2));
+        query.setSortOrder(new SortOrder().add("date"));
+        check("match p=()->[a:HAS_MANY]->(t:Tupel{id:2}) WITH a,t,p ORDER BY a.date SKIP 0 LIMIT 2 RETURN collect(distinct p)",query.getStatement());
+    }
+
+    @Test
+    public void ifLastMatchIsPathMatchAndHasAPreviousWithClauseTheWithClauseShouldResolvePagingAndSorting() {
+        String cypher = "match a-->b with a,b match p=()->[a:HAS_MANY]->(t:Tupel{id:2}) RETURN collect(distinct p)";
+        Query query = new RowModelQuery(cypher,new HashMap<String,Object>());
+        query.setPagination(new Pagination(0, 2));
+        query.setSortOrder(new SortOrder().add("date"));
+        check("match a-->b with a,b ORDER BY a.date SKIP 0 LIMIT 2 match p=()->[a:HAS_MANY]->(t:Tupel{id:2}) RETURN collect(distinct p)",query.getStatement());
+    }
+
+    private void check(String expected, String actual) {
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/NodeEntityQueryPagingTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/NodeEntityQueryPagingTest.java
@@ -11,71 +11,75 @@
  */
 package org.neo4j.ogm.unit.mapper.cypher;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-
 import org.junit.Test;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
 import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.Query;
+import org.neo4j.ogm.cypher.query.RowModelQuery;
+import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.session.request.strategy.VariableDepthQuery;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Vince Bickers
  */
 public class NodeEntityQueryPagingTest {
 
-    private final VariableDepthQuery query = new VariableDepthQuery();
+    private final VariableDepthQuery variableDepthQuery = new VariableDepthQuery();
 
     @Test
     public void testFindAll() {
-        check("MATCH p=()-->() WITH p SKIP 2 LIMIT 2 RETURN p", query.findAll().setPagination(new Pagination(1, 2)).getStatement());
+        check("MATCH p=()-->() WITH p SKIP 2 LIMIT 2 RETURN p", variableDepthQuery.findAll().setPagination(new Pagination(1, 2)).getStatement());
     }
 
     @Test
     public void testFindById() {
-        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 2 LIMIT 2 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(23L, 24L), 1).setPagination(new Pagination(1, 2)).getStatement());
+        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 2 LIMIT 2 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", variableDepthQuery.findAll(Arrays.asList(23L, 24L), 1).setPagination(new Pagination(1, 2)).getStatement());
     }
 
     @Test
     public void testFindByType() {
-        check("MATCH (n:`Raptor`) WITH n SKIP 4 LIMIT 2 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findByType("Raptor", 1).setPagination(new Pagination(2, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WITH n SKIP 4 LIMIT 2 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", variableDepthQuery.findByType("Raptor", 1).setPagination(new Pagination(2, 2)).getStatement());
     }
 
     @Test
     public void testFindByProperty() {
-        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` } WITH n SKIP 0 LIMIT 2 MATCH p=(n)-[*0..2]-(m) RETURN collect(distinct p), ID(n)", query.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), 2).setPagination(new Pagination(0, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` } WITH n SKIP 0 LIMIT 2 MATCH p=(n)-[*0..2]-(m) RETURN collect(distinct p), ID(n)", variableDepthQuery.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), 2).setPagination(new Pagination(0, 2)).getStatement());
     }
 
     @Test
     public void testFindByIdDepthZero() {
-        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 1 LIMIT 1 RETURN n", query.findAll(Arrays.asList(23L, 24L), 0).setPagination(new Pagination(1, 1)).getStatement());
+        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 1 LIMIT 1 RETURN n", variableDepthQuery.findAll(Arrays.asList(23L, 24L), 0).setPagination(new Pagination(1, 1)).getStatement());
     }
 
     @Test
     public void testFindByTypeDepthZero() {
-        check("MATCH (n:`Raptor`) WITH n SKIP 4 LIMIT 2 RETURN n", query.findByType("Raptor", 0).setPagination(new Pagination(2, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WITH n SKIP 4 LIMIT 2 RETURN n", variableDepthQuery.findByType("Raptor", 0).setPagination(new Pagination(2, 2)).getStatement());
     }
 
     @Test
     public void testByPropertyDepthZero() {
-        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` } WITH n SKIP 0 LIMIT 2 RETURN n", query.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), 0).setPagination(new Pagination(0, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` } WITH n SKIP 0 LIMIT 2 RETURN n", variableDepthQuery.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), 0).setPagination(new Pagination(0, 2)).getStatement());
     }
 
     @Test
     public void testFindByIdDepthInfinite() {
-        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 2 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(23L, 24L), -1).setPagination(new Pagination(1, 2)).getStatement());
+        check("MATCH (n) WHERE id(n) in { ids } WITH n SKIP 2 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p)", variableDepthQuery.findAll(Arrays.asList(23L, 24L), -1).setPagination(new Pagination(1, 2)).getStatement());
     }
 
     @Test
     public void testFindByTypeDepthInfinite() {
-        check("MATCH (n:`Raptor`) WITH n SKIP 6 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p)", query.findByType("Raptor", -1).setPagination(new Pagination(3, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WITH n SKIP 6 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p)", variableDepthQuery.findByType("Raptor", -1).setPagination(new Pagination(3, 2)).getStatement());
     }
 
     @Test
     public void testFindByPropertyDepthInfinite() {
-        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` }  WITH n SKIP 0 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p), ID(n)", query.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), -1).setPagination(new Pagination(0, 2)).getStatement());
+        check("MATCH (n:`Raptor`) WHERE n.`name` = { `name` }  WITH n SKIP 0 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN collect(distinct p), ID(n)", variableDepthQuery.findByProperties("Raptor", new Filters().add(new Filter("name", "velociraptor")), -1).setPagination(new Pagination(0, 2)).getStatement());
     }
 
     private void check(String expected, String actual) {

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/ParameterisedStatementTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/ParameterisedStatementTest.java
@@ -177,7 +177,7 @@ public class ParameterisedStatementTest {
     @Test
     public void testFindByPropertyWithIllegalCharacter() throws Exception {
         statement = new VariableDepthRelationshipQuery().findByProperties("HAS-ALBUM", new Filters().add(new Filter("fake-property", "none")), 1);
-        assertEquals("MATCH (n)-[r:`HAS-ALBUM`]->(m) WHERE r.`fake-property` = { `fake-property` } WITH n,r MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", statement.getStatement());
+        assertEquals("MATCH (n)-[r:`HAS-ALBUM`]->(m) WHERE r.`fake-property` = { `fake-property` } WITH r,n MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", statement.getStatement());
         assertEquals("{\"fake-property\":\"none\"}", mapper.writeValueAsString(statement.getParameters()));
 
     }

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQueryPagingTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQueryPagingTest.java
@@ -11,16 +11,16 @@
  */
 package org.neo4j.ogm.unit.mapper.cypher;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-
 import org.junit.Test;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
 import org.neo4j.ogm.cypher.query.Pagination;
 import org.neo4j.ogm.session.request.strategy.QueryStatements;
 import org.neo4j.ogm.session.request.strategy.VariableDepthRelationshipQuery;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Vince Bickers
@@ -31,7 +31,7 @@ public class RelationshipEntityQueryPagingTest {
 
     @Test
     public void testFindAllCollection() throws Exception {
-        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH n,r SKIP 30 LIMIT 10 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).setPagination(new Pagination(3, 10)).getStatement());
+        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH r,n SKIP 30 LIMIT 10 MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).setPagination(new Pagination(3, 10)).getStatement());
     }
 
     @Test
@@ -41,12 +41,12 @@ public class RelationshipEntityQueryPagingTest {
 
     @Test
     public void testFindByLabel() throws Exception {
-        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH p,r SKIP 10 LIMIT 10 RETURN collect(distinct p)", query.findByType("ORBITS", 3).setPagination(new Pagination(1, 10)).getStatement());
+        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH r,p SKIP 10 LIMIT 10 RETURN collect(distinct p)", query.findByType("ORBITS", 3).setPagination(new Pagination(1, 10)).getStatement());
     }
 
     @Test
     public void testFindByProperty() throws Exception {
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH n,r SKIP 0 LIMIT 4 MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(new Filter("distance", 60.2)), 1).setPagination(new Pagination(0, 4)).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH r,n SKIP 0 LIMIT 4 MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(new Filter("distance", 60.2)), 1).setPagination(new Pagination(0, 4)).getStatement());
     }
 
 }

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQuerySortingTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQuerySortingTest.java
@@ -40,32 +40,32 @@ public class RelationshipEntityQuerySortingTest {
     @Test
     public void testFindAllCollection() throws Exception {
         sortOrder.add("distance");
-        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH n,r ORDER BY r.distance MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).setSortOrder(sortOrder).getStatement());
+        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH r,n ORDER BY r.distance MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).setSortOrder(sortOrder).getStatement());
     }
 
     @Test
     public void testFindByLabel() throws Exception {
         sortOrder.add("distance");
-        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH p,r ORDER BY r.distance RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
+        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH r,p ORDER BY r.distance RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
     }
 
     @Test
     public void testFindByProperty() throws Exception {
         filters.add("distance", 60.2);
         sortOrder.add("aphelion");
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH n,r ORDER BY r.aphelion MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", filters, 1).setSortOrder(sortOrder).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH r,n ORDER BY r.aphelion MATCH p=(n)-[*0..1]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", filters, 1).setSortOrder(sortOrder).getStatement());
     }
 
     @Test
     public void testMultipleSortOrders() {
         sortOrder.add(SortOrder.Direction.DESC, "distance", "aphelion");
-        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH p,r ORDER BY r.distance DESC,r.aphelion DESC RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
+        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH r,p ORDER BY r.distance DESC,r.aphelion DESC RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
     }
 
     @Test
     public void testDifferentSortDirections() {
         sortOrder.add(SortOrder.Direction.DESC, "type").add("name");
-        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH p,r ORDER BY r.type DESC,r.name RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
+        assertEquals("MATCH p=()-[r:`ORBITS`*..3]-() WITH r,p ORDER BY r.type DESC,r.name RETURN collect(distinct p)", query.findByType("ORBITS", 3).setSortOrder(sortOrder).getStatement());
     }
 
 }

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQueryTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/RelationshipEntityQueryTest.java
@@ -34,12 +34,12 @@ public class RelationshipEntityQueryTest {
 
     @Test
     public void testFindOne() throws Exception {
-        assertEquals("MATCH (n)-[r]->() WHERE ID(r) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN collect(distinct p)", query.findOne(0L, 2).getStatement());
+        assertEquals("MATCH (n)-[r]->() WHERE ID(r) = { id } WITH n,r MATCH p=(n)-[*0..2]-(m) RETURN collect(distinct p)", query.findOne(0L, 2).getStatement());
     }
 
     @Test
     public void testFindAllCollection() throws Exception {
-        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH n MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).getStatement());
+        assertEquals("MATCH (n)-[r]->() WHERE ID(r) IN { ids } WITH r,n MATCH p=(n)-[*0..1]-(m) RETURN collect(distinct p)", query.findAll(Arrays.asList(1L, 2L, 3L), 1).getStatement());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class RelationshipEntityQueryTest {
 
     @Test
     public void testFindByProperty() throws Exception {
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(new Filter("distance", 60.2)), 4).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(new Filter("distance", 60.2)), 4).getStatement());
     }
 
     @Test(expected = InvalidDepthException.class)
@@ -111,7 +111,7 @@ public class RelationshipEntityQueryTest {
         planetFilter.setRelationshipType("ORBITS");
         planetFilter.setRelationshipDirection("OUTGOING");
         planetFilter.setComparisonOperator(ComparisonOperator.EQUALS);
-        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter), 4).getStatement());
+        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter), 4).getStatement());
     }
 
     /**
@@ -128,7 +128,7 @@ public class RelationshipEntityQueryTest {
         planetFilter.setRelationshipType("ORBITS");
         planetFilter.setRelationshipDirection("INCOMING");
         planetFilter.setComparisonOperator(ComparisonOperator.EQUALS);
-        assertEquals("MATCH (m:`Planet`) WHERE m.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter), 4).getStatement());
+        assertEquals("MATCH (m:`Planet`) WHERE m.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter), 4).getStatement());
     }
 
     /**
@@ -156,7 +156,7 @@ public class RelationshipEntityQueryTest {
         planetMoonsFilter.setBooleanOperator(BooleanOperator.AND);
         planetMoonsFilter.setComparisonOperator(ComparisonOperator.EQUALS);
 
-        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } AND n.`moons` = { `moons` } MATCH (n)-[r:`ORBITS`]->(m) WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetNameFilter,planetMoonsFilter), 4).getStatement());
+        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } AND n.`moons` = { `moons` } MATCH (n)-[r:`ORBITS`]->(m) WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetNameFilter,planetMoonsFilter), 4).getStatement());
     }
 
 
@@ -184,7 +184,7 @@ public class RelationshipEntityQueryTest {
         planetFilter.setRelationshipDirection("INCOMING");
         planetFilter.setComparisonOperator(ComparisonOperator.EQUALS);
 
-        assertEquals("MATCH (n:`Moon`) WHERE n.`name` = { `name` } MATCH (m:`Planet`) WHERE m.`colour` = { `colour` } MATCH (n)-[r:`ORBITS`]->(m) WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(moonFilter,planetFilter), 4).getStatement());
+        assertEquals("MATCH (n:`Moon`) WHERE n.`name` = { `name` } MATCH (m:`Planet`) WHERE m.`colour` = { `colour` } MATCH (n)-[r:`ORBITS`]->(m) WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(moonFilter,planetFilter), 4).getStatement());
     }
 
     /**
@@ -196,7 +196,7 @@ public class RelationshipEntityQueryTest {
         Filter distance = new Filter("distance", 60.2);
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.AND);
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } AND r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance,time), 4).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } AND r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance,time), 4).getStatement());
     }
 
     /**
@@ -208,7 +208,7 @@ public class RelationshipEntityQueryTest {
         Filter distance = new Filter("distance", 60.2);
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.OR);
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } OR r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance, time), 4).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } OR r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance, time), 4).getStatement());
     }
 
     /**
@@ -221,7 +221,7 @@ public class RelationshipEntityQueryTest {
         distance.setComparisonOperator(ComparisonOperator.LESS_THAN);
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.AND);
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` < { `distance` } AND r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance,time), 4).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` < { `distance` } AND r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance,time), 4).getStatement());
     }
 
     /**
@@ -234,7 +234,7 @@ public class RelationshipEntityQueryTest {
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.OR);
         time.setComparisonOperator(ComparisonOperator.GREATER_THAN);
-        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } OR r.`time` > { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance, time), 4).getStatement());
+        assertEquals("MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`distance` = { `distance` } OR r.`time` > { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(distance, time), 4).getStatement());
     }
 
     /**
@@ -253,7 +253,7 @@ public class RelationshipEntityQueryTest {
         planetFilter.setComparisonOperator(ComparisonOperator.EQUALS);
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.AND);
-        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter,time), 4).getStatement());
+        assertEquals("MATCH (n:`Planet`) WHERE n.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter,time), 4).getStatement());
     }
 
 
@@ -273,7 +273,7 @@ public class RelationshipEntityQueryTest {
         planetFilter.setComparisonOperator(ComparisonOperator.EQUALS);
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.AND);
-        assertEquals("MATCH (m:`Planet`) WHERE m.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter,time), 4).getStatement());
+        assertEquals("MATCH (m:`Planet`) WHERE m.`name` = { `name` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(planetFilter,time), 4).getStatement());
     }
 
 
@@ -305,6 +305,6 @@ public class RelationshipEntityQueryTest {
         Filter time = new Filter("time",3600);
         time.setBooleanOperator(BooleanOperator.AND);
 
-        assertEquals("MATCH (n:`Moon`) WHERE n.`name` = { `name` } MATCH (m:`Planet`) WHERE m.`colour` = { `colour` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH n,r MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(moonFilter,planetFilter,time), 4).getStatement());
+        assertEquals("MATCH (n:`Moon`) WHERE n.`name` = { `name` } MATCH (m:`Planet`) WHERE m.`colour` = { `colour` } MATCH (n)-[r:`ORBITS`]->(m) WHERE r.`time` = { `time` } WITH r,n MATCH p=(n)-[*0..4]-() RETURN collect(distinct p), ID(r)", query.findByProperties("ORBITS", new Filters().add(moonFilter,planetFilter,time), 4).getStatement());
     }
 }

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/ClauseTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/ClauseTest.java
@@ -1,0 +1,46 @@
+
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher.parser;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.statement.parser.Clause;
+import org.neo4j.ogm.cypher.statement.parser.MatchClause;
+import org.neo4j.ogm.cypher.statement.parser.ReturnClause;
+import org.neo4j.ogm.cypher.statement.parser.WithClause;
+
+/**
+ * @author Rene Richter
+ */
+public class ClauseTest {
+
+    @Test
+    public void itShouldBeAbleToCreateAReturnClause() throws Exception {
+        ReturnClause returnClause = Clause.newReturnClause("RETURN a");
+        assertTrue(returnClause != null);
+    }
+
+    @Test
+    public void itShouldBeAbleToCreateAMatchClause() throws Exception {
+        MatchClause matchClause = Clause.newMatchClause("MATCH (a)-[r:HAS_MANY]->(b)");
+        assertTrue(matchClause != null);
+    }
+
+    @Test
+    public void itShouldBeAbleToCreateAWithClause() throws Exception {
+        WithClause matchClause = Clause.newWithClause("WITH distinct a,b");
+        assertTrue(matchClause != null);
+    }
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/MatchClauseTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/MatchClauseTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.neo4j.ogm.cypher.statement.parser.MatchClause;
+
+import java.util.List;
+
+/**
+ * @author Rene Richter
+ */
+public class MatchClauseTest {
+
+
+    private MatchClause instance;
+
+    @Test
+    public void test() {
+        this.instance = new MatchClause("MATCH (a:User)-[pr:POSTS]->(p:Post)");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(3,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void test2() {
+        this.instance = new MatchClause("MATCH (a)-[:CAN_CODE]->(b)");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(2,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void test3() {
+        this.instance = new MatchClause("MATCH a-->(b)");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(2,aliases.size());
+        assertEquals("a",aliases.iterator().next());
+    }
+
+    @Test
+    public void test4() {
+        this.instance = new MatchClause("MATCH av<--b");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(2,aliases.size());
+        assertEquals("av",aliases.iterator().next());
+    }
+
+    @Test
+    public void test5() {
+        this.instance = new MatchClause("MATCH av  <-- b");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(2,aliases.size());
+        assertEquals("av",aliases.iterator().next());
+    }
+
+    @Test
+    public void test6() {
+        this.instance = new MatchClause("MATCH av<--b->c<--(e:Blubb)<-[bla:Hugo]");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(5,aliases.size());
+        assertEquals("av",aliases.iterator().next());
+        assertEquals("bla",aliases.get(aliases.size()-1));
+    }
+
+
+    @Test
+    public void itShouldBeTolerantToWhitSpaces() {
+        this.instance = new MatchClause("MATCH av <-- b -> c <--( e :Blubb)<-[ bla :Hugo]");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(5,aliases.size());
+        assertEquals("av",aliases.get(0));
+        assertEquals("bla",aliases.get(aliases.size()-1));
+    }
+
+    @Test
+    public void itShouldAddPathAliasesLast() {
+        this.instance = new MatchClause("MATCH     y = av <-- b -> c <--( e :Blubb)<-[ bla :Hugo]");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(6,aliases.size());
+        assertEquals("av",aliases.get(0));
+        assertEquals("y",aliases.get(aliases.size()-1));
+    }
+
+    @Test
+    public void itShouldIndicateThatItIsAPathMatchClause() {
+        this.instance = new MatchClause("MATCH     y = av <-- b -> c <--( e :Blubb)<-[ bla :Hugo]");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(6,aliases.size());
+        assertEquals("av",aliases.get(0));
+        assertEquals("y",aliases.get(aliases.size()-1));
+        assertTrue(instance.isPathMatch());
+    }
+
+
+
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/ReturnClauseTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/ReturnClauseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.neo4j.ogm.cypher.statement.parser.ReturnClause;
+
+import java.util.List;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class ReturnClauseTest {
+
+    ReturnClause instance;
+
+    @Test
+    public void itShouldMatchSimpleAliases() {
+        instance = new ReturnClause("RETURN a,b,c");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(3,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void itShouldMatchAliasesAfterDots() {
+        instance = new ReturnClause("RETURN collect(distinct uhu ),b,sum(collect(c.gurgl))");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(3,aliases.size());
+        assertEquals("uhu",aliases.get(0));
+        assertEquals("b",aliases.get(1));
+        assertEquals("c",aliases.get(2));
+    }
+
+    @Test
+    public void itShouldBeAbleToExtractAliasesFromDeeplyNestedFunctions() {
+        instance = new ReturnClause("RETURN distinct sum(collect(bla(blubb(a)))))");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(1,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void itShouldBeTolerantToWhitspaces() {
+        instance = new ReturnClause("RETURN distinct sum (   collect  (   bla  (  blubb  (  a  ) )   ) ) )");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(1,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void itShouldIgnoreModifyingWords() {
+        instance = new ReturnClause("return distinct a");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(1,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void itShouldIgnoreModifyingWordsEvenIfNotYetDefined() {
+        instance = new ReturnClause("return asdf a");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(1,aliases.size());
+        assertEquals("a",aliases.get(0));
+    }
+
+    @Test
+    public void itShouldWorkWithArithmeticOperations() {
+        instance = new ReturnClause("return sum(a.hallo - b.hugo)");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(2,aliases.size());
+        assertEquals("a",aliases.get(0));
+        assertEquals("b",aliases.get(1));
+    }
+
+
+
+
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/StatementParserTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/StatementParserTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher.parser;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.neo4j.ogm.cypher.statement.parser.Clause;
+import org.neo4j.ogm.cypher.statement.parser.MatchClause;
+import org.neo4j.ogm.cypher.statement.parser.ReturnClause;
+import org.neo4j.ogm.cypher.statement.parser.StatementParser;
+import org.neo4j.ogm.cypher.statement.parser.WithClause;
+
+import java.util.LinkedList;
+import java.util.ListIterator;
+
+/**
+ *
+ * @author Rene Richter
+ */
+public class StatementParserTest {
+
+    StatementParser parser = new StatementParser();
+
+    @Test
+    public void test1() {
+        String query = "MATCH  (a:User{id:1}),(b:User{id:2}) WITH [a,b] as col UNWIND col as u ORDER BY u.firstname,u.lastname SKIP 10 LIMIT 30 RETURN u";
+        LinkedList<Clause> clauses = parser.parseStatement(query);
+        ListIterator<Clause> clauseListIterator = clauses.listIterator();
+        assertTrue(clauseListIterator.next() instanceof MatchClause);
+        assertTrue(clauseListIterator.next() instanceof WithClause);
+        assertTrue(clauseListIterator.next() instanceof ReturnClause);
+    }
+
+    @Test
+    public void test2() {
+        String query = "MATCH a-->b WHERE a.age < 20 WITH a,b match p=c-[]->()<-[]-(b) WITH p RETURN collect(distinct p)";
+        LinkedList<Clause> clauses = parser.parseStatement(query);
+        ListIterator<Clause> clauseListIterator = clauses.listIterator();
+        assertTrue(clauseListIterator.next() instanceof MatchClause);
+        assertTrue(clauseListIterator.next() instanceof WithClause);
+        assertTrue(clauseListIterator.next() instanceof MatchClause);
+        assertTrue(clauseListIterator.next() instanceof WithClause);
+        assertTrue(clauseListIterator.next() instanceof ReturnClause);
+    }
+
+
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/WithClauseTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/cypher/parser/WithClauseTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c)  [2011-2015] "Neo Technology" / "Graph Aware Ltd."
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *
+ */
+
+package org.neo4j.ogm.unit.mapper.cypher.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.neo4j.ogm.cypher.statement.parser.WithClause;
+
+import java.util.List;
+
+/**
+ * Created by rene on 06.06.15.
+ *
+ * @author rene
+ * @version 0.0.1
+ */
+public class WithClauseTest {
+
+    WithClause instance;
+
+
+    @Test
+    public void test1() {
+        instance = new WithClause("WITH h,i,j,k");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("h",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+
+    }
+
+    @Test
+    public void test2() {
+        instance = new WithClause("WITH h  ,  i  , j , k  ");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("h",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+
+    }
+
+    @Test
+    public void test3() {
+        instance = new WithClause("WITH h.hugo AS blubb ,i,j,k");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("blubb",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+
+    }
+
+    @Test
+    public void test4() {
+        instance = new WithClause("WITH (h.hugo - 3*b) AS blubb ,i,j,k");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("blubb",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+    }
+
+    @Test
+    public void test5() {
+        instance = new WithClause("WITH [a,b] as col UNWIND col as u");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(1,aliases.size());
+        assertEquals("u",aliases.get(0));
+    }
+
+    @Test
+    public void test6() {
+        instance = new WithClause("WITH sum(h.hugo - 3*b) AS blubb ,i,j,k");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("blubb",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+    }
+
+    @Test
+    public void test7() {
+        instance = new WithClause("WITH sum(h.hugo - {modifier}*b.salery) AS blubb ,distinct i,j,k");
+        List<String> aliases = instance.parseAliases();
+        assertEquals(4,aliases.size());
+        assertEquals("blubb",aliases.get(0));
+        assertEquals("i",aliases.get(1));
+        assertEquals("j",aliases.get(2));
+        assertEquals("k",aliases.get(3));
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -27,5 +27,4 @@
   <root level="info">
 		<appender-ref ref="console" />
 	</root>
-
 </configuration>


### PR DESCRIPTION
In order to achieve paging and sorting support for custom queries,
this commit will refactor the query augmentation by introducing a query parser.
This feature needs to make assumptions on the query semantics.

If the query is intended for node- or relationship
entities, the first RETURN alias will be the anchor for sorting.

If the query asks for a path and has a with clause right before
the path, the with-clause will be used for sorting and pagination to
narrow down the path.

If no previous with-clause is present, one will be generated after the
path-match with node and relationship aliases. The first alias found
will be used for sorting.