### PR TITLE
Correcting inter-project dependencies

### DIFF
--- a/bolt-driver/pom.xml
+++ b/bolt-driver/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ogm-api</artifactId>
-      <version>${neo4j.ogm.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,40 +28,40 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-compiler</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-http-driver</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-embedded-driver</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-bolt-driver</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-test</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/embedded-driver/pom.xml
+++ b/embedded-driver/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>

--- a/http-driver/pom.xml
+++ b/http-driver/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-api</artifactId>
-            <version>${neo4j.ogm.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,6 @@
         <slf4j>1.7.14</slf4j>
         <logback>1.1.3</logback>
 
-        <!--current version of neo4j-ogm that other ogm modules must depend on -->
-        <neo4j.ogm.version>2.0.1-SNAPSHOT</neo4j.ogm.version>
-
         <!-- default for build, if no profiles invoked -->
         <neo4j>2.3.3</neo4j>
         <bolt>1.0.0-RC1</bolt>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,19 +29,19 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ogm-http-driver</artifactId>
-      <version>${neo4j.ogm.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ogm-embedded-driver</artifactId>
-      <version>${neo4j.ogm.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-ogm-bolt-driver</artifactId>
-      <version>${neo4j.ogm.version}</version>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://github.com/neo4j/neo4j-ogm/issues/140

Using project.version for inter-project dependencies. As a result Maven will be able to correcly resolve them,