### PR TITLE
TransientRelationship.convert throws a NullPointerException

### DIFF
--- a/src/main/java/org/neo4j/ogm/mapper/TransientRelationship.java
+++ b/src/main/java/org/neo4j/ogm/mapper/TransientRelationship.java
@@ -64,9 +64,9 @@ public class TransientRelationship {
      */
     public MappedRelationship convert(Map<String, Long> refMap) {
 
-        Long srcIdentity = src.startsWith("_") ? refMap.get(src) : Long.parseLong(src.substring(1));
-        Long tgtIdentity = tgt.startsWith("_") ? refMap.get(tgt) : Long.parseLong(tgt.substring(1));
-        Long relIdentity = ref.startsWith("_") ? refMap.get(ref) : Long.parseLong(ref.substring(1));
+        Long srcIdentity = src.startsWith("_") ? refMap.get(src) : (Long)Long.parseLong(src.substring(1));
+        Long tgtIdentity = tgt.startsWith("_") ? refMap.get(tgt) : (Long)Long.parseLong(tgt.substring(1));
+        Long relIdentity = ref.startsWith("_") ? refMap.get(ref) : (Long)Long.parseLong(ref.substring(1));
 
         if (srcIdentity == null) {
             throw new RuntimeException("Couldn't get identity for " + src);

--- a/src/test/java/org/neo4j/ogm/domain/mappings/Article.java
+++ b/src/test/java/org/neo4j/ogm/domain/mappings/Article.java
@@ -24,29 +24,6 @@ import org.neo4j.ogm.annotation.Relationship;
  */
 public class Article extends Entity
 {
-    private String title;
-
-    @Relationship(type = "LIKE", direction = Relationship.INCOMING)
-    private Set<Person> likes = new HashSet<Person>();
-
-    public Article() {}
-
-    public Set<Person> getLikes()
-    {
-        return likes;
-    }
-
-    public void setLikes(Set<Person> likes)
-    {
-        this.likes = likes;
-    }
-
-    @Override
-    public String toString()
-    {
-        return "Article{" +
-            "id:" + getNodeId() +
-            ", title:'" + title + "'" +
-            '}';
-    }
+    @Relationship(type = "RELATED_TO")
+    public Set<RichRelation> relations = new HashSet<>();
 }

--- a/src/test/java/org/neo4j/ogm/domain/mappings/Person.java
+++ b/src/test/java/org/neo4j/ogm/domain/mappings/Person.java
@@ -14,21 +14,23 @@
 
 package org.neo4j.ogm.domain.mappings;
 
+import org.neo4j.ogm.annotation.Relationship;
+
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * @author Nils Dröge
  */
 public class Person extends Entity
 {
-    private String name;
+    @Relationship(type = "RELATED_TO")
+    public Set<RichRelation> relations = new HashSet<>();
 
-    public Person() {}
-
-    public Person(String name)
-    {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
+    public void addRelation(Article article, RichRelation relation) {
+        relation.person = this;
+        relation.article = article;
+        relations.add(relation);
+        article.relations.add(relation);
     }
 }

--- a/src/test/java/org/neo4j/ogm/domain/mappings/RichRelation.java
+++ b/src/test/java/org/neo4j/ogm/domain/mappings/RichRelation.java
@@ -10,6 +10,8 @@ import org.neo4j.ogm.annotation.StartNode;
 @RelationshipEntity(type = "RELATED_TO")
 public class RichRelation
 {
+    Long id;
+
     @StartNode
     public Person person;
 

--- a/src/test/java/org/neo4j/ogm/domain/mappings/RichRelation.java
+++ b/src/test/java/org/neo4j/ogm/domain/mappings/RichRelation.java
@@ -1,0 +1,18 @@
+package org.neo4j.ogm.domain.mappings;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+
+/**
+ * @author Nils Dröge
+ */
+@RelationshipEntity(type = "RELATED_TO")
+public class RichRelation
+{
+    @StartNode
+    public Person person;
+
+    @EndNode
+    public Article article;
+}

--- a/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
+++ b/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
@@ -30,10 +30,20 @@ public class RichRelationTest {
     public void shouldCreateARichRelation()
     {
         Person person = new Person();
-        Article article = new Article();
-        RichRelation relation = new RichRelation();
-        person.addRelation(article, relation);
+        session.save(person);
 
-        session.save(person); // TODO: should not throw a RuntimeException
+        Article article1 = new Article();
+        session.save(article1);
+        Article article2 = new Article();
+        session.save(article2);
+
+        RichRelation relation1 = new RichRelation();
+        person.addRelation(article1, relation1);
+        session.save(person, 1);
+        session.clear();
+
+        RichRelation relation2 = new RichRelation();
+        person.addRelation(article2, relation2);
+        session.save(person, 1); // TODO: should not throw a RuntimeException("Couldn't get identity for _1")
     }
 }

--- a/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
+++ b/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
@@ -1,0 +1,39 @@
+package org.neo4j.ogm.integration.mappings;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.ogm.domain.mappings.Article;
+import org.neo4j.ogm.domain.mappings.Person;
+import org.neo4j.ogm.domain.mappings.RichRelation;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.Neo4jIntegrationTestRule;
+
+import java.io.IOException;
+
+/**
+ * @author Nils Dröge
+ */
+public class RichRelationTest {
+    @Rule
+    public Neo4jIntegrationTestRule neo4jRule = new Neo4jIntegrationTestRule();
+
+    private Session session;
+
+    @Before
+    public void init() throws IOException {
+        session =  new SessionFactory("org.neo4j.ogm.domain.mappings").openSession(neo4jRule.url());
+    }
+
+    @Test
+    public void shouldCreateARichRelation()
+    {
+        Person person = new Person();
+        Article article = new Article();
+        RichRelation relation = new RichRelation();
+        person.addRelation(article, relation);
+
+        session.save(person); // TODO: should not throw a RuntimeException
+    }
+}

--- a/src/test/java/org/neo4j/ogm/unit/mapper/TransientRelationshipTest.java
+++ b/src/test/java/org/neo4j/ogm/unit/mapper/TransientRelationshipTest.java
@@ -1,0 +1,29 @@
+package org.neo4j.ogm.unit.mapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.neo4j.ogm.mapper.TransientRelationship;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author nils.droege@c3.co
+ * @since 2015-07-23
+ */
+public class TransientRelationshipTest
+{
+    @Test
+    public void convertShouldNotThowNullpointerException()
+    {
+        TransientRelationship tr = new TransientRelationship("123", "_1", "", "456", null, null);
+        Map<String, Long> refMap = new HashMap<>();
+
+        try {
+            tr.convert(refMap);
+        } catch (NullPointerException ex) {
+            Assert.fail("NullPointerException is unexpected");
+        } catch (RuntimeException re) {
+        }
+    }
+}


### PR DESCRIPTION
The Methods throwed a NullPointerExcetion, if the ref is not in the refMap.
The expected RuntimeException is more helpful.