### PR TITLE
Execute @PostLoad method after fully hydrating all entities

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ o Generate correct statements for entities with label field
 o Fix creation of relationship entities with identical properties
 o Add @Id to relationship entities
 o Remove requirement to have graph id in entities
+o Execute @PostLoad method after fully hydrating all entities, fixes #403
 
 3.0.0-RC1
 o Add verifyConnection configuration property for bolt and http driver

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ o Fix creation of relationship entities with identical properties
 o Add @Id to relationship entities
 o Remove requirement to have graph id in entities
 o Execute @PostLoad method after fully hydrating all entities, fixes #403
+o Fix execution of @PostLoad method when entities are loaded via session.query()
 
 3.0.0-RC1
 o Add verifyConnection configuration property for bolt and http driver

--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -114,14 +114,20 @@ public class GraphEntityMapper implements ResponseMapper<GraphModel> {
         return results;
     }
 
-    public <T> List<T> map(Class<T> type, GraphModel graphModel) {
-        Set<Long> nodeIds = new LinkedHashSet<>();
-        Set<Long> edgeIds = new LinkedHashSet<>();
-        List<T> results = map(type, graphModel, nodeIds, edgeIds);
-        executePostLoad(nodeIds, edgeIds);
-        return results;
-    }
-
+    /**
+     * Map graph model and return found entities of given type type
+     *
+     * This method doesn't execute @PostLoad, call this method after processing whole request while accumulating
+     * nodeIds and edgeIds.
+     *
+     * @param type class of entities to return
+     * @param graphModel graph model to map
+     * @param nodeIds accumulator for mapped nodeIds
+     * @param edgeIds accumulator for mapped edgeIds
+     * @param <T> type
+     *
+     * @return list of entities matching given type
+     */
     public <T> List<T> map(Class<T> type, GraphModel graphModel, Set<Long> nodeIds, Set<Long> edgeIds) {
 
         Set<Long> modelNodeIds = new LinkedHashSet<>();

--- a/core/src/main/java/org/neo4j/ogm/context/GraphRowListModelMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphRowListModelMapper.java
@@ -63,6 +63,7 @@ public class GraphRowListModelMapper implements ResponseMapper<GraphRowListModel
                 }
             }
         }
+        ogm.executePostLoad(nodeIds, edgeIds);
 
         if (classInfo.annotationsInfo().get(RelationshipEntity.class) == null) {
             for (Long resultEntityId : resultEntityIds) {

--- a/test/src/test/java/org/neo4j/ogm/domain/postload/User.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/postload/User.java
@@ -13,7 +13,13 @@
 
 package org.neo4j.ogm.domain.postload;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.neo4j.ogm.annotation.PostLoad;
+import org.neo4j.ogm.annotation.Relationship;
+
+import static org.neo4j.ogm.annotation.Relationship.UNDIRECTED;
 
 /**
  * @author Frantisek Hartman
@@ -23,6 +29,9 @@ public class User {
     static int postLoadCount = 0;
 
     Long id;
+
+    @Relationship(type = "FRIEND_OF", direction = UNDIRECTED)
+    private Set<User> friends;
 
     public static int getPostLoadCount() {
         return postLoadCount;
@@ -41,4 +50,20 @@ public class User {
         postLoadCount++;
     }
 
+    public Set<User> getFriends() {
+        return friends;
+    }
+
+    public void addFriend(User friend) {
+        if (friends == null) {
+            friends = new HashSet<>();
+        }
+        friends.add(friend);
+
+        if (friend.friends == null) {
+            friend.friends = new HashSet<>();
+        }
+
+        friend.friends.add(this);
+    }
 }


### PR DESCRIPTION
Fixes #403, performance issue when mapping large number of rows
returned.

<!--- Provide a general summary of your changes in the Title above -->

## Description
executePostLoad is executed after processing all rows
repeated iteration over accumulating nodeIds and edgeIds is then avoided 

<!--- Describe your changes in detail -->

## Related Issue
See #403 

## How Has This Been Tested?
All tests pass without modification.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
