### PR TITLE
Make rollback close bolt session when transaction is closed

### DIFF
--- a/bolt-driver/pom.xml
+++ b/bolt-driver/pom.xml
@@ -42,5 +42,9 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
@@ -56,9 +56,7 @@ public class BoltTransaction extends AbstractTransaction {
 				nativeSession.close();
 			}
 		} catch (Exception e) {
-			if (nativeSession.isOpen()) {
-				nativeSession.close();
-			}
+			closeNativeSessionIfPossible();
 			throw new TransactionException(e.getLocalizedMessage());
 		} finally {
 			super.rollback();
@@ -80,17 +78,13 @@ public class BoltTransaction extends AbstractTransaction {
 				}
 			}
 		} catch (ClientException ce) {
-			if (nativeSession.isOpen()) {
-				nativeSession.close();
+			closeNativeSessionIfPossible();
+			if (ce.code().startsWith(NEO_CLIENT_ERROR_SECURITY)) {
+				throw new ConnectionException("Security Error: " + ce.code() + ", " + ce.getMessage(), ce);
 			}
-			if (ce.neo4jErrorCode().startsWith(NEO_CLIENT_ERROR_SECURITY)) {
-				throw new ConnectionException("Security Error: " + ce.neo4jErrorCode() + ", " + ce.getMessage(), ce);
-			}
-			throw new CypherException("Error executing Cypher", ce, ce.neo4jErrorCode(), ce.getMessage());
+			throw new CypherException("Error executing Cypher", ce, ce.code(), ce.getMessage());
 		} catch (Exception e) {
-			if (nativeSession.isOpen()) {
-				nativeSession.close();
-			}
+			closeNativeSessionIfPossible();
 			throw new TransactionException(e.getLocalizedMessage());
 		} finally {
 			super.commit();
@@ -102,5 +96,11 @@ public class BoltTransaction extends AbstractTransaction {
 
 	public Transaction nativeBoltTransaction() {
 		return nativeTransaction;
+	}
+
+	private void closeNativeSessionIfPossible() {
+		if (nativeSession.isOpen()) {
+			nativeSession.close();
+		}
 	}
 }

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
@@ -50,10 +50,10 @@ public class BoltTransaction extends AbstractTransaction {
 				if (nativeTransaction.isOpen()) {
 					nativeTransaction.failure();
 					nativeTransaction.close();
-					nativeSession.close();
 				} else {
 					LOGGER.warn("Transaction is already closed");
 				}
+				nativeSession.close();
 			}
 		} catch (Exception e) {
 			if (nativeSession.isOpen()) {

--- a/bolt-driver/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
+++ b/bolt-driver/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2002-2016 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.drivers.bolt.transaction;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.ogm.transaction.TransactionManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+import static org.neo4j.ogm.transaction.Transaction.Type.READ_ONLY;
+
+public class BoltTransactionTest {
+
+    @Test
+    public void commitShouldCloseTransactionAndSession() {
+        Transaction nativeTx = openTransactionMock();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        boltTx.commit();
+
+        InOrder inOrder = inOrder(nativeSession, nativeTx);
+        inOrder.verify(nativeTx).close();
+        inOrder.verify(nativeSession).close();
+    }
+
+    @Test
+    public void commitShouldCloseSessionWhenTransactionIsClosed() {
+        Transaction nativeTx = closedTransactionMock();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        try {
+            boltTx.commit();
+        } catch (Exception ignore) {
+            // do not care about exceptions, native session should just get closed at the end
+        }
+
+        verify(nativeTx, never()).close();
+        verify(nativeSession).close();
+    }
+
+    @Test
+    public void commitShouldCloseSessionWhenTransactionCloseThrows() {
+        Transaction nativeTx = openTransactionMock();
+        doThrow(new RuntimeException("Close failed")).when(nativeTx).close();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        try {
+            boltTx.commit();
+            fail("Exception expected");
+        } catch (Exception e) {
+            assertEquals("Close failed", e.getMessage());
+        }
+
+        verify(nativeSession).close();
+    }
+
+    @Test
+    public void rollbackShouldCloseTransactionAndSession() {
+        Transaction nativeTx = openTransactionMock();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        boltTx.rollback();
+
+        InOrder inOrder = inOrder(nativeSession, nativeTx);
+        inOrder.verify(nativeTx).close();
+        inOrder.verify(nativeSession).close();
+    }
+
+    @Test
+    public void rollbackShouldCloseSessionWhenTransactionIsClosed() {
+        Transaction nativeTx = closedTransactionMock();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        boltTx.rollback();
+
+        verify(nativeTx, never()).close();
+        verify(nativeSession).close();
+    }
+
+    @Test
+    public void rollbackShouldCloseSessionWhenTransactionCloseThrows() {
+        Transaction nativeTx = openTransactionMock();
+        doThrow(new RuntimeException("Close failed")).when(nativeTx).close();
+        Session nativeSession = openSessionMock();
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+
+        try {
+            boltTx.rollback();
+            fail("Exception expected");
+        } catch (Exception e) {
+            assertEquals("Close failed", e.getMessage());
+        }
+
+        verify(nativeSession).close();
+    }
+
+    private static Session openSessionMock() {
+        Session session = mock(Session.class);
+        when(session.isOpen()).thenReturn(true);
+        return session;
+    }
+
+    private static Transaction openTransactionMock() {
+        Transaction tx = mock(Transaction.class);
+        when(tx.isOpen()).thenReturn(true);
+        return tx;
+    }
+
+    private static Transaction closedTransactionMock() {
+        return mock(Transaction.class);
+    }
+
+    private static TransactionManager committingTxManager() {
+        TransactionManager txManager = mock(TransactionManager.class);
+        when(txManager.canCommit()).thenReturn(true);
+        return txManager;
+    }
+
+    private static TransactionManager rollingBackTxManager() {
+        TransactionManager txManager = mock(TransactionManager.class);
+        when(txManager.canRollback()).thenReturn(true);
+        return txManager;
+    }
+}


### PR DESCRIPTION
## Description
`BoltTransaction` is the owner of neo4j driver's `Session` and is responsible for it's lifecycle. It's `#rollback()` method did not try to close session if native transaction was closed. However transaction and session are, to some extent, independent and both should always be closed to free up resources.

This PR makes `BoltTransaction#rollback()` always close session and adds tests for `#commit()` and `#rollback()`. It also removes usages of a deprecated method.

## Related Issue
https://github.com/neo4j/neo4j-ogm/issues/363

## Motivation and Context
It is safer to attempt closing `Session` even if `Transaction` is already closed.

## How Has This Been Tested?
Added mock-based tests for `BoltTransaction`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
