### PR TITLE
Call on the transactional endpoint was not setting correct X-WRITE he…

### DIFF
--- a/http-driver/src/main/java/org/neo4j/ogm/drivers/http/driver/HttpDriver.java
+++ b/http-driver/src/main/java/org/neo4j/ogm/drivers/http/driver/HttpDriver.java
@@ -84,7 +84,7 @@ public final class HttpDriver extends AbstractConfigurableDriver
 
     @Override
     public Transaction newTransaction(Transaction.Type type, String bookmark) {
-        return new HttpTransaction(transactionManager, this, newTransactionUrl(), type);
+        return new HttpTransaction(transactionManager, this, newTransactionUrl(type), type);
     }
 
     public CloseableHttpResponse executeHttpRequest(HttpRequestBase request) throws HttpRequestException {
@@ -111,13 +111,13 @@ public final class HttpDriver extends AbstractConfigurableDriver
         }
     }
 
-    private String newTransactionUrl() {
+    private String newTransactionUrl(Transaction.Type type) {
 
         String url = transactionEndpoint(driverConfig.getURI());
         LOGGER.debug( "Thread: {}, POST {}", Thread.currentThread().getId(), url );
 
         HttpPost request = new HttpPost(url);
-        request.setHeader("X-WRITE", readOnly() ? "0" : "1");
+        request.setHeader("X-WRITE", type == Transaction.Type.READ_ONLY ? "0" : "1");
 
         try (CloseableHttpResponse response = executeHttpRequest(request)) {
             Header location = response.getHeaders("Location")[0];


### PR DESCRIPTION
…ader when transaction is read only. Fixes #323

## Description
The request to start a transaction was not taking into account the transaction type.
Read only transactions always call  /db/data/transaction with X-WRITE header set to 1.

## Related Issue
#323  

## Motivation and Context
Causes problems for HA, where routing on master/slaves can use this header.

## How Has This Been Tested?
Tested manually. Didn't add specific test because there is no test harness on outgoing requests atm.

Ran all the existing unit / integration tests. 

Also ran the tests of spring-data-neo4j with the patched OGM version.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
