### PR TITLE
Change jar entry logging from DEBUG to TRACE

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/scanner/ClassPathScanner.java
+++ b/core/src/main/java/org/neo4j/ogm/scanner/ClassPathScanner.java
@@ -88,7 +88,7 @@ public class ClassPathScanner {
 
         String name = entry.getName();
 
-        LOGGER.debug("Scanning class entry: {}", name);
+        LOGGER.trace("Scanning class entry: {}", name);
 
         for (String pathToScan : classPaths) {
             if (name.contains(pathToScan)) {


### PR DESCRIPTION
`ClassPathScanner` logs every entry in a jar file at `DEBUG` level.  `DEBUG` logging should be useful to developers, and its usefulness is greatly diminished by the interesting messages getting lost in tens of thousands of lines of spam.

With this change, every entry in a jar file is logged at `TRACE`, and only the ones that turn out to be interesting are logged at `DEBUG`.
