### PR TITLE
Issue/392: Escape the constraint and index statements generated by the AutoIndex

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndex.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndex.java
@@ -22,6 +22,7 @@ import org.neo4j.ogm.session.request.RowDataStatement;
  * Represents an Index that can be auto generated in Neo4j.
  *
  * @author Mark Angrish
+ * @author Eric Spiegelberg
  */
 class AutoIndex {
 
@@ -35,9 +36,9 @@ class AutoIndex {
     AutoIndex(String label, String property, boolean unique) {
 
         if (unique) {
-            this.description = "CONSTRAINT ON ( " + label.toLowerCase() + ":" + label + " ) ASSERT " + label.toLowerCase() + "." + property + " IS UNIQUE";
+            this.description = "CONSTRAINT ON ( `" + label.toLowerCase() + "`:`" + label + "` ) ASSERT `" + label.toLowerCase() + "`.`" + property + "` IS UNIQUE";
         } else {
-            this.description = "INDEX ON :" + label + "( " + property + " )";
+            this.description = "INDEX ON :`" + label + "`( `" + property + "` )";
         }
     }
 

--- a/test/src/test/java/org/neo4j/ogm/autoindex/AutoIndexManagerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/autoindex/AutoIndexManagerTest.java
@@ -25,11 +25,11 @@ public class AutoIndexManagerTest extends MultiDriverTestClass {
     private MetaData metaData = new MetaData("org.neo4j.ogm.domain.forum");
 
     private static final String CREATE_LOGIN_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( `login`:`Login` ) ASSERT `login`.`userName` IS UNIQUE";
-    private static final String CREATE_TAG_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( `t-a-g`:`T-A-G` ) ASSERT `t-a-g`.`description` IS UNIQUE";    
-    private static final String CREATE_TAG_INDEX_CYPHER = "CREATE INDEX ON :`t-a-g`(`description`)";
+    private static final String CREATE_TAG_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( `t-a-g`:`T-A-G` ) ASSERT `t-a-g`.`short-description` IS UNIQUE";    
+    private static final String CREATE_TAG_INDEX_CYPHER = "CREATE INDEX ON :`t-a-g`(`short-description`)";
     
     private static final String DROP_LOGIN_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (`login`:`Login`) ASSERT `login`.`userName` IS UNIQUE";
-    private static final String DROP_TAG_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (`t-a-g`:`T-A-G`) ASSERT `t-a-g`.`description` IS UNIQUE";
+    private static final String DROP_TAG_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (`t-a-g`:`T-A-G`) ASSERT `t-a-g`.`short-description` IS UNIQUE";
 
     @Test
     public void shouldPreserveNoneConfiguration() {

--- a/test/src/test/java/org/neo4j/ogm/autoindex/AutoIndexManagerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/autoindex/AutoIndexManagerTest.java
@@ -1,11 +1,9 @@
 package org.neo4j.ogm.autoindex;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -20,13 +18,18 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  * Make sure this tests works across all drivers supporting Neo4j 3.x and above.
  *
  * @author Mark Angrish
+ * @author Eric Spiegelberg
  */
 public class AutoIndexManagerTest extends MultiDriverTestClass {
 
     private MetaData metaData = new MetaData("org.neo4j.ogm.domain.forum");
 
-    private static final String CREATE_LOGIN_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( login:Login ) ASSERT login.userName IS UNIQUE";
-    private static final String DROP_LOGIN_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (login:Login) ASSERT login.userName IS UNIQUE";
+    private static final String CREATE_LOGIN_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( `login`:`Login` ) ASSERT `login`.`userName` IS UNIQUE";
+    private static final String CREATE_TAG_CONSTRAINT_CYPHER = "CREATE CONSTRAINT ON ( `t-a-g`:`T-A-G` ) ASSERT `t-a-g`.`description` IS UNIQUE";    
+    private static final String CREATE_TAG_INDEX_CYPHER = "CREATE INDEX ON :`t-a-g`(`description`)";
+    
+    private static final String DROP_LOGIN_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (`login`:`Login`) ASSERT `login`.`userName` IS UNIQUE";
+    private static final String DROP_TAG_CONSTRAINT_CYPHER = "DROP CONSTRAINT ON (`t-a-g`:`T-A-G`) ASSERT `t-a-g`.`description` IS UNIQUE";
 
     @Test
     public void shouldPreserveNoneConfiguration() {
@@ -55,14 +58,14 @@ public class AutoIndexManagerTest extends MultiDriverTestClass {
     @Test
     public void testIndexesAreSuccessfullyValidated() {
 
-        createLoginConstraint();
+        createConstraints();
 
         Configuration configuration = getBaseConfiguration().autoIndex("validate").build();
         AutoIndexManager indexManager = new AutoIndexManager(metaData, driver, configuration);
-        assertThat(indexManager.getIndexes()).hasSize(1);
+        assertThat(indexManager.getIndexes()).hasSize(2);
         indexManager.build();
 
-        dropLoginConstraint();
+        dropConstraints();
     }
 
     @Test(expected = MissingIndexException.class)
@@ -75,7 +78,8 @@ public class AutoIndexManagerTest extends MultiDriverTestClass {
     @Test
     public void testIndexDumpMatchesDatabaseIndexes() throws IOException {
 
-        createLoginConstraint();
+        createConstraints();
+        
         File file = new File("./test.cql");
 
         try {
@@ -86,41 +90,46 @@ public class AutoIndexManagerTest extends MultiDriverTestClass {
                     .build();
 
             AutoIndexManager indexManager = new AutoIndexManager(metaData, driver, configuration);
-            assertThat(indexManager.getIndexes()).hasSize(1);
+            assertThat(indexManager.getIndexes()).hasSize(2);
             indexManager.build();
 
             assertThat(file.exists()).isTrue();
             try (InputStream is = new FileInputStream("./test.cql")) {
                 String actual = IOUtils.toString(is);
-                assertThat(actual).isEqualToIgnoringWhitespace(CREATE_LOGIN_CONSTRAINT_CYPHER);
+                String expected = CREATE_LOGIN_CONSTRAINT_CYPHER + " " + CREATE_TAG_CONSTRAINT_CYPHER;
+                assertThat(actual).isEqualToIgnoringWhitespace(expected);
             }
 
         } finally {
             file.delete();
         }
 
-        dropLoginConstraint();
+        dropConstraints();
     }
 
     @Test
     public void testIndexesAreSuccessfullyAsserted() {
 
-        createLoginConstraint();
+        createConstraints();
 
         Configuration configuration = getBaseConfiguration().autoIndex("assert").build();
         AutoIndexManager indexManager = new AutoIndexManager(metaData, driver, configuration);
 
-        assertThat(indexManager.getIndexes()).hasSize(1);
+        assertThat(indexManager.getIndexes()).hasSize(2);
         indexManager.build();
 
-        dropLoginConstraint();
+        dropConstraints();
     }
 
-    private void createLoginConstraint() {
+    private void createConstraints() {
         getGraphDatabaseService().execute(CREATE_LOGIN_CONSTRAINT_CYPHER);
+        getGraphDatabaseService().execute(CREATE_TAG_CONSTRAINT_CYPHER);        
+        getGraphDatabaseService().execute(CREATE_TAG_INDEX_CYPHER);
     }
 
-    private void dropLoginConstraint() {
+    private void dropConstraints() {
         getGraphDatabaseService().execute(DROP_LOGIN_CONSTRAINT_CYPHER);
+        getGraphDatabaseService().execute(DROP_TAG_CONSTRAINT_CYPHER);
     }
+    
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/forum/Tag.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/forum/Tag.java
@@ -16,9 +16,10 @@ package org.neo4j.ogm.domain.forum;
 import org.neo4j.ogm.annotation.GraphId;
 import org.neo4j.ogm.annotation.Index;
 import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
 
 /**
- * A entity class used to demonstrate/test labels that require being escaped. 
+ * A entity class used to demonstrate/test labels and properties that require being escaped. 
  *  
  * @author Eric Spiegelberg
  */
@@ -29,6 +30,7 @@ public class Tag {
     private Long tagId;
 
     @Index(unique = true)
+    @Property(name="short-description")
     private String description;
     
 	public Long getTagId() {

--- a/test/src/test/java/org/neo4j/ogm/domain/forum/Tag.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/forum/Tag.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.domain.forum;
+
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * A entity class used to demonstrate/test labels that require being escaped. 
+ *  
+ * @author Eric Spiegelberg
+ */
+@NodeEntity(label="T-A-G")
+public class Tag {
+
+    @GraphId
+    private Long tagId;
+
+    @Index(unique = true)
+    private String description;
+    
+	public Long getTagId() {
+		return tagId;
+	}
+
+	public void setTagId(Long tagId) {
+		this.tagId = tagId;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+    
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Escape the constraint and index statements generated by the AutoIndex. This is required when an entity specifies a label with hyphen(s) or other characters that require escaping. Without this change invalid Cypher is generated and the execution results in an exception.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/neo4j/neo4j-ogm/issues/392

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Invalid Cypher is generated for entities that specify a label with a hyphen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new entity, Tag, specifies a label of "T-A-G". The AutoIndexManager and it's AutoIndexManagerTest has been enhanced to generate properly escaped Cypher with AutoIndexManagerTest demonstrating the creation and dropping of indexes where the escaping of the label is required.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
