### PR TITLE
Issues 204 - Fail to set Credentials when using Bolt protocol in URI

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/config/DriverConfiguration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/DriverConfiguration.java
@@ -16,7 +16,7 @@ package org.neo4j.ogm.config;
 import org.neo4j.ogm.authentication.Credentials;
 import org.neo4j.ogm.authentication.UsernamePasswordCredentials;
 
-import java.net.URL;
+import java.net.URI;
 
 /**
  *
@@ -55,7 +55,7 @@ public class DriverConfiguration {
     public DriverConfiguration setURI(String uri) {
         configuration.set(URI[0], uri);
         try { // if this URI is a genuine resource, see if it has an embedded user-info and set credentials accordingly
-            URL url = new URL(uri);
+            URI url = new URI(uri);
             String userInfo = url.getUserInfo();
             if (userInfo != null) {
                 String[] userPass = userInfo.split(":");
@@ -161,8 +161,8 @@ public class DriverConfiguration {
         return null;
     }
 
-    private void determineDefaultDriverName(URL url) {
-        switch (url.getProtocol()) {
+    private void determineDefaultDriverName(URI uri) {
+        switch (uri.getScheme()) {
             case "http":
             case "https":
                 setDriverClassName("org.neo4j.ogm.drivers.http.driver.HttpDriver");

--- a/core/src/test/java/org/neo4j/ogm/drivers/DriverConfigurationTest.java
+++ b/core/src/test/java/org/neo4j/ogm/drivers/DriverConfigurationTest.java
@@ -13,17 +13,19 @@
 
 package org.neo4j.ogm.drivers;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+import org.neo4j.ogm.authentication.Credentials;
+import org.neo4j.ogm.authentication.UsernamePasswordCredentials;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.config.DriverConfiguration;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author vince
  */
 
-public class DriverConfigTest {
+public class DriverConfigurationTest {
 
     @Test
     public void shouldLoadHttpDriverConfigFromPropertiesFile() {
@@ -45,6 +47,19 @@ public class DriverConfigTest {
         assertEquals("NONE", driverConfig.getEncryptionLevel());
         assertEquals("TRUST_ON_FIRST_USE", driverConfig.getTrustStrategy());
         assertEquals("/tmp/cert", driverConfig.getTrustCertFile());
+    }
+
+    @Test
+    public void shouldSetUsernameAndPasswordCredentialsForBoltProtocol() {
+        String username = "neo4j";
+        String password = "password";
+        Configuration dbConfig = new Configuration();
+        dbConfig.driverConfiguration().setURI("bolt://" + username + ":" + password + "@localhost");
+        Credentials credentials = dbConfig.driverConfiguration().getCredentials();
+        UsernamePasswordCredentials basic = (UsernamePasswordCredentials) credentials;
+        assert basic != null;
+        assert username.equals(basic.getUsername());
+        assert password.equals(basic.getPassword());
     }
 
 }

--- a/core/src/test/java/org/neo4j/ogm/drivers/DriverConfigurationTest.java
+++ b/core/src/test/java/org/neo4j/ogm/drivers/DriverConfigurationTest.java
@@ -20,6 +20,7 @@ import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.config.DriverConfiguration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author vince
@@ -57,9 +58,9 @@ public class DriverConfigurationTest {
         dbConfig.driverConfiguration().setURI("bolt://" + username + ":" + password + "@localhost");
         Credentials credentials = dbConfig.driverConfiguration().getCredentials();
         UsernamePasswordCredentials basic = (UsernamePasswordCredentials) credentials;
-        assert basic != null;
-        assert username.equals(basic.getUsername());
-        assert password.equals(basic.getPassword());
+        assertNotNull(basic);
+        assertEquals(username, basic.getUsername());
+        assertEquals(password, basic.getPassword());
     }
 
 }


### PR DESCRIPTION
Issues #204 
- Changing URL to URI in setURI() in order to avoid exception for 'bolt' scheme
- Replacing protocol from URL to URI scheme in determineDefaultDriverName()
- Adding unit test