### PR TITLE
Fix #153 -- Neo4jSession save( ) cannot handle unique constraints

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/annotation/NodeEntity.java
+++ b/api/src/main/java/org/neo4j/ogm/annotation/NodeEntity.java
@@ -33,6 +33,8 @@ public @interface NodeEntity {
 
     static final String CLASS = "org.neo4j.ogm.annotation.NodeEntity";
     static final String LABEL = "label";
+    static final String MERGENAME = "mergename";
 
     String label() default "";
+    String mergename() default "";
 }

--- a/api/src/main/java/org/neo4j/ogm/compiler/NodeBuilder.java
+++ b/api/src/main/java/org/neo4j/ogm/compiler/NodeBuilder.java
@@ -30,6 +30,8 @@ public interface NodeBuilder {
 
 	NodeBuilder setLabels(Collection<String> labels);
 
+	NodeBuilder setMergeName(String mergeName);
+
 	String[] labels();
 
 	Node node();

--- a/api/src/main/java/org/neo4j/ogm/model/Node.java
+++ b/api/src/main/java/org/neo4j/ogm/model/Node.java
@@ -21,6 +21,8 @@ import java.util.List;
 public interface Node {
     String[] getLabels();
 
+    String getMergeName();
+
     Long getId();
 
     List<Property<String, Object>> getPropertyList();

--- a/api/src/main/java/org/neo4j/ogm/response/model/NodeModel.java
+++ b/api/src/main/java/org/neo4j/ogm/response/model/NodeModel.java
@@ -27,6 +27,7 @@ public class NodeModel implements Node {
 
     private Long id;
     private String[] labels;
+    private String mergeName;
     private List<Property<String, Object>> properties = new ArrayList<>();
 
     public List<Property<String, Object>> getPropertyList() {
@@ -59,6 +60,15 @@ public class NodeModel implements Node {
     public void setLabels(String[] labels) {
         this.labels = labels;
     }
+
+    public void setMergeName(String mergeName) {
+        this.mergeName = mergeName;
+    }
+
+    public String getMergeName() {
+        return mergeName;
+    }
+
 
     public Object property(String key) {
         for (Property property : properties) {

--- a/compiler/src/main/java/org/neo4j/ogm/compiler/builders/DefaultNodeBuilder.java
+++ b/compiler/src/main/java/org/neo4j/ogm/compiler/builders/DefaultNodeBuilder.java
@@ -47,6 +47,12 @@ public class DefaultNodeBuilder implements NodeBuilder {
 	}
 
 	@Override
+	public NodeBuilder setMergeName(String newMergeName){
+		node.setMergeName(newMergeName);
+		return this;
+	}
+
+	@Override
 	public Long reference() {
 		return node.getId();
 	}

--- a/compiler/src/main/java/org/neo4j/ogm/compiler/emitters/NewNodeEmitter.java
+++ b/compiler/src/main/java/org/neo4j/ogm/compiler/emitters/NewNodeEmitter.java
@@ -39,12 +39,27 @@ public class NewNodeEmitter implements CypherEmitter {
 		if (newNodes != null && newNodes.size() > 0) {
 			Node firstNode = newNodes.iterator().next();
 
-			queryBuilder.append("UNWIND {rows} as row ")
-					.append("CREATE (n");
-			for (String label : firstNode.getLabels()) {
-				queryBuilder.append(":`").append(label).append("`");
+			if (firstNode.getMergeName().equals("")){
+				queryBuilder.append("UNWIND {rows} as row ")
+						.append("CREATE (n");
+				for (String label : firstNode.getLabels()) {
+					queryBuilder.append(":`").append(label).append("`");
+				}
+				queryBuilder.append(") SET n=row.props ");
 			}
-			queryBuilder.append(") SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type");
+			else{
+				queryBuilder.append("UNWIND {rows} as row ")
+						.append("MERGE (n");
+				for (String label : firstNode.getLabels()) {
+					queryBuilder.append(":`").append(label).append("`");
+				}
+				queryBuilder.append(" {");
+				queryBuilder.append(firstNode.getMergeName()).append(":").append("row.props.").append(firstNode.getMergeName()).append("})");
+				queryBuilder.append(" ON CREATE SET n=row.props ");
+				queryBuilder.append(" ON MATCH SET n=row.props ");
+			}
+
+			queryBuilder.append("RETURN row.nodeRef as ref, ID(n) as id, row.type as type");
 			List<Map> rows = new ArrayList<>();
 			for (Node node : newNodes) {
 				Map<String, Object> rowMap = new HashMap<>();

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -256,10 +256,10 @@ public class EntityGraphMapper implements EntityMapper {
         NodeBuilder nodeBuilder;
         if (id == null) {
             Long entityIdRef = EntityUtils.identity(entity, metaData);
-            nodeBuilder = compiler.newNode(entityIdRef).setLabels(classInfo.labels());
+            nodeBuilder = compiler.newNode(entityIdRef).setLabels(classInfo.labels()).setMergeName(classInfo.mergeName());
             context.registerNewObject(entityIdRef, entity);
         } else {
-            nodeBuilder = compiler.existingNode(Long.valueOf(id.toString())).setLabels(classInfo.labels());
+            nodeBuilder = compiler.existingNode(Long.valueOf(id.toString())).setLabels(classInfo.labels()).setMergeName(classInfo.mergeName());
         }
         Long identity = EntityUtils.identity(entity,metaData);
         context.visit(identity, nodeBuilder);

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -72,6 +72,7 @@ public class ClassInfo {
     private String className;
     private String directSuperclassName;
     private String neo4jName;
+    private String mergeName;
 
     private boolean isInterface;
     private boolean isAbstract;
@@ -244,6 +245,26 @@ public class ClassInfo {
             }
         }
         return neo4jName;
+    }
+
+    public String mergeName(){
+        if(mergeName == null){
+            try{
+                lock.lock();
+                if (mergeName == null) {
+                    AnnotationInfo annotationInfo = annotationsInfo.get(NodeEntity.CLASS);
+                    if (annotationInfo != null) {
+                        mergeName = annotationInfo.get(NodeEntity.MERGENAME, "");
+                        return mergeName;
+                    }
+                    mergeName = "";
+                }
+            }
+            finally {
+                lock.unlock();
+            }
+        }
+        return mergeName;
     }
 
     private Collection<String> collectLabels(Collection<String> labelNames) {

--- a/core/src/test/java/org/neo4j/ogm/cypher/CypherCompilerTest.java
+++ b/core/src/test/java/org/neo4j/ogm/cypher/CypherCompilerTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.ogm.MetaData;
+import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.compiler.CompileContext;
 import org.neo4j.ogm.compiler.Compiler;
 import org.neo4j.ogm.context.EntityGraphMapper;
@@ -769,8 +770,19 @@ public class CypherCompilerTest {
         List<Statement> statements = compiler.createNodesStatements();
         List<String> createNodeStatements = cypherStatements(statements);
         assertEquals(2, createNodeStatements.size());
-        assertTrue(createNodeStatements.contains("UNWIND {rows} as row CREATE (n:`l'artiste`) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
-        assertTrue(createNodeStatements.contains("UNWIND {rows} as row CREATE (n:`l'album`) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
+
+        assertTrue(Artist.class.isAnnotationPresent(NodeEntity.class));
+        assertTrue(Album.class.isAnnotationPresent(NodeEntity.class));
+
+        NodeEntity nodeEntity = Artist.class.getAnnotation(NodeEntity.class);
+        if (!nodeEntity.mergename().equals("")){
+            assertTrue(createNodeStatements.contains("UNWIND {rows} as row MERGE (n:`l'album` {name:row.props.name}) ON CREATE SET n=row.props  ON MATCH SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
+            assertTrue(createNodeStatements.contains("UNWIND {rows} as row MERGE (n:`l'artiste` {name:row.props.name}) ON CREATE SET n=row.props  ON MATCH SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
+        }
+        else{
+            assertTrue(createNodeStatements.contains("UNWIND {rows} as row CREATE (n:`l'artiste`) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
+            assertTrue(createNodeStatements.contains("UNWIND {rows} as row CREATE (n:`l'album`) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, row.type as type"));
+        }
         for (Statement statement : statements) {
             List rows = (List) statement.getParameters().get("rows");
             assertEquals(1, rows.size());

--- a/core/src/test/java/org/neo4j/ogm/domain/music/Album.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/music/Album.java
@@ -19,7 +19,7 @@ import org.neo4j.ogm.annotation.Relationship;
 /**
  * @author Luanne Misquitta
  */
-@NodeEntity(label = "l'album")
+@NodeEntity(label = "l'album", mergename = "name")
 public class Album {
 
     private Long id;

--- a/core/src/test/java/org/neo4j/ogm/domain/music/Artist.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/music/Artist.java
@@ -22,7 +22,7 @@ import org.neo4j.ogm.annotation.Relationship;
 /**
  * @author Luanne Misquitta
  */
-@NodeEntity(label = "l'artiste")
+@NodeEntity(label = "l'artiste", mergename = "name")
 public class Artist {
 
     private Long id;

--- a/core/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
@@ -17,10 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -165,4 +162,62 @@ public class SaveCapabilityTest extends MultiDriverTestClass{
         assertEquals("Should have two node to save" , 2, context.registry().size());
     }
 
+    /**
+     * @see Issue #153
+     */
+    @Test
+    public void saveWithMergeNameShouldSame(){
+        Album lost = new Album("fishjam");
+        lost.setArtist(bonJovi);
+        session.save(lost);
+        session.clear();
+
+        lost = new Album("fishjam");
+        Artist leann = new Artist("Leann Rimes");
+        lost.setArtist(leann);
+        session.save(lost);
+        session.clear();
+
+        //Artist loadedLeann = session.load(Artist.class, leann.getId());
+        Collection<Album> allAlbum = session.loadAll(Album.class);
+        assertEquals(1, allAlbum.size());
+
+        Collection<Artist> allArtist = session.loadAll(Artist.class);
+        assertEquals(2, allArtist.size());
+    }
+
+    /**
+     * @see Issue #153
+     */
+    @Test
+    public void saveListWithMergeNameShouldSame(){
+        final int ALBUM_COUNT = 10;
+        List<Album> albumList = new ArrayList<Album>();
+
+        for (int i = 0; i < ALBUM_COUNT; i++){
+            albumList.add(new Album("fishjam" + i));
+        }
+        session.save(albumList);
+        session.clear();
+
+        //first only the ALBUM_COUNT count
+        Collection<Album> allAlbumFromDB = session.loadAll(Album.class);
+        assertEquals(ALBUM_COUNT, allAlbumFromDB.size());
+        session.clear();
+
+
+        //save again with same name
+        List<Album> anotherAlbumList = new ArrayList<Album>();
+
+        for (int i = 0; i < ALBUM_COUNT * 2; i++){
+            anotherAlbumList.add(new Album("fishjam" + i));
+        }
+        session.save(anotherAlbumList);
+        session.clear();
+
+        //now count will be (ALBUM_COUNT * 2) = 10(old) + 10(new)
+        allAlbumFromDB = session.loadAll(Album.class);
+        assertEquals(ALBUM_COUNT * 2, allAlbumFromDB.size());
+        session.clear();
+    }
 }


### PR DESCRIPTION
I have same need for #153 , so I add mergename in @NodeEntity to support MERGE with user's application ID( such as SSN, ISBN, emails, logins, etc.).
Usage: please refer  saveWithMergeNameShouldSame() and saveListWithMergeNameShouldSame() in SaveCapabilityTest.java.

BTW: 
1.I was hoping to support multi merge name(String[] ), but I found that it seems that AnnotationInfo.java can not support it, and my key only need one field, so I just support one merge field. If anybody can fix this, please do it.
2.If there is not "mergename" in @NodeEntity, it will remain the old logical (CREATE);
3.I am also considering whether let use to choose SET n=Xxx or SET n+=Xxx when MERGE, for simplicity now just use SET n=Xxx now.

Thanks.