### PR TITLE
Fix up dependencies ( logback to test scope, update others )

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,9 @@
 o Fixes an issue with the mapping context where node entities are deregistered, but not referenced relationship entities
 o Fixes issue when type descriptors are defined on interfaces
 o Fixes metadata label resolution with certain class hierarchies
+o Change logback dependencies to 'test' scope
+o Change ancient comments-lang to org.apache.commons:commons-lang3
+
 
 1.1.2
 --------------

--- a/neo4j-ogm-docs/pom.xml
+++ b/neo4j-ogm-docs/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-ogm-docs</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
 
     <name>Neo4j OGM Documentation</name>
     <packaging>pom</packaging>

--- a/neo4j-ogm-docs/src/main/asciidoc/reference/programming-model/relationships.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/programming-model/relationships.adoc
@@ -133,4 +133,10 @@ public class Movie {
 }
 ----
 
+[NOTE]
+====
+The `@RelationshipEntity` annotation must appear on all leaf subclasses if they are part of a class hierarchy representing relationship entities.
+This annotation is optional on superclasses.
+====
+
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,12 @@
                             <excludes>
                                 <exclude>**/defects/**</exclude>
                             </excludes>
+                            <systemProperties>
+                                <property>
+                                    <name>java.io.tmpdir</name>
+                                    <value>${project.build.testOutputDirectory}</value>
+                                </property>
+                            </systemProperties>
                         </configuration>
                     </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <neo4j>2.2.5</neo4j>
         <neo4j-io>2.2.5</neo4j-io>
-        <commonslang>2.6</commonslang>
-        <jackson>2.5.1</jackson>
-        <httpclient>4.3.6</httpclient>
+        <commonslang>3.4</commonslang>
+        <jackson>2.6.2</jackson>
+        <httpclient>4.5</httpclient>
         <junit>4.12</junit>
-        <slf4j>1.7.5</slf4j>
+        <slf4j>1.7.12</slf4j>
         <logback>1.1.3</logback>
     </properties>
 
@@ -60,17 +60,19 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${logback}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <version>${commonslang}</version>
         </dependency>
 

--- a/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -18,8 +18,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.neo4j.ogm.authentication.UsernamePasswordCredentials;
 import org.neo4j.ogm.metadata.MetaData;
 
@@ -32,7 +33,7 @@ import org.neo4j.ogm.metadata.MetaData;
 public class SessionFactory {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
-    private final CloseableHttpClient httpClient = HttpClients.createDefault();
+    private final CloseableHttpClient httpClient;
     private final MetaData metaData;
 
     /**
@@ -48,6 +49,13 @@ public class SessionFactory {
      */
     public SessionFactory(String... packages) {
         this.metaData = new MetaData(packages);
+        httpClient = HttpClientBuilder.create()
+                .setDefaultRequestConfig(RequestConfig.copy(RequestConfig.DEFAULT)
+                        .setConnectionRequestTimeout(-1) // Default/Undefined - use OS defaults
+                        .setSocketTimeout(-1)  // Default/Undefined - use OS defaults
+                        .build()
+                )
+                .build();
     }
 
     /**

--- a/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -17,7 +17,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.ogm.cypher.query.GraphModelQuery;
 import org.neo4j.ogm.cypher.query.Query;
 import org.neo4j.ogm.cypher.query.RowModelQuery;
@@ -38,7 +39,7 @@ import org.neo4j.ogm.session.result.RowQueryStatisticsResult;
 public class ExecuteQueriesDelegate implements Capability.ExecuteQueries {
 
     private static final Pattern WRITE_CYPHER_KEYWORDS = Pattern.compile("\\b(CREATE|MERGE|SET|DELETE|REMOVE)\\b");
-    
+
     private final Neo4jSession session;
 
     public ExecuteQueriesDelegate(Neo4jSession neo4jSession) {

--- a/src/main/java/org/neo4j/ogm/session/delegates/ExecuteStatementsDelegate.java
+++ b/src/main/java/org/neo4j/ogm/session/delegates/ExecuteStatementsDelegate.java
@@ -15,7 +15,8 @@ package org.neo4j.ogm.session.delegates;
 
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.ogm.cypher.query.RowModelQueryWithStatistics;
 import org.neo4j.ogm.session.Capability;
 import org.neo4j.ogm.session.Neo4jSession;

--- a/src/main/java/org/neo4j/ogm/typeconversion/ByteArrayWrapperBase64Converter.java
+++ b/src/main/java/org/neo4j/ogm/typeconversion/ByteArrayWrapperBase64Converter.java
@@ -15,7 +15,8 @@
 package org.neo4j.ogm.typeconversion;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
+
 
 /**
  * By default the OGM will map Byte[] wrapped byte[] objects to Base64

--- a/src/test/java/org/neo4j/ogm/auth/AuthenticationTest.java
+++ b/src/test/java/org/neo4j/ogm/auth/AuthenticationTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilders;
 import org.neo4j.harness.internal.InProcessServerControls;
+import org.neo4j.helpers.Settings;
 import org.neo4j.kernel.Version;
 import org.neo4j.ogm.domain.bike.Bike;
 import org.neo4j.ogm.session.Session;
@@ -41,6 +42,7 @@ import org.neo4j.ogm.session.result.ResultProcessingException;
 import org.neo4j.ogm.session.transaction.Transaction;
 import org.neo4j.ogm.testutil.TestUtils;
 import org.neo4j.server.AbstractNeoServer;
+import org.neo4j.shell.ShellSettings;
 
 /**
  * @author Vince Bickers
@@ -71,6 +73,7 @@ public class AuthenticationTest
                     .withConfig("dbms.security.auth_enabled", "true")
                     .withConfig("org.neo4j.server.webserver.port", String.valueOf(neoPort))
                     .withConfig("dbms.security.auth_store.location", authStore.toAbsolutePath().toString())
+                    .withConfig(ShellSettings.remote_shell_enabled.name(), Settings.FALSE)
                     .newServer();
 
             initialise(controls);

--- a/src/test/java/org/neo4j/ogm/testutil/TestServer.java
+++ b/src/test/java/org/neo4j/ogm/testutil/TestServer.java
@@ -14,6 +14,7 @@
 
 package org.neo4j.ogm.testutil;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Scanner;
 
@@ -22,7 +23,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilders;
 import org.neo4j.harness.internal.InProcessServerControls;
+import org.neo4j.helpers.Settings;
 import org.neo4j.server.AbstractNeoServer;
+import org.neo4j.shell.ShellSettings;
 
 /**
  * @author Vince Bickers
@@ -38,6 +41,8 @@ public class TestServer {
         try {
             ServerControls controls = TestServerBuilders.newInProcessBuilder()
                     .withConfig("dbms.security.auth_enabled", "false")
+                    .withConfig("org.neo4j.server.webserver.port", String.valueOf(TestUtils.getAvailablePort()))
+                    .withConfig(ShellSettings.remote_shell_enabled.name(), Settings.FALSE)
                     .newServer();
 
             initialise(controls);
@@ -54,6 +59,7 @@ public class TestServer {
             ServerControls controls = TestServerBuilders.newInProcessBuilder()
                     .withConfig("dbms.security.auth_enabled", "false")
                     .withConfig("org.neo4j.server.webserver.port", String.valueOf(port))
+                    .withConfig(ShellSettings.remote_shell_enabled.name(), Settings.FALSE)
                     .newServer();
 
             initialise(controls);


### PR DESCRIPTION
Change logback dependencies to 'test' scope and replace ancient commons-lang dependency with org.apache.commons:commons-lang3, updated other dependencies ( jackson and httpclient ) to more current revisions.

logback shouldn't be expressed as a compile time dependency, it's only needed in tests. Only slf4j-api should be.

commons-lang is _ancient_ and org.apache.commons:commons-lang3 should be used instead