### PR TITLE
Make tests passing on Windows

### DIFF
--- a/api/src/test/java/org/neo4j/ogm/classloader/DefaultResourceResolverTest.java
+++ b/api/src/test/java/org/neo4j/ogm/classloader/DefaultResourceResolverTest.java
@@ -29,7 +29,7 @@ public class DefaultResourceResolverTest {
 
         DefaultResourceResolver resourceResolver = new DefaultResourceResolver();
         File f = resourceResolver.resolve(new URL("file:///foo%23bar/WEB-INF/classes/Dependency.class"));
-        Assert.assertEquals("/foo#bar/WEB-INF/classes/Dependency.class", f.getPath());
+        Assert.assertEquals(new File("/foo#bar/WEB-INF/classes/Dependency.class"), f);
 
     }
 
@@ -38,7 +38,7 @@ public class DefaultResourceResolverTest {
 
         DefaultResourceResolver resourceResolver = new DefaultResourceResolver();
         File f = resourceResolver.resolve(new URL("jar:file:///foo%23bar/WEB-INF/lib/dependencies.jar!/Dependency.class"));
-        Assert.assertEquals("/foo#bar/WEB-INF/lib/dependencies.jar", f.getPath());
+        Assert.assertEquals(new File("/foo#bar/WEB-INF/lib/dependencies.jar"), f);
 
     }
 

--- a/core/src/test/java/org/neo4j/ogm/drivers/DriverServiceTest.java
+++ b/core/src/test/java/org/neo4j/ogm/drivers/DriverServiceTest.java
@@ -16,17 +16,12 @@ package org.neo4j.ogm.drivers;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.config.DriverConfiguration;
 import org.neo4j.ogm.driver.Driver;
 import org.neo4j.ogm.drivers.http.driver.HttpDriver;
 import org.neo4j.ogm.service.DriverService;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -35,24 +30,10 @@ import static org.junit.Assert.assertNotNull;
  */
 public class DriverServiceTest {
 
-    public static final String TMP_NEO4J_DB = Paths.get(System.getProperty("java.io.tmpdir"), "neo4j.db").toString();
+    @Rule
+    public final TemporaryFolder tmpNeo4JDB = new TemporaryFolder();
+
     private DriverConfiguration driverConfiguration = new Configuration().driverConfiguration();
-
-    @BeforeClass
-    public static void createEmbeddedStore() throws IOException {
-        try {
-            Files.createDirectory(Paths.get(TMP_NEO4J_DB));
-        } catch(FileAlreadyExistsException e){
-            // the directory already exists.
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @AfterClass
-    public static void deleteEmbeddedStore() throws IOException {
-        deleteDirectory(new File(TMP_NEO4J_DB));
-    }
 
     @Test
     public void shouldLoadHttpDriver() {
@@ -69,7 +50,7 @@ public class DriverServiceTest {
     public void shouldLoadEmbeddedDriver() {
         driverConfiguration.setDriverClassName("org.neo4j.ogm.drivers.embedded.driver.EmbeddedDriver");
 
-        String uri = "file://" + TMP_NEO4J_DB;
+        String uri = tmpNeo4JDB.getRoot().toURI().toString();
 
         driverConfiguration.setURI(uri);
 
@@ -85,17 +66,6 @@ public class DriverServiceTest {
         Driver driver = DriverService.load(driverConfiguration);
         assertNotNull(driver);
         driver.close();
-    }
-
-    static void deleteDirectory(File dir) throws IOException {
-        if (dir.isDirectory()) {
-            for (File file : dir.listFiles()) {
-                deleteDirectory(file);
-            }
-        }
-        if (!dir.delete()) {
-            throw new RuntimeException("Failed to delete file: " + dir);
-        }
     }
 
 


### PR DESCRIPTION
Two tests are not successful on Windows because of file separator ('/' vs '\') and uri handling.
This pull req makes them passing on windows, linux and macos.