### PR TITLE
Issue/384 back port to 2.1.x: Correct results when paging and filtering on a relationship property

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 2.1.5
 --------------
 o Expose connection.liveness.check.timeout driver property to fix connection problems with firewalls. See #358.
+o Map relationship entities without any properties
 
 2.1.4
 --------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 --------------
 o Expose connection.liveness.check.timeout driver property to fix connection problems with firewalls. See #358.
 o Map relationship entities without any properties
+o Return correct results when paging and filtering on relationship property
 
 2.1.4
 --------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2.1.5
+--------------
+o Expose connection.liveness.check.timeout driver property to fix connection problems with firewalls. See #358.
+
 2.1.4
 --------------
 o Allow use of CompositeConverter on fields in @RelationshipEntity classes

--- a/api/src/main/java/org/neo4j/ogm/config/DriverConfiguration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/DriverConfiguration.java
@@ -93,6 +93,11 @@ public class DriverConfiguration {
         return this;
     }
 
+    public DriverConfiguration setConnectionLivenessCheckTimeout(Integer timeoutInMs) {
+        configuration.set(CONNECTION_LIVELINESS_CHECK_TIMEOUT[0], timeoutInMs.toString());
+        return this;
+    }
+
     public DriverConfiguration setEncryptionLevel(String encryptionLevel) {
         configuration.set(ENCRYPTION_LEVEL[0], encryptionLevel);
         return this;

--- a/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
@@ -14,6 +14,8 @@ package org.neo4j.ogm.cypher.query;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Extends {@link CypherQuery} with additional functionality for Paging and Sorting.
  *
@@ -50,7 +52,7 @@ public class PagingAndSortingQuery extends CypherQuery implements PagingAndSorti
                 if (stmt.contains(")-[r0")) {
                     sorting = sorting.replace("$", "r0");
                     if (!withClause.contains(",r0") && (!withClause.contains("r0,"))) {
-                        newWithClause = newWithClause + ",r0";
+                        newWithClause = StringUtils.removeEnd(newWithClause, "n") + "distinct n";                    	
                     }
                 } else {
                     sorting = sorting.replace("$", "n");

--- a/core/src/test/java/org/neo4j/ogm/cypher/query/PagingAndSortingQueryTest.java
+++ b/core/src/test/java/org/neo4j/ogm/cypher/query/PagingAndSortingQueryTest.java
@@ -14,7 +14,7 @@
 
 package org.neo4j.ogm.cypher.query;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class PagingAndSortingQueryTest {
 		String stmt = query.getStatement();
 		assertEquals("MATCH (n:`User`) WHERE n.`name` = { `name_0` } " +
 				"MATCH (n)-[r0:`RATED`]-(m0) WHERE r0.`stars` = { `ratings_stars_1` } " +
-				"WITH n,r0 SKIP 0 LIMIT 4 MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)", stmt);
+				"WITH distinct n SKIP 0 LIMIT 4 MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)", stmt);
 		System.out.println(stmt);
 	}
 

--- a/core/src/test/resources/ogm-bolt.properties
+++ b/core/src/test/resources/ogm-bolt.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2002-2016 "Neo Technology,"
+# Copyright (c) 2002-2017 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # This product is licensed to you under the Apache License, Version 2.0 (the "License").
@@ -18,3 +18,6 @@ URI=bolt://localhost
 #Do not set the pool size to < 150 otherwise tests that spawn 100 concurrent requests will fail
 connection.pool.size=150
 encryption.level=NONE
+# stale connections test interval in milliseconds
+# please see official driver documentation before activating this
+#connection.liveness.check.timeout=100


### PR DESCRIPTION
Replace "n,r0" with "distinct n" when filtering on a relationship property.

<!--- Provide a general summary of your changes in the Title above -->
These changes dynamically modify the base query when paging and filtering on a relationship property to return “distinct n” rather than “n,ro” so that correct results are returned.

## Description
<!--- Describe your changes in detail -->
These changes dynamically modify the base query when paging and filtering on a relationship property to return “distinct n” rather than “n,ro”. The previous code, by returning “n,r0”, returns incorrect results.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/neo4j/neo4j-ogm/issues/384

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prior to this change, filtering on a relationship property may return incorrect results. These changes back port a fix, also submitted as a PR against the master, to the 2.1.x branch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The CineastsRelationshipEntityTest test was updated to include testFilterOnRelationshipEntity(), which demonstrates the issue. Prior to these changes, testFilterOnRelationshipEntity() fails, by applying these changes the test -- and all other tests -- pass successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
