### PR TITLE
Default transaction is not cleared from thread local when the query fails

### DIFF
--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/request/BoltRequest.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/request/BoltRequest.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.neo4j.ogm.config.ObjectMapperFactory;
 import org.neo4j.ogm.drivers.bolt.response.GraphModelResponse;
 import org.neo4j.ogm.drivers.bolt.response.GraphRowModelResponse;
@@ -35,12 +38,16 @@ import org.neo4j.ogm.model.GraphModel;
 import org.neo4j.ogm.model.GraphRowListModel;
 import org.neo4j.ogm.model.RestModel;
 import org.neo4j.ogm.model.RowModel;
-import org.neo4j.ogm.request.*;
+import org.neo4j.ogm.request.DefaultRequest;
+import org.neo4j.ogm.request.GraphModelRequest;
+import org.neo4j.ogm.request.GraphRowListModelRequest;
+import org.neo4j.ogm.request.Request;
+import org.neo4j.ogm.request.RestModelRequest;
+import org.neo4j.ogm.request.RowModelRequest;
+import org.neo4j.ogm.request.Statement;
 import org.neo4j.ogm.response.EmptyResponse;
 import org.neo4j.ogm.response.Response;
 import org.neo4j.ogm.transaction.TransactionManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author vince
@@ -85,14 +92,13 @@ public class BoltRequest implements Request {
         String[] columns = null;
         for (Statement statement : query.getStatements()) {
             StatementResult result = executeRequest(statement);
-            if (columns == null) {
-                List<String> columnSet = result.keys();
-                columns = columnSet.toArray(new String[columnSet.size()]);
-            }
             RowModelResponse rowModelResponse = new RowModelResponse(result, transactionManager);
             RowModel model;
             while ((model = rowModelResponse.next()) != null) {
                 rowmodels.add(model);
+            }
+            if (columns == null) {
+                columns = rowModelResponse.columns();
             }
             result.consume();
         }

--- a/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
@@ -250,48 +250,55 @@ public class RequestExecutor {
             newTransaction = true;
         }
 
-        //If there are statements that depend on new nodes i.e. relationships created between new nodes,
-        //we must create the new nodes first, and then use their node IDs when creating relationships between them
-        if (compiler.hasStatementsDependentOnNewNodes()) {
+        try {
+            //If there are statements that depend on new nodes i.e. relationships created between new nodes,
+            //we must create the new nodes first, and then use their node IDs when creating relationships between them
+            if (compiler.hasStatementsDependentOnNewNodes()) {
 
-            DefaultRequest createNodesRowRequest = new DefaultRequest();
-            createNodesRowRequest.setStatements(compiler.createNodesStatements());
+                DefaultRequest createNodesRowRequest = new DefaultRequest();
+                createNodesRowRequest.setStatements(compiler.createNodesStatements());
 
-            // execute the statements to create new nodes. The ids will be returned
-            // and will be used in subsequent statements that refer to these new nodes.
-            try (Response<RowModel> response = session.requestHandler().execute(createNodesRowRequest)) {
-                registerEntityIds(context, response, entityReferenceMappings, relReferenceMappings);
-            }
+                // execute the statements to create new nodes. The ids will be returned
+                // and will be used in subsequent statements that refer to these new nodes.
+                try (Response<RowModel> response = session.requestHandler().execute(createNodesRowRequest)) {
+                    registerEntityIds(context, response, entityReferenceMappings, relReferenceMappings);
+                }
 
-            List<Statement> statements = new ArrayList<>();
-            statements.addAll(compiler.createRelationshipsStatements());
-            statements.addAll(compiler.updateNodesStatements());
-            statements.addAll(compiler.updateRelationshipStatements());
-            statements.addAll(compiler.deleteRelationshipStatements());
-            statements.addAll(compiler.deleteRelationshipEntityStatements());
+                List<Statement> statements = new ArrayList<>();
+                statements.addAll(compiler.createRelationshipsStatements());
+                statements.addAll(compiler.updateNodesStatements());
+                statements.addAll(compiler.updateRelationshipStatements());
+                statements.addAll(compiler.deleteRelationshipStatements());
+                statements.addAll(compiler.deleteRelationshipEntityStatements());
 
-            DefaultRequest defaultRequest = new DefaultRequest();
-            defaultRequest.setStatements(statements);
-
-            try (Response<RowModel> response = session.requestHandler().execute(defaultRequest)) {
-                registerEntityIds(context, response, entityReferenceMappings, relReferenceMappings);
-                registerNewRelIds(response, relReferenceMappings);
-            }
-        } else { // only update / delete statements
-            List<Statement> statements = compiler.getAllStatements();
-            if (statements.size() > 0) {
                 DefaultRequest defaultRequest = new DefaultRequest();
                 defaultRequest.setStatements(statements);
+
                 try (Response<RowModel> response = session.requestHandler().execute(defaultRequest)) {
                     registerEntityIds(context, response, entityReferenceMappings, relReferenceMappings);
                     registerNewRelIds(response, relReferenceMappings);
                 }
+            } else { // only update / delete statements
+                List<Statement> statements = compiler.getAllStatements();
+                if (statements.size() > 0) {
+                    DefaultRequest defaultRequest = new DefaultRequest();
+                    defaultRequest.setStatements(statements);
+                    try (Response<RowModel> response = session.requestHandler().execute(defaultRequest)) {
+                        registerEntityIds(context, response, entityReferenceMappings, relReferenceMappings);
+                        registerNewRelIds(response, relReferenceMappings);
+                    }
+                }
             }
-        }
 
-        if (transactionRequired && newTransaction) {
-            tx.commit();
-            tx.close();
+            if (transactionRequired && newTransaction) {
+                tx.commit();
+                tx.close();
+            }
+        } catch (Exception e) {
+            if (transactionRequired && newTransaction) {
+                tx.rollback();
+                tx.close();
+            }
         }
 
         //Update the mapping context now that the request is successful

--- a/test/src/test/java/org/neo4j/ogm/persistence/transaction/DefaultTransactionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/transaction/DefaultTransactionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.persistence.transaction;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.neo4j.ogm.domain.simple.User;
+import org.neo4j.ogm.model.Result;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+
+import static java.util.Collections.emptyMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test of behaviour of the Session for default transactions (transactions without explicit handling)
+ *
+ * @author Frantisek Hartman
+ */
+public class DefaultTransactionTest extends MultiDriverTestClass {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultTransactionTest.class);
+
+    private static SessionFactory sessionFactory;
+    private Session session;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.simple");
+    }
+
+    @Before
+    public void init() throws IOException {
+        session = sessionFactory.openSession();
+        Result result = session.query("CREATE CONSTRAINT ON (u:User) ASSERT u.name IS UNIQUE", emptyMap());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        session.query("DROP CONSTRAINT ON (u:User) ASSERT u.name IS UNIQUE", emptyMap());
+    }
+
+    @Test
+    public void shouldBeAbleToUseSessionAfterDefaultTransactionFails() throws Exception {
+
+        User u1 = new User("frantisek");
+        session.save(u1);
+        session.clear();
+
+        try {
+            session.save(new User("frantisek"));
+        } catch (Exception ex) {
+            logger.info("Caught exception", ex);
+        }
+
+        User loaded = session.load(User.class, u1.getId());
+        assertThat(loaded).isNotNull();
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/persistence/transaction/DefaultTransactionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/transaction/DefaultTransactionTest.java
@@ -14,7 +14,6 @@
 package org.neo4j.ogm.persistence.transaction;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,6 +31,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import static java.util.Collections.emptyMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Test of behaviour of the Session for default transactions (transactions without explicit handling)
@@ -70,6 +70,7 @@ public class DefaultTransactionTest extends MultiDriverTestClass {
 
         try {
             session.save(new User("frantisek"));
+            fail("Constraint violation should have make the second save fail");
         } catch (Exception ex) {
             logger.info("Caught exception", ex);
         }


### PR DESCRIPTION
## Description

The transactions are not always cleaned up in case of errors when running requests.

## Related Issue

See #393 

## How Has This Been Tested?

See DefaultTransactionTests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
