### PR TITLE
Alternative performance fix for issue #327

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -169,7 +169,7 @@ public class EntityGraphMapper implements EntityMapper {
                 clearRelatedObjects(mappedRelationship.getEndNodeId());
 
                 // finally remove the relationship from the mapping context
-                mappingContext.removeRelationship(mappedRelationship);
+                mappedRelationshipIterator.remove();
             }
         }
     }

--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -544,7 +544,9 @@ public class GraphEntityMapper implements ResponseMapper<GraphModel> {
         } else {
             if (classInfos.size() == 0) {
                 // not necessarily a problem, we mey be fetching edges we don't want to hydrate
-                logger.debug("Unable to find a matching @RelationshipEntity for {}", edge.toString());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Unable to find a matching @RelationshipEntity for {}", edge.toString());
+                }
             } else {
                 // almost definitely a user bug
                 logger.error("Found more than one matching @RelationshipEntity for {} but cannot tell which one to use", edge.toString());

--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -14,15 +14,22 @@
 package org.neo4j.ogm.context;
 
 import java.lang.reflect.Field;
-import java.util.*;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 import org.neo4j.ogm.MetaData;
 import org.neo4j.ogm.classloader.MetaDataClassLoader;
 import org.neo4j.ogm.context.register.EntityRegister;
 import org.neo4j.ogm.context.register.LabelHistoryRegister;
 import org.neo4j.ogm.context.register.TypeRegister;
-import org.neo4j.ogm.entity.io.*;
+import org.neo4j.ogm.entity.io.EntityAccessManager;
+import org.neo4j.ogm.entity.io.FieldReader;
+import org.neo4j.ogm.entity.io.FieldWriter;
+import org.neo4j.ogm.entity.io.PropertyReader;
+import org.neo4j.ogm.entity.io.RelationalReader;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 
@@ -64,9 +71,7 @@ public class MappingContext {
         this.nodeEntityRegister = new EntityRegister<>();
         this.primaryIndexNodeRegister = new EntityRegister<>();
         this.relationshipEntityRegister = new EntityRegister<>();
-        // NOTE: The use of CopyOnWriteArraySet here is to prevent ConcurrentModificationException from occurring when
-        // the purge() method is called.
-        this.relationshipRegister = new CopyOnWriteArraySet<>();
+        this.relationshipRegister = new HashSet<>();
         this.labelHistoryRegister = new LabelHistoryRegister();
     }
 
@@ -347,18 +352,9 @@ public class MappingContext {
     }
 
 
-    /**
-     * NOTE: There was a lot of concurrent code in other classes (see commit) to prevent this method from throwing
-     * ConcurrentModificationException. This is due to: 1) not deleting through the iterator
-     * 2) using an iterative approach along with recursion and then modifying the underlying collection.
-     * To get around this we can either block all methods that are involved in the recursion stack from concurrently
-     * modifying the mapped relationship collection (previous implementation: very inefficient) to copying the collection
-     * on write (current implementation: inefficient).
-     * TODO: The best way to fix this method is to replace it with an iterative approach using a <code>Stack</code> and
-     * call remove() on the mappedRelationshipIterator. This will be both efficient and safe.
-     */
     private void purge(Object entity, PropertyReader identityReader, Class type) {
         Long id = (Long) identityReader.readProperty(entity);
+        Set<Object> relEntitiesToPurge = new HashSet<>();
         if (id != null) {
             // remove a NodeEntity
             if (!metaData.isRelationshipEntity(type.getName())) {
@@ -375,14 +371,12 @@ public class MappingContext {
                             if (mappedRelationship.getRelationshipId() != null) {
                                 Object relEntity = relationshipEntityRegister.get(mappedRelationship.getRelationshipId());
                                 if (relEntity != null) {
-                                    ClassInfo relClassInfo = metaData.classInfo(relEntity);
-                                    PropertyReader relIdentityReader = EntityAccessManager.getIdentityPropertyReader(relClassInfo);
-                                    purge(relEntity, relIdentityReader, relClassInfo.getUnderlyingClass());
+                                    relEntitiesToPurge.add(relEntity);
                                 }
                             }
 
                             // finally remove the mapped relationship
-                            relationshipRegister.remove(mappedRelationship);
+                            mappedRelationshipIterator.remove();
                         }
                     }
                 }
@@ -397,6 +391,11 @@ public class MappingContext {
                     Object endNode = endNodeReader.read(entity);
                     removeEntity(endNode);
                 }
+            }
+           for (Object relEntity : relEntitiesToPurge) {
+                ClassInfo relClassInfo = metaData.classInfo(relEntity);
+                PropertyReader relIdentityReader = EntityAccessManager.getIdentityPropertyReader(relClassInfo);
+                purge(relEntity, relIdentityReader, relClassInfo.getUnderlyingClass());
             }
         }
     }

--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
@@ -71,6 +71,7 @@ public class FieldInfo {
      * The associated composite attribute converter for this field, if applicable, otherwise null.
      */
     private CompositeAttributeConverter<?> compositeConverter;
+    private String descriptorClass;
 
 
     /**
@@ -274,10 +275,14 @@ public class FieldInfo {
      * @return collection class name
      */
     public String getCollectionClassname() {
+        if (descriptorClass != null) {
+            return descriptorClass;
+        }
         String descriptorClass = descriptor.replace("/", ".");
         if (descriptorClass.startsWith("L")) {
             descriptorClass = descriptorClass.substring(1, descriptorClass.length() - 1); //remove the leading L and trailing ;
         }
+        this.descriptorClass = descriptorClass;
         return descriptorClass;
     }
 


### PR DESCRIPTION
Based on the fix from @nmervaillie which replaces the CopyOnWriteArraySet used for the relationship register, this removes deletion of mapped relationships recursively, in an iterator.

## Description
see above

## Related Issue
#327 

## Motivation and Context
Performance impact caused by the CopyOnWriteArraySet

## How Has This Been Tested?
Used test that demonstrates the problem from @nmervaillie 

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
