### PR TITLE
Regression: ensure RelationshipEntities not referenced by NodeEntitie…

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -190,7 +190,7 @@ public class ClassInfo {
         return className.substring(className.lastIndexOf('.') + 1);
     }
 
-    ClassInfo directSuperclass() {
+    public ClassInfo directSuperclass() {
         return directSuperclass;
     }
 


### PR DESCRIPTION
…s can be loaded. Fixes #309

## Description
This PR restores the correct hydration of relationship entities where the referenced start and end node entities do not themselves maintain a reference to the relationship.

## Related Issue
https://jira.spring.io/browse/DATAGRAPH-944

## Motivation and Context
A recent commit made to support polymorphic relationship entities introduced a change in behaviour for relationship entities whose start and end nodes don't maintain an explicit reference to that relationship. These relationship entities were not being properly hydrated.

This PR restores the previous behaviour for such relationship entities.

## How Has This Been Tested?
An explicit test for this scenario has been added to the RelationshipEntityTest class

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
