### PR TITLE
Change graph id handling for new entities #381

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -279,12 +279,12 @@ public class EntityGraphMapper implements EntityMapper {
         }
 
         CompileContext context = compiler.context();
-        Object id = EntityAccessManager.getIdentityPropertyReader(classInfo).readProperty(entity);
+        Long id = (Long) EntityAccessManager.getIdentityPropertyReader(classInfo).readProperty(entity);
         Collection<String> labels = EntityUtils.labels(entity, metaData);
 
         NodeBuilder nodeBuilder;
         final String primaryIndex = classInfo.primaryIndexField() != null ? classInfo.primaryIndexField().property() : null;
-        if (id == null) {
+        if (id < 0) {
             Long entityIdRef = EntityUtils.identity(entity, metaData);
             nodeBuilder = compiler.newNode(entityIdRef).addLabels(labels).setPrimaryIndex(primaryIndex);
             context.registerNewObject(entityIdRef, entity);
@@ -338,7 +338,7 @@ public class EntityGraphMapper implements EntityMapper {
             CompileContext context = compiler.context();
             Long srcIdentity = (Long) EntityAccessManager.getIdentityPropertyReader(srcInfo).readProperty(entity);
 
-            if (srcIdentity != null) {
+            if (srcIdentity >= 0) {
                 boolean cleared = clearContextRelationships(context, srcIdentity, endNodeType, directedRelationship);
                 if (!cleared) {
                     logger.debug("this relationship is already being managed: {}-{}-{}-()", entity, relationshipType, relationshipDirection);
@@ -479,11 +479,11 @@ public class EntityGraphMapper implements EntityMapper {
         RelationshipBuilder relationshipBuilder;
 
         if (isRelationshipEntity(entity)) {
-            Long relId = (Long) EntityAccessManager.getIdentityPropertyReader(metaData.classInfo(entity)).readProperty(entity);
+            Long relId = (Long) EntityUtils.identity(entity, metaData);
 
             boolean relationshipEndsChanged = haveRelationEndsChanged(entity, relId);
 
-            if (relId == null || relationshipEndsChanged) { //if the RE itself is new, or it exists but has one of it's end nodes changed
+            if (relId < 0 || relationshipEndsChanged) { //if the RE itself is new, or it exists but has one of it's end nodes changed
                 relationshipBuilder = cypherBuilder.newRelationship(directedRelationship.type());
                 if (relationshipEndsChanged) {
                     Field identityField = metaData.classInfo(entity).getField(metaData.classInfo(entity).identityField());
@@ -561,8 +561,8 @@ public class EntityGraphMapper implements EntityMapper {
         ClassInfo targetInfo = metaData.classInfo(targetEntity);
         ClassInfo startInfo = metaData.classInfo(startEntity);
 
-        Long tgtIdentity = (Long) EntityAccessManager.getIdentityPropertyReader(targetInfo).readProperty(targetEntity);
-        Long srcIdentity = (Long) EntityAccessManager.getIdentityPropertyReader(startInfo).readProperty(startEntity);
+        Long tgtIdentity = EntityUtils.identity(targetEntity, metaData);
+        Long srcIdentity = EntityUtils.identity(startEntity, metaData);
 
 
         // create or update the relationship mapping register between the start and end nodes. Note, this
@@ -578,7 +578,7 @@ public class EntityGraphMapper implements EntityMapper {
         // TODO : move this to a common function
         if (mappingContext.isDirty(relationshipEntity)) {
             context.register(relationshipEntity);
-            if (tgtIdentity != null && srcIdentity != null) {
+            if (tgtIdentity >= 0 && srcIdentity >= 0) {
                 MappedRelationship mappedRelationship = createMappedRelationship(relationshipBuilder, relNodes);
                 if (context.removeRegisteredRelationship(mappedRelationship)) {
                     logger.debug("RE successfully marked for re-writing");
@@ -630,7 +630,8 @@ public class EntityGraphMapper implements EntityMapper {
         }
 
         // if the RE is new, register it in the context so that we can set its ID correctly when it is created,
-        if (EntityAccessManager.getIdentityPropertyReader(relEntityClassInfo).readProperty(relationshipEntity) == null) {
+        Long id = (Long) EntityAccessManager.getIdentityPropertyReader(relEntityClassInfo).readProperty(relationshipEntity);
+        if (id < 0) {
             context.registerNewObject(reIdentity, relationshipEntity);
         }
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
@@ -32,6 +32,7 @@ import org.neo4j.ogm.session.event.PersistenceEvent;
 import org.neo4j.ogm.session.request.strategy.DeleteStatements;
 import org.neo4j.ogm.session.request.strategy.impl.NodeDeleteStatements;
 import org.neo4j.ogm.session.request.strategy.impl.RelationshipDeleteStatements;
+import org.neo4j.ogm.utils.EntityUtils;
 
 /**
  * @author Vince Bickers
@@ -98,9 +99,8 @@ public class DeleteDelegate implements Capability.Delete {
 
             if (classInfo != null) {
 
-                Field identityField = classInfo.getField(classInfo.identityField());
-                Long identity = (Long) FieldWriter.read(identityField, object);
-                if (identity != null) {
+                Long identity = EntityUtils.identity(object, session.metaData());
+                if (identity >= 0) {
                     Statement request = getDeleteStatementsBasedOnType(object.getClass()).delete(identity);
                     if (session.eventsEnabled()) {
                         if (!notified.contains(object)) {

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/GraphIdDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/GraphIdDelegate.java
@@ -19,6 +19,7 @@ import org.neo4j.ogm.exception.MappingException;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.session.Capability;
 import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.utils.EntityUtils;
 
 /**
  * @author Luanne Misquitta
@@ -37,9 +38,9 @@ public class GraphIdDelegate implements Capability.GraphId {
 			ClassInfo classInfo = session.metaData().classInfo(possibleEntity);
 			try {
 				if (classInfo != null) {
-					Object id = EntityAccessManager.getIdentityPropertyReader(classInfo).readProperty(possibleEntity);
-					if (id != null) {
-						return (long) id;
+					Long id = EntityUtils.identity(possibleEntity, session.metaData());
+					if (id >= 0) {
+						return id;
 					}
 				}
 			} catch (MappingException me) {

--- a/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
@@ -188,7 +188,7 @@ public class RequestExecutor {
 				if (!classInfo.isRelationshipEntity()) {
 					PropertyReader idReader = EntityAccessManager.getIdentityPropertyReader(classInfo);
 					Long id = (Long) idReader.readProperty(obj);
-					if (id != null) {
+					if (id >= 0) {
 						LOGGER.debug("updating existing node id: {}, {}", id, obj);
 						registerEntity(session.context(), classInfo, id, obj);
 					}

--- a/core/src/test/java/org/neo4j/ogm/cypher/CypherCompilerTest.java
+++ b/core/src/test/java/org/neo4j/ogm/cypher/CypherCompilerTest.java
@@ -50,6 +50,7 @@ import org.neo4j.ogm.domain.social.Individual;
 import org.neo4j.ogm.domain.social.Mortal;
 import org.neo4j.ogm.request.Statement;
 import org.neo4j.ogm.session.request.RowStatementFactory;
+import org.neo4j.ogm.utils.EntityUtils;
 
 /**
  * @author Vince Bickers
@@ -820,8 +821,8 @@ public class CypherCompilerTest {
         for (Statement statement : statements) {
             List rows = (List) statement.getParameters().get("rows");
             assertEquals(1, rows.size());
-            assertEquals((long)-System.identityHashCode(adam), ((Map)rows.get(0)).get("startNodeId"));
-            assertEquals((long)-System.identityHashCode(vince), ((Map)rows.get(0)).get("endNodeId"));
+            assertEquals(EntityUtils.identity(adam, mappingMetadata), ((Map)rows.get(0)).get("startNodeId"));
+            assertEquals(EntityUtils.identity(vince, mappingMetadata), ((Map)rows.get(0)).get("endNodeId"));
         }
     }
 
@@ -851,11 +852,13 @@ public class CypherCompilerTest {
         List<String> createRelStatements = cypherStatements(statements);
         assertEquals(1, createRelStatements.size());
         assertTrue(createRelStatements.contains("UNWIND {rows} as row MATCH (startNode) WHERE ID(startNode) = row.startNodeId MATCH (endNode) WHERE ID(endNode) = row.endNodeId MERGE (startNode)-[rel:`KNOWN_BY`]->(endNode) RETURN row.relRef as ref, ID(rel) as id, row.type as type"));
-        for (Statement statement : statements) {
+
+        for (int i = 0; i < statements.size(); i++) {
+            Statement statement = statements.get(i);
             List rows = (List) statement.getParameters().get("rows");
             assertEquals(1, rows.size());
-            assertEquals((long)-System.identityHashCode(vince), ((Map)rows.get(0)).get("startNodeId"));
-            assertEquals((long)-System.identityHashCode(adam), ((Map)rows.get(0)).get("endNodeId"));
+            assertEquals(EntityUtils.identity(vince, mappingMetadata), ((Map) rows.get(0)).get("startNodeId"));
+            assertEquals(EntityUtils.identity(adam, mappingMetadata), ((Map) rows.get(0)).get("endNodeId"));
         }
     }
 

--- a/core/src/test/java/org/neo4j/ogm/persistence/session/events/LifecycleTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/session/events/LifecycleTest.java
@@ -90,10 +90,11 @@ public class LifecycleTest extends EventTestBaseClass {
         @Override
         public void onPreSave(Event event) {
             FileSystemEntity entity = (FileSystemEntity)event.getObject();
-            if (entity.getId() == null) {
+            if (entity.getUuid() == null) {
                 entity.setUuid(UUID.randomUUID().toString());
             }
         }
+
 
         @Override
         public void onPostSave(Event event) {


### PR DESCRIPTION
Replace `System.identityHashCode` with decrementing counter.

This commit changes how org.neo4j.ogm.utils.EntityUtils.identity()
works.

When the id is present it is returned - same as before.

When the id is missing identityHashCode was used, which means multiple
calls returned same value. To keep this behaviour the id generated value
is written to the entity.

Code that depended on the null value of the id was changed to
< 0 and >= 0 comparisons.