### PR TITLE
Make Session::load(type, id) consider type-information in its queries

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -54,7 +54,7 @@ public class LoadOneDelegate {
         }
 
         QueryStatements queryStatements = session.queryStatementsFor(type);
-        PagingAndSortingQuery qry = queryStatements.findOne(id, depth);
+        PagingAndSortingQuery qry = queryStatements.findOneByType(session.entityType(type.getName()), id, depth);
 
         try (Response<GraphModel> response = session.requestHandler().execute((GraphModelRequest) qry)) {
             new GraphEntityMapper(session.metaData(), session.context()).map(type, response);

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/QueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/QueryStatements.java
@@ -37,6 +37,16 @@ public interface QueryStatements<ID extends Serializable> {
     PagingAndSortingQuery findOne(ID id, int depth);
 
     /**
+     * construct a query to fetch a single object with the specified id of a specific type
+     *
+     * @param label the label attached to the object or relationship type
+     * @param id the id of the object to find
+     * @param depth the depth to traverse for any related objects
+     * @return a {@link PagingAndSortingQuery}
+     */
+    PagingAndSortingQuery findOneByType(String label, ID id, int depth);
+
+    /**
      * construct a query to fetch all objects
      *
      * @return a {@link PagingAndSortingQuery}

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
@@ -64,6 +64,11 @@ public class NodeQueryStatements<ID extends Serializable> implements QueryStatem
     }
 
     @Override
+    public PagingAndSortingQuery findOneByType(String label, ID id, int depth) {
+        return null;
+    }
+
+    @Override
     public PagingAndSortingQuery findAll(Collection<ID> ids, int depth) {
         int max = max(depth);
         int min = min(max);

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
@@ -45,6 +45,16 @@ public class NodeQueryStatements<ID extends Serializable> implements QueryStatem
 
     @Override
     public PagingAndSortingQuery findOne(ID id, int depth) {
+       return findOneByType("", id, depth);
+    }
+
+    @Override
+    public PagingAndSortingQuery findOneByType(String label, ID id, int depth) {
+        String match = "n";
+        if (label != null && !label.equals("")) {
+            match = String.format("%s:`%s`", match, label);
+        }
+
         int max = max(depth);
         int min = min(max);
         if (depth < 0) {
@@ -53,19 +63,14 @@ public class NodeQueryStatements<ID extends Serializable> implements QueryStatem
         if (max > 0) {
             String qry;
             if (primaryIndex != null) {
-                qry = String.format("MATCH (n) WHERE n." + primaryIndex + " = { id } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN p", min, max);
+                qry = String.format("MATCH (%s) WHERE n." + primaryIndex + " = { id } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN p", match, min, max);
             } else {
-                qry = String.format("MATCH (n) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN p", min, max);
+                qry = String.format("MATCH (%s) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*%d..%d]-(m) RETURN p", match, min, max);
             }
             return new DefaultGraphModelRequest(qry, Utils.map("id", id));
         } else {
             return DepthZeroReadStrategy.findOne(id, primaryIndex);
         }
-    }
-
-    @Override
-    public PagingAndSortingQuery findOneByType(String label, ID id, int depth) {
-        return null;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatements.java
@@ -60,6 +60,11 @@ public class RelationshipQueryStatements<ID extends Serializable> implements Que
     }
 
     @Override
+    public PagingAndSortingQuery findOneByType(String label, ID id, int depth) {
+        return null;
+    }
+
+    @Override
     public PagingAndSortingQuery findAll(Collection<ID> ids, int depth) {
         int max = max(depth);
         int min = min(max);

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -42,6 +42,10 @@ public class NodeQueryStatementsTest {
         assertEquals("MATCH (n) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN p", queryStatements.findOne(0L, 2).getStatement());
     }
 
+    public void testFindOneByType() throws Exception {
+        assertEquals("MATCH (n:`Orbit`) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN p", queryStatements.findOneByType("Orbit", 0L, 3).getStatement());
+    }
+
     @Test
     public void testFindAllCollection() throws Exception {
         assertEquals("MATCH (n) WHERE ID(n) IN { ids } WITH n MATCH p=(n)-[*0..1]-(m) RETURN p", queryStatements.findAll(Arrays.asList(1L, 2L, 3L), 1).getStatement());

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -42,8 +42,13 @@ public class NodeQueryStatementsTest {
         assertEquals("MATCH (n) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN p", queryStatements.findOne(0L, 2).getStatement());
     }
 
+    @Test
     public void testFindOneByType() throws Exception {
-        assertEquals("MATCH (n:`Orbit`) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN p", queryStatements.findOneByType("Orbit", 0L, 3).getStatement());
+        assertEquals("MATCH (n:`Orbit`) WHERE ID(n) = { id } WITH n MATCH p=(n)-[*0..2]-(m) RETURN p", queryStatements.findOneByType("Orbit", 0L, 2).getStatement());
+
+        // Also assert that an empty label is the same as using the typeless variant
+        assertEquals(queryStatements.findOneByType("", 0L, 2).getStatement(), queryStatements.findOne(0L, 2).getStatement());
+        assertEquals(queryStatements.findOneByType(null, 0L, 2).getStatement(), queryStatements.findOne(0L, 2).getStatement());
     }
 
     @Test

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
@@ -52,6 +52,12 @@ public class RelationshipQueryStatementsTest {
                         "WITH startPaths, COLLECT(DISTINCT p2) AS endPaths " +
                         "WITH startPaths + endPaths AS paths UNWIND paths AS p RETURN DISTINCT p",
                 query.findOneByType("ORBITS", 0L, 2).getStatement());
+
+        // Also assert that an empty type is the same as the untyped findOne(..)
+        assertEquals(query.findOneByType("", 0L, 2).getStatement(),
+                query.findOne(0L, 2).getStatement());
+        assertEquals(query.findOneByType(null, 0L, 2).getStatement(),
+                query.findOne(0L, 2).getStatement());
     }
 
     @Test

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
@@ -45,6 +45,16 @@ public class RelationshipQueryStatementsTest {
     }
 
     @Test
+    public void testFindOneByType() throws Exception {
+        assertEquals("MATCH ()-[r0:`ORBITS`]-() WHERE ID(r0)={id}  " +
+                        "WITH STARTNODE(r0) AS n, ENDNODE(r0) AS m MATCH p1 = (n)-[*0..2]-() " +
+                        "WITH COLLECT(DISTINCT p1) AS startPaths, m MATCH p2 = (m)-[*0..2]-() " +
+                        "WITH startPaths, COLLECT(DISTINCT p2) AS endPaths " +
+                        "WITH startPaths + endPaths AS paths UNWIND paths AS p RETURN DISTINCT p",
+                query.findOneByType("ORBITS", 0L, 2).getStatement());
+    }
+
+    @Test
     public void testFindAllCollection() throws Exception {
         assertEquals("MATCH ()-[r0]-() WHERE ID(r0) IN {ids}  " +
                         "WITH r0,startnode(r0) AS n, endnode(r0) AS m " +


### PR DESCRIPTION
## Description

Changes are listed below (mirrors the commit messages). I can squash if you want me to, in case you dont like the Github UI feature. :smiley:

### Add stubbed `QueryStatements::findOneByType(..)`

This commit includes the stubbed out method to query a single
node/object from database by its type and ID.

There are also (failing) tests which sketch the required functionality.

### Add `QueryStatement::findOneByType(..)` implementation

This commits adds implementations for QueryStatement::findOneByType(..)`
in the classes `NodeQueryStatements` and `RelationshipQueryStatements`.

The tests for the method are also extended. They now test that an empty
label ("" or null) is the same as the untyped query `findOne(..)`

### Make `LoadOneDelegate::load(..)` consider type-info

The commits changes the query-building call from
`queryStatements.findOne(..)` to a more appropiate
`queryStatements.findOneByType(..)`.

Tests were not changed since this functionality is currently not covered
by tests.


## Related Issue
#365 (Session::load(type, id) should support types in its queries or provide a typed interface)

## Motivation and Context
See issue.

## How Has This Been Tested?
1) New tests were introduced for new functionality
2) The fixed functionality was not tested and no tests were added -- I could not identify a simple way to test the relationship between top-level API calls on `Session` and the executed queries
3) Full unittests on Windows 10 Pro, Java 1.8.0_131 (x64) were run without errors (but 21 ignores). No other tests were affected. Ignored tests:
![image](https://cloud.githubusercontent.com/assets/225374/26275177/1fb7a1ba-3d5b-11e7-962a-db4ab779fb6e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

*I think, those don't apply on this issue/PR, feel free to correct me*

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
