### PR TITLE
Support for @Labels without get/set

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/function/DistanceComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/DistanceComparison.java
@@ -24,6 +24,9 @@ public class DistanceComparison implements FilterFunction<DistanceFromPoint> {
     private DistanceFromPoint value;
     private Filter filter;
 
+    public DistanceComparison() {
+    }
+
     public DistanceComparison(DistanceFromPoint value) {
         this.value = value;
     }

--- a/core/src/main/java/org/neo4j/ogm/entity/io/EntityAccessManager.java
+++ b/core/src/main/java/org/neo4j/ogm/entity/io/EntityAccessManager.java
@@ -11,6 +11,7 @@
 
 package org.neo4j.ogm.entity.io;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -138,6 +139,10 @@ public class EntityAccessManager {
         }
 
         // fall back to the field if method cannot be found
+        FieldInfo labelField = classInfo.labelFieldOrNull();
+        if (labelField != null && labelField.getName().equals(propertyName)) {
+            return factory.makeFieldAccessor(labelField);
+        }
         FieldInfo fieldInfo = classInfo.propertyField(propertyName);
         if (fieldInfo != null) {
             return factory.makeFieldAccessor(fieldInfo);

--- a/core/src/test/java/org/neo4j/ogm/domain/restaurant/Restaurant.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/restaurant/Restaurant.java
@@ -71,11 +71,4 @@ public class Restaurant {
 		this.location = location;
 	}
 
-	public Collection<String> getLabels() {
-		return labels;
-	}
-
-	public void setLabels(Collection<String> labels) {
-		this.labels = labels;
-	}
 }

--- a/core/src/test/java/org/neo4j/ogm/domain/restaurant/Restaurant.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/restaurant/Restaurant.java
@@ -14,49 +14,68 @@
 
 package org.neo4j.ogm.domain.restaurant;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Labels;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 
 public class Restaurant {
 
-    @GraphId
-    private Long id;
-    private String name;
-    private int zip;
+	@GraphId
+	private Long id;
+	private String name;
+	private int zip;
 
-    @Convert(LocationConverter.class)
-    Location location;
+	@Convert(LocationConverter.class)
+	Location location;
 
-    public Restaurant() {
-    }
+	@Labels
+	public Collection<String> labels = new ArrayList<>();
 
-    public Restaurant(String name, Location location, int zip) {
-        this.name = name;
-        this.location = location;
-        this.zip = zip;
-    }
+	public Restaurant() {
+	}
 
-    public String getName() {
-        return name;
-    }
+	public Restaurant(String name, Location location, int zip) {
+		this.name = name;
+		this.location = location;
+		this.zip = zip;
+	}
 
-    public void setName(String name) {
-        this.name = name;
-    }
+	public Long getId() {
+		return id;
+	}
 
-    public int getZip() {
-        return zip;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void setZip(int zip) {
-        this.zip = zip;
-    }
+	public void setName(String name) {
+		this.name = name;
+	}
 
-    public Location getLocation() {
-        return location;
-    }
+	public int getZip() {
+		return zip;
+	}
 
-    public void setLocation(Location location) {
-        this.location = location;
-    }
+	public void setZip(int zip) {
+		this.zip = zip;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+
+	public void setLocation(Location location) {
+		this.location = location;
+	}
+
+	public Collection<String> getLabels() {
+		return labels;
+	}
+
+	public void setLabels(Collection<String> labels) {
+		this.labels = labels;
+	}
 }

--- a/core/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
@@ -257,7 +257,7 @@ public class PizzaIntegrationTest extends MultiDriverTestClass {
      * @see issue #159
      */
     @Test
-    public void shouldSyncMappedLabelsFromEntityToTheNode_and_NodeToEntity() {
+    public void shouldSyncMappedLabelsFromEntityToTheNode_and_NodeToEntity_noGetterOrSetter() {
 
         Pizza pizza = new Pizza();
         pizza.setName("Mushroom & Pepperoni");

--- a/core/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
@@ -17,10 +17,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.function.DistanceComparison;
 import org.neo4j.ogm.cypher.function.DistanceFromPoint;
@@ -28,6 +25,7 @@ import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.function.FilterFunction;
 import org.neo4j.ogm.domain.restaurant.Location;
 import org.neo4j.ogm.domain.restaurant.Restaurant;
+import org.neo4j.ogm.service.Components;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.GraphTestUtils;
@@ -45,6 +43,7 @@ public class RestaurantIntegrationTest extends MultiDriverTestClass {
 	@Before
 	public void init() throws IOException {
 		session = new SessionFactory("org.neo4j.ogm.domain.restaurant").openSession();
+		Assume.assumeTrue(Components.neo4jVersion() >= 3);
 	}
 
 	@After
@@ -55,69 +54,61 @@ public class RestaurantIntegrationTest extends MultiDriverTestClass {
 	@Test
 	public void shouldSaveRestaurantWithCompositeLocationConverter() {
 
-		if (!TestUtils.neo4jVersion().startsWith("2")) {
-			Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
-					new Location(37.61649, -122.38681), 94128);
-			session.save(restaurant);
+		Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
+				new Location(37.61649, -122.38681), 94128);
+		session.save(restaurant);
 
-			GraphTestUtils.assertSameGraph(getGraphDatabaseService(),
-					"CREATE (n:`Restaurant` {name: 'San Francisco International Airport (SFO)', latitude: 37.61649, longitude: -122.38681, zip: 94128})");
-		}
+		GraphTestUtils.assertSameGraph(getGraphDatabaseService(),
+				"CREATE (n:`Restaurant` {name: 'San Francisco International Airport (SFO)', latitude: 37.61649, longitude: -122.38681, zip: 94128})");
 	}
 
 	@Test
 	public void shouldQueryByDistance() {
 
-		if (!TestUtils.neo4jVersion().startsWith("2")) {
-			Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
-					new Location(37.61649, -122.38681), 94128);
-			session.save(restaurant);
+		Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
+				new Location(37.61649, -122.38681), 94128);
+		session.save(restaurant);
 
-			HashMap<String, Object> parameters = new HashMap<>();
-			parameters.put("distance", 1000);
+		HashMap<String, Object> parameters = new HashMap<>();
+		parameters.put("distance", 1000);
 
-			Restaurant found = session.queryForObject(Restaurant.class, "MATCH (r:Restaurant) " +
-							"WHERE distance(point(r),point({latitude:37.0, longitude:-118.0, crs: 'WGS-84'})) < {distance}*1000 RETURN r;",
-					parameters);
+		Restaurant found = session.queryForObject(Restaurant.class, "MATCH (r:Restaurant) " +
+						"WHERE distance(point(r),point({latitude:37.0, longitude:-118.0, crs: 'WGS-84'})) < {distance}*1000 RETURN r;",
+				parameters);
 
-			Assert.assertNotNull(found);
-		}
+		Assert.assertNotNull(found);
 	}
 
 	@Test
 	public void shouldQueryByDistanceUsingFilter() {
-		if (!TestUtils.neo4jVersion().startsWith("2")) {
-			Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
-					new Location(37.61649, -122.38681), 94128);
-			session.save(restaurant);
-			session.clear();
 
-			Filter filter = new Filter(new DistanceComparison(new DistanceFromPoint(37.61649, -122.38681, 1000 * 1000.0)));
-			filter.setComparisonOperator(ComparisonOperator.LESS_THAN);
-			Collection<Restaurant> found = session.loadAll(Restaurant.class, filter);
-			Assert.assertNotNull(found);
-			assertTrue(found.size() >= 1);
-		}
+		Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
+				new Location(37.61649, -122.38681), 94128);
+		session.save(restaurant);
+		session.clear();
+
+		Filter filter = new Filter(new DistanceComparison(new DistanceFromPoint(37.61649, -122.38681, 1000 * 1000.0)));
+		filter.setComparisonOperator(ComparisonOperator.LESS_THAN);
+		Collection<Restaurant> found = session.loadAll(Restaurant.class, filter);
+		Assert.assertNotNull(found);
+		assertTrue(found.size() >= 1);
 	}
 
 	@Test
 	public void saveAndRetrieveRestaurantWithLocation() {
 
-		if (!TestUtils.neo4jVersion().startsWith("2")) {
-			Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
-					new Location(37.61649, -122.38681), 94128);
+		Restaurant restaurant = new Restaurant("San Francisco International Airport (SFO)",
+				new Location(37.61649, -122.38681), 94128);
 
-			session.save(restaurant);
-			session.clear();
+		session.save(restaurant);
+		session.clear();
 
-			Collection<Restaurant> results = session.loadAll(Restaurant.class,
-					new Filter("name", "San Francisco International Airport (SFO)"));
-			assertEquals(1, results.size());
-			Restaurant result = results.iterator().next();
-			assertNotNull(result.getLocation());
-			assertEquals(37.61649, result.getLocation().getLatitude(), 0);
-			assertEquals(-122.38681, result.getLocation().getLongitude(), 0);
-		}
-
+		Collection<Restaurant> results = session.loadAll(Restaurant.class,
+				new Filter("name", "San Francisco International Airport (SFO)"));
+		assertEquals(1, results.size());
+		Restaurant result = results.iterator().next();
+		assertNotNull(result.getLocation());
+		assertEquals(37.61649, result.getLocation().getLatitude(), 0);
+		assertEquals(-122.38681, result.getLocation().getLongitude(), 0);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,6 @@
                             </excludes>
 
                             <systemPropertyVariables>
-                                <neo4j.version>${neo4j}</neo4j.version>
                                 <ogm.properties>${ogm.properties}</ogm.properties>
                             </systemPropertyVariables>
 
@@ -272,7 +271,6 @@
                                         <exclude>**/BoltDriverTest.java</exclude>
                                     </excludes>
                                     <systemPropertyVariables>
-                                        <neo4j.version>${neo4j}</neo4j.version>
                                         <ogm.properties>${ogm.properties}</ogm.properties>
                                     </systemPropertyVariables>
 
@@ -309,7 +307,6 @@
                                         <exclude>**/BoltDriverTest.java</exclude>
                                     </excludes>
                                     <systemPropertyVariables>
-                                        <neo4j.version>${neo4j}</neo4j.version>
                                         <ogm.properties>${ogm.properties}</ogm.properties>
                                     </systemPropertyVariables>
 
@@ -342,7 +339,6 @@
                                         <include>**/*.java</include>
                                     </includes>
                                     <systemPropertyVariables>
-                                        <neo4j.version>${neo4j}</neo4j.version>
                                         <ogm.properties>${ogm.properties}</ogm.properties>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/test/src/main/java/org/neo4j/ogm/testutil/TestUtils.java
+++ b/test/src/main/java/org/neo4j/ogm/testutil/TestUtils.java
@@ -53,14 +53,6 @@ public final class TestUtils {
 		return cypher;
 	}
 
-	/**
-	 * Returns the Neo4j version specified by the Maven Profile. We use this approach to exclude certain tests from
-	 * 2.x runs, so that the build server and maven can share the same approach.
-	 */
-	public static String neo4jVersion() {
-		return System.getProperty("neo4j.version").trim();
-	}
-
 	private TestUtils() {
 	}
 }


### PR DESCRIPTION
Support for @Labels without get/set
Fix the way that spatial tests are excluded from 2.x - this way is compatible with both mvn and CI server, plus cleaner, than previously. 
