### PR TITLE
Fix duplicate nodes for Session.save(Iterable<T>)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ o Generate correct statements for entities with label field
 o Fix creation of relationship entities with identical properties
 o Add @Id to relationship entities
 o Remove requirement to have graph id in entities
+o Fix duplicate nodes for Session.save(Iterable<T>)
 
 3.0.0-RC1
 o Add verifyConnection configuration property for bolt and http driver

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -50,6 +50,7 @@ public class EntityGraphMapper implements EntityMapper {
 
     private final MetaData metaData;
     private final MappingContext mappingContext;
+    private final Compiler compiler  = new MultiStatementCypherCompiler();
 
     /**
      * Constructs a new {@link EntityGraphMapper} that uses the given {@link MetaData}.
@@ -73,8 +74,6 @@ public class EntityGraphMapper implements EntityMapper {
         if (entity == null) {
             throw new NullPointerException("Cannot map null object");
         }
-
-        Compiler compiler = new MultiStatementCypherCompiler();
 
         // add all the relationships we know about. This includes the relationships that
         // won't be modified by the mapping request.
@@ -131,6 +130,11 @@ public class EntityGraphMapper implements EntityMapper {
 
         deleteObsoleteRelationships(compiler);
 
+        return compiler.context();
+    }
+
+    @Override
+    public CompileContext compileContext() {
         return compiler.context();
     }
 

--- a/core/src/main/java/org/neo4j/ogm/context/EntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityMapper.java
@@ -26,6 +26,9 @@ public interface EntityMapper {
      * Processes the given object and any of its composite persistent objects and produces Cypher queries to persist their state
      * in Neo4j.
      *
+     * NOTE: multiple map calls from same EntityMapper instance return same CompileContext with accumulated results.
+     * You can also use {@link #compileContext()} to get final CompileContext.
+     *
      * @param entity The "root" node of the object graph to persist
      * @return A {@link org.neo4j.ogm.cypher.compiler.CompileContext} object containing the statements required to persist the given object to Neo4j, along
      * with a representation of the changes to be made by the Cypher statements never <code>null</code>
@@ -37,6 +40,9 @@ public interface EntityMapper {
      * Processes the given object and any of its composite persistent objects to the specified depth and produces Cypher queries
      * to persist their state in Neo4j.
      *
+     * NOTE: multiple map calls from same EntityMapper instance return same CompileContext with accumulated results.
+     * You can also use {@link #compileContext()} to get final CompileContext.
+     *
      * @param entity The "root" node of the object graph to persist
      * @param depth The number of objects away from the "root" to traverse when looking for objects to map
      * @return A {@link CompileContext} object containing the statements required to persist the given object to Neo4j, along
@@ -44,4 +50,11 @@ public interface EntityMapper {
      * @throws NullPointerException if invoked with <code>null</code>
      */
     CompileContext map(Object entity, int depth);
+
+    /**
+     * Returns compile context after multiple {@link #map(Object)} operations were called
+     *
+     * @return CompileContext
+     */
+    CompileContext compileContext();
 }

--- a/test/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
@@ -450,6 +450,7 @@ public class DirectRelationshipsTest {
         assertThat(statements).hasSize(1);
         assertThat(statements.get(0).getStatement()).isEqualTo("UNWIND {rows} as row MATCH (startNode) WHERE ID(startNode) = row.startNodeId MATCH (endNode) WHERE ID(endNode) = row.endNodeId MATCH (startNode)-[rel:`CONTAINS`]->(endNode) DELETE rel");
 
+        mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
         //There are no more changes to the graph
         compiler = mapper.map(doc1).getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
@@ -80,7 +80,6 @@ public class CompilerTest {
     @Before
     public void setUpMapper() {
         mappingContext = new MappingContext(mappingMetadata);
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
     }
 
     @After
@@ -892,7 +891,8 @@ public class CompilerTest {
     }
 
     private Compiler mapAndCompile(Object object) {
-        CompileContext context = this.mapper.map(object);
+        EntityMapper mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        CompileContext context = mapper.map(object);
         Compiler compiler = context.getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());
         return compiler;

--- a/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
@@ -12,6 +12,7 @@
  */
 package org.neo4j.ogm.drivers;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.collect.Iterables;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -65,6 +67,22 @@ public class BasicDriverTest extends MultiDriverTestClass {
         assertThat(user.getId()).isNotNull();
     }
 
+    @Test
+    public void shouldSaveMultipleObjects() throws Exception {
+        User bilbo = new User("Bilbo Baggins");
+        User frodo = new User("Bilbo Baggins");
+        bilbo.befriend(frodo);
+
+        // Get an Iterable which is not a Collection
+        Iterable<User> iterable = Iterables.concat(newArrayList(bilbo), newArrayList(frodo));
+        assertThat(iterable).isNotInstanceOf(Collection.class);
+
+        session.save(iterable);
+
+        session.clear();
+        Collection<User> users = session.loadAll(User.class);
+        assertThat(users).hasSize(2);
+    }
 
     // load tests
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See test case and fix in EntityGraphMapper


## Description
The issue was that CompileContext (where we store information about new entities) was created for each entity in iterable. If entities refer to each other they were created multiple times.

## How Has This Been Tested?
Test case provided.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
