### PR TITLE
Consume non-200 responses response entities

### DIFF
--- a/src/main/java/org/neo4j/ogm/session/transaction/TransactionManager.java
+++ b/src/main/java/org/neo4j/ogm/session/transaction/TransactionManager.java
@@ -102,11 +102,7 @@ public class TransactionManager {
             StatusLine statusLine = response.getStatusLine();
 
             logger.debug("Status code: " + statusLine.getStatusCode());
-            if (statusLine.getStatusCode() >= 300) {
-                throw new HttpResponseException(
-                        statusLine.getStatusCode(),
-                        statusLine.getReasonPhrase());
-            }
+
             // close the content stream/release the connection
             HttpEntity responseEntity = response.getEntity();
 
@@ -120,6 +116,12 @@ public class TransactionManager {
             }
             else {
                 request.releaseConnection();
+            }
+
+            if (statusLine.getStatusCode() >= 300) {
+                throw new HttpResponseException(
+                        statusLine.getStatusCode(),
+                        statusLine.getReasonPhrase());
             }
             return response;
         }


### PR DESCRIPTION
Not a complete fix but I was able to alleviate issue mentioned in #80 with a combination of making sure 40x response entities are consumed and by increase my Neo4j server's transaction timeout value. (`org.neo4j.server.transaction.timeout`)