### PR TITLE
NullPointer exception while while updating the @EndNode entity

### DIFF
--- a/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
+++ b/src/test/java/org/neo4j/ogm/integration/mappings/RichRelationTest.java
@@ -62,4 +62,23 @@ public class RichRelationTest {
         person.addRelation(article2, relation2);
         session.save(person, 1);
     }
+
+    @Test
+    public void shouldUpdateEndNodeEntityWithoutException()
+    {
+        Person person = new Person();
+        session.save(person);
+
+        Article article1 = new Article();
+        session.save(article1);
+        RichRelation relation1 = new RichRelation();
+        person.addRelation(article1, relation1);
+        session.save(person, 1);
+        session.clear();
+
+        Article updateArticle = new Article();
+        updateArticle.setNodeId(article1.getNodeId());
+        updateArticle.relations = article1.relations;
+        session.save(updateArticle, 1);
+    }
 }


### PR DESCRIPTION
As discussed I added an integration test for a NullPointer exception while updating the @EndNode entity of a rich relation

In my own project, I have a similar test, but not always fails.
I could notice, that the @StartNode entitiy was missing in the visitedObjects of the CypherContext.
And the result is that the srcNodeBuilder is null.