### PR TITLE
Added support for neo4j.properties.file.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/config/Configuration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/Configuration.java
@@ -40,7 +40,7 @@ public class Configuration {
 	private String generatedIndexesOutputDir;
 	private String generatedIndexesOutputFilename;
 	private String neo4jHaPropertiesFile;
-	private String neo4jPropertiesFile;
+	private String neo4jPropertiesUrl;
 	private String driverName;
 	private Credentials credentials;
     private Integer connectionLivenessCheckTimeout;
@@ -63,7 +63,7 @@ public class Configuration {
         this.autoIndex = builder.autoIndex != null ? AutoIndexMode.fromString(builder.autoIndex) : AutoIndexMode.NONE;
 		this.generatedIndexesOutputDir = builder.generatedIndexesOutputDir != null ? builder.generatedIndexesOutputDir : ".";
 		this.generatedIndexesOutputFilename = builder.generatedIndexesOutputFilename != null ? builder.generatedIndexesOutputFilename : "generated_indexes.cql";
-		this.neo4jPropertiesFile = builder.neo4jPropertiesFile;
+		this.neo4jPropertiesUrl = builder.neo4jPropertiesUrl;
 		this.neo4jHaPropertiesFile = builder.neo4jHaPropertiesFile;
 
 		if (this.uri != null) {
@@ -143,7 +143,7 @@ public class Configuration {
         return neo4jHaPropertiesFile;
 	}
 
-	public String getNeo4jPropertiesFile() { return neo4jPropertiesFile; }
+	public String getNeo4jPropertiesUrl() { return neo4jPropertiesUrl; }
 
 	public Credentials getCredentials() {
 		return credentials;
@@ -191,7 +191,7 @@ public class Configuration {
 			return false;
 		if (neo4jHaPropertiesFile != null ? !neo4jHaPropertiesFile.equals(that.neo4jHaPropertiesFile) : that.neo4jHaPropertiesFile != null)
 			return false;
-		if(neo4jPropertiesFile != null ? !neo4jPropertiesFile.equals(that.neo4jPropertiesFile) : that.neo4jPropertiesFile != null)
+		if(neo4jPropertiesUrl != null ? !neo4jPropertiesUrl.equals(that.neo4jPropertiesUrl) : that.neo4jPropertiesUrl != null)
 		    return false;
 		if (!driverName.equals(that.driverName)) return false;
 		return credentials != null ? credentials.equals(that.credentials) : that.credentials == null;
@@ -208,7 +208,7 @@ public class Configuration {
 		result = 31 * result + (generatedIndexesOutputDir != null ? generatedIndexesOutputDir.hashCode() : 0);
 		result = 31 * result + (generatedIndexesOutputFilename != null ? generatedIndexesOutputFilename.hashCode() : 0);
 		result = 31 * result + (neo4jHaPropertiesFile != null ? neo4jHaPropertiesFile.hashCode() : 0);
-        result = 31 * result + (neo4jPropertiesFile != null ? neo4jPropertiesFile.hashCode() : 0);
+        result = 31 * result + (neo4jPropertiesUrl != null ? neo4jPropertiesUrl.hashCode() : 0);
 		result = 31 * result + driverName.hashCode();
 		result = 31 * result + (credentials != null ? credentials.hashCode() : 0);
 		return result;
@@ -232,7 +232,7 @@ public class Configuration {
 					.generatedIndexesOutputDir(builder.generatedIndexesOutputDir)
 					.generatedIndexesOutputFilename(builder.generatedIndexesOutputFilename)
 					.neo4jHaPropertiesFile(builder.neo4jHaPropertiesFile)
-                    .neo4jPropertiesFile(builder.neo4jPropertiesFile)
+                    .neo4jPropertiesUrl(builder.neo4jPropertiesUrl)
 					.credentials(builder.username, builder.password);
 		}
 
@@ -247,7 +247,7 @@ public class Configuration {
 		private static final String GENERATED_INDEXES_OUTPUT_DIR = "indexes.auto.dump.dir";
 		private static final String GENERATED_INDEXES_OUTPUT_FILENAME = "indexes.auto.dump.filename";
 		private static final String NEO4J_HA_PROPERTIES_FILE = "neo4j.ha.properties.file";
-		private static final String NEO4J_PROPERTIES_FILE = "neo4j.properties.file";
+		private static final String NEO4J_PROPERTIES_URL = "neo4j.properties.url";
 
 		private String uri;
 		private Integer connectionPoolSize;
@@ -260,7 +260,7 @@ public class Configuration {
 		private String generatedIndexesOutputDir;
 		private String generatedIndexesOutputFilename;
 		private String neo4jHaPropertiesFile;
-		private String neo4jPropertiesFile;
+		private String neo4jPropertiesUrl;
 		private String username;
 		private String password;
 
@@ -313,8 +313,8 @@ public class Configuration {
 					case NEO4J_HA_PROPERTIES_FILE:
 						this.neo4jHaPropertiesFile = (String) entry.getValue();
 						break;
-                    case NEO4J_PROPERTIES_FILE:
-                        this.neo4jPropertiesFile = (String) entry.getValue();
+                    case NEO4J_PROPERTIES_URL:
+                        this.neo4jPropertiesUrl = (String) entry.getValue();
                         break;
 					default:
 						LOGGER.warn("Could not process property with key: {}", entry.getKey());
@@ -418,8 +418,8 @@ public class Configuration {
 			return this;
 		}
 
-		public Builder neo4jPropertiesFile(String neo4jPropertiesFile) {
-		    this.neo4jPropertiesFile = neo4jPropertiesFile;
+		public Builder neo4jPropertiesUrl(String neo4jPropertiesFile) {
+		    this.neo4jPropertiesUrl = neo4jPropertiesFile;
 		    return this;
         }
 

--- a/api/src/main/java/org/neo4j/ogm/config/Configuration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/Configuration.java
@@ -40,6 +40,7 @@ public class Configuration {
 	private String generatedIndexesOutputDir;
 	private String generatedIndexesOutputFilename;
 	private String neo4jHaPropertiesFile;
+	private String neo4jPropertiesFile;
 	private String driverName;
 	private Credentials credentials;
     private Integer connectionLivenessCheckTimeout;
@@ -62,6 +63,7 @@ public class Configuration {
         this.autoIndex = builder.autoIndex != null ? AutoIndexMode.fromString(builder.autoIndex) : AutoIndexMode.NONE;
 		this.generatedIndexesOutputDir = builder.generatedIndexesOutputDir != null ? builder.generatedIndexesOutputDir : ".";
 		this.generatedIndexesOutputFilename = builder.generatedIndexesOutputFilename != null ? builder.generatedIndexesOutputFilename : "generated_indexes.cql";
+		this.neo4jPropertiesFile = builder.neo4jPropertiesFile;
 		this.neo4jHaPropertiesFile = builder.neo4jHaPropertiesFile;
 
 		if (this.uri != null) {
@@ -141,6 +143,8 @@ public class Configuration {
         return neo4jHaPropertiesFile;
 	}
 
+	public String getNeo4jPropertiesFile() { return neo4jPropertiesFile; }
+
 	public Credentials getCredentials() {
 		return credentials;
 	}
@@ -187,6 +191,8 @@ public class Configuration {
 			return false;
 		if (neo4jHaPropertiesFile != null ? !neo4jHaPropertiesFile.equals(that.neo4jHaPropertiesFile) : that.neo4jHaPropertiesFile != null)
 			return false;
+		if(neo4jPropertiesFile != null ? !neo4jPropertiesFile.equals(that.neo4jPropertiesFile) : that.neo4jPropertiesFile != null)
+		    return false;
 		if (!driverName.equals(that.driverName)) return false;
 		return credentials != null ? credentials.equals(that.credentials) : that.credentials == null;
 	}
@@ -202,6 +208,7 @@ public class Configuration {
 		result = 31 * result + (generatedIndexesOutputDir != null ? generatedIndexesOutputDir.hashCode() : 0);
 		result = 31 * result + (generatedIndexesOutputFilename != null ? generatedIndexesOutputFilename.hashCode() : 0);
 		result = 31 * result + (neo4jHaPropertiesFile != null ? neo4jHaPropertiesFile.hashCode() : 0);
+        result = 31 * result + (neo4jPropertiesFile != null ? neo4jPropertiesFile.hashCode() : 0);
 		result = 31 * result + driverName.hashCode();
 		result = 31 * result + (credentials != null ? credentials.hashCode() : 0);
 		return result;
@@ -225,6 +232,7 @@ public class Configuration {
 					.generatedIndexesOutputDir(builder.generatedIndexesOutputDir)
 					.generatedIndexesOutputFilename(builder.generatedIndexesOutputFilename)
 					.neo4jHaPropertiesFile(builder.neo4jHaPropertiesFile)
+                    .neo4jPropertiesFile(builder.neo4jPropertiesFile)
 					.credentials(builder.username, builder.password);
 		}
 
@@ -239,6 +247,7 @@ public class Configuration {
 		private static final String GENERATED_INDEXES_OUTPUT_DIR = "indexes.auto.dump.dir";
 		private static final String GENERATED_INDEXES_OUTPUT_FILENAME = "indexes.auto.dump.filename";
 		private static final String NEO4J_HA_PROPERTIES_FILE = "neo4j.ha.properties.file";
+		private static final String NEO4J_PROPERTIES_FILE = "neo4j.properties.file";
 
 		private String uri;
 		private Integer connectionPoolSize;
@@ -251,6 +260,7 @@ public class Configuration {
 		private String generatedIndexesOutputDir;
 		private String generatedIndexesOutputFilename;
 		private String neo4jHaPropertiesFile;
+		private String neo4jPropertiesFile;
 		private String username;
 		private String password;
 
@@ -303,6 +313,9 @@ public class Configuration {
 					case NEO4J_HA_PROPERTIES_FILE:
 						this.neo4jHaPropertiesFile = (String) entry.getValue();
 						break;
+                    case NEO4J_PROPERTIES_FILE:
+                        this.neo4jPropertiesFile = (String) entry.getValue();
+                        break;
 					default:
 						LOGGER.warn("Could not process property with key: {}", entry.getKey());
 				}
@@ -404,6 +417,11 @@ public class Configuration {
 			this.neo4jHaPropertiesFile = neo4jHaPropertiesFile;
 			return this;
 		}
+
+		public Builder neo4jPropertiesFile(String neo4jPropertiesFile) {
+		    this.neo4jPropertiesFile = neo4jPropertiesFile;
+		    return this;
+        }
 
 		public Configuration build() {
 			return new Configuration(this);

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedDriver.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedDriver.java
@@ -93,8 +93,8 @@ public class EmbeddedDriver extends AbstractConfigurableDriver {
                     .loadPropertiesFromURL(url)
                     .newGraphDatabase();
             }
-            else if(config.getNeo4jPropertiesFile() != null) {
-                URL url = new File(config.getNeo4jPropertiesFile()).toURI().toURL();
+            else if(config.getNeo4jPropertiesUrl() != null) {
+                URL url = new URL(config.getNeo4jPropertiesUrl());
                 graphDatabaseService = new GraphDatabaseFactory()
                     .newEmbeddedDatabaseBuilder(file)
                     .loadPropertiesFromURL(url)

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedDriver.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedDriver.java
@@ -84,23 +84,28 @@ public class EmbeddedDriver extends AbstractConfigurableDriver {
             }
 
             // do we want to start a HA instance or a community instance?
-            String haPropertiesFileName = config.getNeo4jHaPropertiesFile();
-            if (haPropertiesFileName != null) {
-                setHAGraphDatabase(file, Thread.currentThread().getContextClassLoader().getResource(haPropertiesFileName));
-            } else {
-                setGraphDatabase(file);
+            if(config.getNeo4jHaPropertiesFile() != null) {
+                URL url = Thread.currentThread()
+                    .getContextClassLoader()
+                    .getResource(config.getNeo4jHaPropertiesFile());
+                graphDatabaseService = new HighlyAvailableGraphDatabaseFactory()
+                    .newEmbeddedDatabaseBuilder(file)
+                    .loadPropertiesFromURL(url)
+                    .newGraphDatabase();
+            }
+            else if(config.getNeo4jPropertiesFile() != null) {
+                URL url = new File(config.getNeo4jPropertiesFile()).toURI().toURL();
+                graphDatabaseService = new GraphDatabaseFactory()
+                    .newEmbeddedDatabaseBuilder(file)
+                    .loadPropertiesFromURL(url)
+                    .newGraphDatabase();
+            }
+            else {
+                graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase(file);
             }
         } catch (Exception e) {
             throw new ConnectionException("Error connecting to embedded graph", e);
         }
-    }
-
-    private void setHAGraphDatabase(File file, URL propertiesFileURL) {
-        graphDatabaseService = new HighlyAvailableGraphDatabaseFactory().newEmbeddedDatabaseBuilder(file).loadPropertiesFromURL(propertiesFileURL).newGraphDatabase();
-    }
-
-    private void setGraphDatabase(File file) {
-        graphDatabaseService = new GraphDatabaseFactory().newEmbeddedDatabase(file);
     }
 
     @Override


### PR DESCRIPTION
As described in #408, I encountered the need to use a non-HA embedded database with a non-default configuration.  I ended up adding a `neo4j.properties.url` property that behaves similarly to `neo4j.ha.properties.file`.  Loading the properties and deciding what to do based on `dbms.mode` was messy and seems like it might be brittle if more modes are added.

- If `neo4j.ha.properties.file` is set, then the behavior is as before, including the restriction that the config file must be found in the classpath.
- Else if `neo4j.properties.url` is set, then a non-HA `GraphDatabaseService` is created with the specified configuration.  Unlike `neo4j.ha.properties.file`, this may be outside the classpath.
- Else a non-HA instance is created with a default config as before.

It's a URL instead of a URI because `GraphDatabaseBuilder` has a `loadPropertiesFromURL` method.  I'll change it to a URI if that would be better.