### PR TITLE
(DO NOT MERGE) Change order in which field writers are looked up, fix #361

### DIFF
--- a/core/src/test/java/org/neo4j/ogm/domain/filesystem/Folder.java
+++ b/core/src/test/java/org/neo4j/ogm/domain/filesystem/Folder.java
@@ -23,10 +23,11 @@ import java.util.Collection;
  */
 public class Folder extends FileSystemEntity {
 
+    @Relationship(type = "CONTAINS", direction = Relationship.OUTGOING)
     private Collection<Document> documents = new ArrayList<>();
+    @Relationship(type = "ARCHIVED", direction = Relationship.OUTGOING)
     private Collection<Document> archived = new ArrayList<>();
 
-    @Relationship(type = "CONTAINS", direction = Relationship.OUTGOING)
     public Collection<Document> getDocuments() {
         return documents;
     }
@@ -35,7 +36,6 @@ public class Folder extends FileSystemEntity {
         this.documents = documents;
     }
 
-    @Relationship(type = "ARCHIVED", direction = Relationship.OUTGOING)
     public Collection<Document> getArchived() {
         return archived;
     }


### PR DESCRIPTION
For one-to-one and one-to-many relationships the writer is looked up
 by using findIterableWriter, which will return setter of matching type,
 event if there is a setter for scalar matching by field name.

This commit changes the writer lookup to getRelationalWriter and handles
the iterable/scalar cases.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
#361 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
All tests pass, only change in org.neo4j.ogm.domain.filesystem.Folder was needed - I think the mapping was wrong there in the first place  - 
The state of Folder after this line
https://github.com/neo4j/neo4j-ogm/blob/ddb6db5cba707eced487614630b6bf0ad3bc60b0/core/src/test/java/org/neo4j/ogm/persistence/model/DegenerateEntityModelTests.java#L76
is wrong.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
