### PR TITLE
Issue/384: Correct results when paging and filtering on a relationship property

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
@@ -12,8 +12,6 @@
  */
 package org.neo4j.ogm.cypher.query;
 
-import org.neo4j.ogm.session.request.NodeQueryBuilder;
-
 import java.util.Map;
 
 /**
@@ -67,6 +65,7 @@ public class PagingAndSortingQuery implements PagingAndSorting {
             StringBuilder sb = new StringBuilder();
 
             String returnClause = this.returnClause;
+
             sb.append(matchClause);
             if (!sorting.isEmpty()) {
                 sb.append(sorting.replace("$", "n"));

--- a/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
@@ -35,6 +35,7 @@ public class NodeQueryBuilder {
     private Map<String, Object> parameters;
     private int matchClauseId;
     private boolean built = false;
+    private boolean hasRelationshipMatch = false;
 
     public NodeQueryBuilder(String principalLabel, Iterable<Filter> filters) {
         this.principalClause = new PrincipalNodeMatchClause(principalLabel);
@@ -56,6 +57,7 @@ public class NodeQueryBuilder {
                 }
                 if (filter.isNested()) {
                     appendNestedFilter(filter);
+                    hasRelationshipMatch = true;
                 } else {
                     //If the filter is not nested, it belongs to the node we're returning
                     principalClause().append(filter);
@@ -130,6 +132,12 @@ public class NodeQueryBuilder {
 
         for (MatchClause matchClause : pathClauses) {
             stringBuilder.append(matchClause.toCypher());
+        }
+
+        if (hasRelationshipMatch) {
+            stringBuilder.append("WITH DISTINCT n");
+        } else {
+            stringBuilder.append("WITH n");
         }
 
         return stringBuilder;

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatements.java
@@ -92,7 +92,7 @@ public class NodeQueryStatements<ID extends Serializable> implements QueryStatem
     @Override
     public PagingAndSortingQuery findByType(String label, Filters parameters, int depth) {
         FilteredQuery filteredQuery = FilteredQueryBuilder.buildNodeQuery(label, parameters);
-        String matchClause = filteredQuery.statement()+ "WITH n";
+        String matchClause = filteredQuery.statement();
         String returnClause = loadClauseBuilder.build(label, depth);
         return new PagingAndSortingQuery(matchClause, returnClause, filteredQuery.parameters(), depth != 0, true);
     }

--- a/test/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/User.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/cineasts/annotated/User.java
@@ -15,6 +15,7 @@ package org.neo4j.ogm.domain.cineasts.annotated;
 
 
 import java.net.URL;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -174,5 +175,23 @@ public class User {
 
     public UUID getUuid() {
         return uuid;
+    }
+
+    /**
+     * Add given users as friends, also adds the opposite direction
+     */
+    public void addFriends(User ... newFriends) {
+        if (friends == null) {
+            friends = new HashSet<>();
+        }
+
+        for (User newFriend : newFriends) {
+            friends.add(newFriend);
+
+            if (newFriend.friends == null) {
+                newFriend.friends = new HashSet<>();
+            }
+            newFriend.friends.add(this);
+        }
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -13,6 +13,7 @@
 
 package org.neo4j.ogm.persistence.examples.cineasts.annotated;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.*;
 
 import java.net.MalformedURLException;
@@ -23,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.query.Pagination;
 import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.domain.cineasts.annotated.*;
 import org.neo4j.ogm.session.Session;
@@ -801,6 +803,95 @@ public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
         assertThat(movie.getRatings()).hasSize(1);
         assertThat(movie.getRatings().iterator().next().getComment()).isNull();
     }
+
+    @Test
+    public void testFilterOnRelationshipEntity() throws Exception {
+        Movie pulpFiction = new Movie("Pulp Fiction", 1994);
+
+        Movie ootf = new Movie("Harry Potter and the Order of the Phoenix", 2009);
+
+        User frantisek = new User();
+        frantisek.setName("Frantisek");
+        frantisek.setLogin("frantisek");
+
+        Rating pulpRating = new Rating();
+        pulpRating.setStars(3);
+        pulpRating.setMovie(pulpFiction);
+        pulpRating.setUser(frantisek);
+        pulpFiction.setRatings(newHashSet(pulpRating));
+
+        Rating ootfRating = new Rating();
+        ootfRating.setStars(3);
+        ootfRating.setMovie(ootf);
+        ootfRating.setUser(frantisek);
+
+        frantisek.setRatings(newHashSet(ootfRating, pulpRating));
+
+        User otto = new User();
+        otto.setName("Otto");
+        otto.setLogin("otto");
+
+        Rating pulpRating2 = new Rating();
+        pulpRating2.setStars(3);
+        pulpRating2.setMovie(pulpFiction);
+        pulpRating2.setUser(otto);
+
+        Rating ootfRating2 = new Rating();
+        ootfRating2.setStars(3);
+        ootfRating2.setMovie(ootf);
+        ootfRating2.setUser(otto);
+
+        pulpFiction.setRatings(newHashSet(pulpRating, pulpRating2));
+        ootf.setRatings(newHashSet(ootfRating, ootfRating2));
+        otto.setRatings(newHashSet(pulpRating2, ootfRating2));
+        session.save(otto);
+
+        session.clear();
+
+        Filter filter = new Filter("stars", ComparisonOperator.EQUALS, 3);
+        filter.setNestedPropertyName("ratings");
+        filter.setNestedPropertyType(Rating.class);
+        filter.setNestedRelationshipEntity(true);
+        Collection<User> users = session.loadAll(User.class, filter, new Pagination(0, 2));
+
+        assertThat(users).hasSize(2);
+    }
+
+    @Test
+    public void testFilterOnRelatedNode() throws Exception {
+        User frantisek = new User();
+        frantisek.setName("Frantisek");
+        frantisek.setLogin("frantisek");
+
+        User michal = new User();
+        michal.setName("Michal");
+        michal.setLogin("michal");
+
+        User ottoH = new User();
+        ottoH.setName("Otto");
+        ottoH.setLogin("otto");
+
+        User ottoB = new User();
+        ottoB.setName("Otto von Bismarc");
+        ottoB.setLogin("ottob");
+
+        frantisek.addFriends(ottoH, ottoB);
+        session.save(frantisek);
+
+        michal.addFriends(ottoH, ottoB);
+        session.save(michal);
+
+        Filter filter = new Filter("name", ComparisonOperator.CONTAINING, "Otto"); // name contains ' '
+        filter.setNestedPropertyName("friends");
+        filter.setNestedPropertyType(User.class);
+        SortOrder sortOrder = new SortOrder();
+
+        sortOrder.add("name");
+        Collection<User> users = session.loadAll(User.class, filter, sortOrder, new Pagination(0, 2));
+
+        assertThat(users).hasSize(2);
+    }
+
 
     private void bootstrap(String cqlFileName) {
         session.query(TestUtils.readCQLFile(cqlFileName).toString(), Utils.map());

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/CountStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/CountStatementsTest.java
@@ -48,7 +48,7 @@ public class CountStatementsTest {
     @Test
     public void testCountNodesWithLabelAndFilters() throws Exception {
         CypherQuery query = statements.countNodes("Person", new Filters().add(new Filter("name", ComparisonOperator.EQUALS, "Jim")));
-        assertThat(query.getStatement()).isEqualTo("MATCH (n:`Person`) WHERE n.`name` = { `name_0` }  RETURN COUNT(n)");
+        assertThat(query.getStatement()).isEqualTo("MATCH (n:`Person`) WHERE n.`name` = { `name_0` } WITH n RETURN COUNT(n)");
         assertThat(query.getParameters().toString()).isEqualTo("{name_0=Jim}");
     }
 

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeDeleteStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeDeleteStatementsTest.java
@@ -13,16 +13,17 @@
 
 package org.neo4j.ogm.session.request.strategy.impl;
 
-import static org.assertj.core.api.Assertions.*;
-
 import java.util.Arrays;
 
 import org.junit.Test;
+
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
 import org.neo4j.ogm.cypher.query.CypherQuery;
 import org.neo4j.ogm.session.request.strategy.DeleteStatements;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author vince
@@ -54,12 +55,22 @@ public class NodeDeleteStatementsTest {
     @Test
     public void testDeleteWithLabelAndFilters() throws Exception {
         CypherQuery query = statements.delete("INFLUENCE", new Filters().add(new Filter("score", ComparisonOperator.EQUALS, -12.2)));
-        assertThat(query.getStatement()).isEqualTo("MATCH (n:`INFLUENCE`) WHERE n.`score` = { `score_0` }  OPTIONAL MATCH (n)-[r0]-() DELETE r0, n");
+        assertThat(query.getStatement()).isEqualTo(
+                "MATCH (n:`INFLUENCE`) "
+                        + "WHERE n.`score` = { `score_0` } "
+                        + "WITH n "
+                        + "OPTIONAL MATCH (n)-[r0]-() "
+                        + "DELETE r0, n");
     }
 
     @Test
     public void testDeleteWithLabelAndFiltersAndList() throws Exception {
         CypherQuery query = statements.deleteAndList("INFLUENCE", new Filters().add(new Filter("score", ComparisonOperator.EQUALS, -12.2)));
-        assertThat(query.getStatement()).isEqualTo("MATCH (n:`INFLUENCE`) WHERE n.`score` = { `score_0` }  OPTIONAL MATCH (n)-[r0]-() DELETE r0, n RETURN ID(n)");
+        assertThat(query.getStatement()).isEqualTo(
+                "MATCH (n:`INFLUENCE`) "
+                        + "WHERE n.`score` = { `score_0` } "
+                        + "WITH n "
+                        + "OPTIONAL MATCH (n)-[r0]-() "
+                        + "DELETE r0, n RETURN ID(n)");
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -378,7 +378,7 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection("OUTGOING");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -391,7 +391,7 @@ public class NodeQueryStatementsTest {
         filter.setNestedEntityTypeLabel("Asteroid");
         filter.setRelationshipType("COLLIDES");
         filter.setRelationshipDirection("OUTGOING");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(filter), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Asteroid`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(filter), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Asteroid`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -404,7 +404,7 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection("INCOMING");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)<-[:`COLLIDES`]-(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)<-[:`COLLIDES`]-(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -417,7 +417,7 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection("UNDIRECTED");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]-(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } MATCH (n)-[:`COLLIDES`]-(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -433,7 +433,7 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection("OUTGOING");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) WHERE n.`diameter` > { `diameter_0` } MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) WHERE n.`diameter` > { `diameter_0` } MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -449,7 +449,7 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection("OUTGOING");
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), -1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) WHERE n.`diameter` > { `diameter_0` } MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), -1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) WHERE n.`diameter` > { `diameter_0` } MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -502,7 +502,7 @@ public class NodeQueryStatementsTest {
 
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (n)-[r0:`COLLIDES`]->(m0) " +
                 "WHERE r0.`totalDestructionProbability` = { `collision_totalDestructionProbability_0` } " +
-                "WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+                "WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -528,7 +528,7 @@ public class NodeQueryStatementsTest {
         satelliteParam.setNestedRelationshipEntity(true);
 
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(satelliteParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (n)-[r0:`COLLIDES`]->(m0) WHERE r0.`totalDestructionProbability` = { `collision_totalDestructionProbability_0` } " +
-                "MATCH (n)<-[r1:`MONITORED_BY`]-(m1) WHERE r1.`signalStrength` >= { `monitoringSatellites_signalStrength_1` } WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+                "MATCH (n)<-[r1:`MONITORED_BY`]-(m1) WHERE r1.`signalStrength` >= { `monitoringSatellites_signalStrength_1` } WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
 
@@ -554,7 +554,7 @@ public class NodeQueryStatementsTest {
 
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam, moonParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (n)-[r0:`COLLIDES`]->(m0) " +
                 "WHERE r0.`totalDestructionProbability` = { `collision_totalDestructionProbability_0` } " +
-                "MATCH (m1:`Moon`) WHERE m1.`name` = { `moon_name_1` } MATCH (n)<-[:`ORBITS`]-(m1) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+                "MATCH (m1:`Moon`) WHERE m1.`name` = { `moon_name_1` } MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
 
@@ -578,7 +578,7 @@ public class NodeQueryStatementsTest {
         assertThat(queryStatements.findByType("Asteroid",
                 new Filters().add(planetParam).add(moonParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } " +
                 "MATCH (m1:`Moon`) WHERE m1.`name` = { `moon_name_1` } MATCH (n)-[:`COLLIDES`]->(m0) " +
-                "MATCH (n)<-[:`ORBITS`]-(m1) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+                "MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**
@@ -620,7 +620,7 @@ public class NodeQueryStatementsTest {
         moonParam.setRelationshipType("COLLIDES");
         moonParam.setRelationshipDirection("OUTGOING");
         moonParam.setBooleanOperator(BooleanOperator.AND);
-        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(moonParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } AND m0.`size` = { `collidesWith_size_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+        assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(moonParam), 1).getStatement()).isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = { `collidesWith_name_0` } AND m0.`size` = { `collidesWith_size_1` } MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
These changes dynamically modify the base query when paging *and* filtering on a relationship property to return “distinct n” rather than “n” so that correct results are returned.

## Description
<!--- Describe your changes in detail -->
These changes dynamically modify the base query when paging *and* filtering on a relationship property to return “distinct n” rather than “n”. The previous code, by simply returning “n”, was incorrect because “n" might be repeated when there are multiple filter criteria that match.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/neo4j/neo4j-ogm/issues/384

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prior to this change, filtering on a relationship property may return incorrect results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The CineastsRelationshipEntityTest test was updated to include testFilterOnRelationshipEntity(), which demonstrates the issue. Prior to these changes, testFilterOnRelationshipEntity() fails, by applying these changes the test -- and all other tests -- pass successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
