### PR TITLE
Look for primary indexes on class hierarchy and not only on leaf clas…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 2.1.2
 --------------
 o Fixes issue where the X-Write header is wrong on read-only transactions first request. Fixes #323.
+o Primary index annotations are picked up on the whole class class hierarchy, not only on leaf class. Fixes #332.
 
 
 2.1.1

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -119,7 +119,6 @@ public class ClassInfo {
         methodsInfo = new MethodsInfo(dataInputStream, constantPool);
         annotationsInfo = new AnnotationsInfo(dataInputStream, constantPool);
         new ClassValidator(this).validate();
-        primaryIndexField = primaryIndexField();
     }
 
     /**

--- a/core/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/ExtendedUser.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/ExtendedUser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.domain.cineasts.annotated;
+
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Nicolas Mervaillie
+ */
+@NodeEntity
+public class ExtendedUser extends User {
+
+    public ExtendedUser() {
+    }
+
+    public ExtendedUser(String login, String name, String password) {
+        super(login, name, password);
+    }
+}

--- a/core/src/test/java/org/neo4j/ogm/index/LookupByPrimaryIndexTests.java
+++ b/core/src/test/java/org/neo4j/ogm/index/LookupByPrimaryIndexTests.java
@@ -3,6 +3,7 @@ package org.neo4j.ogm.index;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.neo4j.ogm.domain.cineasts.annotated.ExtendedUser;
 import org.neo4j.ogm.domain.cineasts.annotated.User;
 import org.neo4j.ogm.domain.cineasts.partial.Actor;
 import org.neo4j.ogm.index.domain.valid.Invoice;
@@ -13,6 +14,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 /**
  * @author Mark Angrish
+ * @author Nicolas Mervaillie
  */
 public class LookupByPrimaryIndexTests extends MultiDriverTestClass {
 
@@ -28,6 +30,22 @@ public class LookupByPrimaryIndexTests extends MultiDriverTestClass {
         final Session session2 = sessionFactory.openSession();
 
         final User retrievedUser1 = session2.load(User.class, "login1");
+        assertNotNull(retrievedUser1);
+        assertEquals(user1.getLogin(), retrievedUser1.getLogin());
+    }
+
+    @Test
+    public void loadUsesPrimaryIndexWhenPresentOnSuperclass() {
+
+        SessionFactory sessionFactory = new SessionFactory("org.neo4j.ogm.domain.cineasts.annotated");
+        final Session session = sessionFactory.openSession();
+
+        ExtendedUser user1 = new ExtendedUser("login2", "Name 2", "password");
+        session.save(user1);
+
+        final Session session2 = sessionFactory.openSession();
+
+        final User retrievedUser1 = session2.load(ExtendedUser.class, "login2");
         assertNotNull(retrievedUser1);
         assertEquals(user1.getLogin(), retrievedUser1.getLogin());
     }

--- a/core/src/test/java/org/neo4j/ogm/index/MergeWithPrimaryIndexTests.java
+++ b/core/src/test/java/org/neo4j/ogm/index/MergeWithPrimaryIndexTests.java
@@ -65,7 +65,7 @@ public class MergeWithPrimaryIndexTests {
 
     @Test(expected = Neo4jException.class)
     public void exceptionRaisedWhenMoreThanOnePrimaryIndexDefinedInSameClass() {
-        new MetaData("org.neo4j.ogm.index.domain.invalid");
+        new MetaData("org.neo4j.ogm.index.domain.invalid").classInfo("BadClass").primaryIndexField();
     }
 
 


### PR DESCRIPTION
…s. Fixes #332.

Not sure about how it really works here, but applying the same logic as for ids fixes the bug (deferring metadata lookup from startup to later).
Not an ideal fix but will be ok till v3.0 refactoring

## Related Issue

#332
http://stackoverflow.com/questions/42610217/struggling-with-retrieving-an-entity-from-neo4j-using-a-primary-index

## How Has This Been Tested?

org.neo4j.ogm.index.LookupByPrimaryIndexTests#loadUsesPrimaryIndexWhenPresentOnSuperclass

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
