### PR TITLE
Store visited NodeBuilder along with horizon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 3.0.2
 o Entity count returns incorrect result on abstract non-annotated type. #435
 o Fix classpath scanning issue with Play framework. #429
+o Store horizon along with visited nodes to traverse to correct depth. #407
 
 3.0.1
 o Add filter function for in-collection query. #423

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
 o Entity count returns incorrect result on abstract non-annotated type. #435
 o Fix classpath scanning issue with Play framework. #429
 o Store horizon along with visited nodes to traverse to correct depth. #407
+o Fix mapping of directed transient relationships defined in both directions
 
 3.0.1
 o Add filter function for in-collection query. #423

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -808,7 +808,7 @@ public class EntityGraphMapper implements EntityMapper {
     private boolean hasTransientRelationship(CompileContext ctx, Long src, RelationshipBuilder relationshipBuilder, Long tgt) {
         for (Object object : ctx.getTransientRelationships(new SrcTargetKey(src, tgt))) {
             if (object instanceof TransientRelationship) {
-                if (((TransientRelationship) object).equalsIgnoreDirection(src, relationshipBuilder, tgt)) {
+                if (((TransientRelationship) object).equals(src, relationshipBuilder, tgt)) {
                     return true;
                 }
             }

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -208,14 +208,13 @@ public class EntityGraphMapper implements EntityMapper {
             return null;
         }
 
-        if (context.visited(entity)) {
+        if (context.visited(entity, horizon)) {
             LOGGER.debug("already visited: {}", entity);
             return context.visitedNode(entity);
         }
 
-        NodeBuilder nodeBuilder = getNodeBuilder(compiler, entity);
+        NodeBuilder nodeBuilder = getNodeBuilder(compiler, entity, horizon);
         if (nodeBuilder != null) {
-            updateNode(entity, context, nodeBuilder);
             if (horizon != 0) {
                 mapEntityReferences(entity, nodeBuilder, horizon - 1, compiler);
             } else {
@@ -258,9 +257,16 @@ public class EntityGraphMapper implements EntityMapper {
      *
      * @param compiler the {@link org.neo4j.ogm.cypher.compiler.Compiler}
      * @param entity the object to save
+     * @param horizon current horizon
      * @return a {@link NodeBuilder} object for either a new node or an existing one
      */
-    private NodeBuilder getNodeBuilder(Compiler compiler, Object entity) {
+    private NodeBuilder getNodeBuilder(Compiler compiler, Object entity, int horizon) {
+        CompileContext context = compiler.context();
+
+        NodeBuilder nodeBuilder = context.visitedNode(entity);
+        if (nodeBuilder != null) {
+            return nodeBuilder;
+        }
 
         ClassInfo classInfo = metaData.classInfo(entity);
 
@@ -269,14 +275,11 @@ public class EntityGraphMapper implements EntityMapper {
             return null;
         }
 
-        CompileContext context = compiler.context();
         Long id = mappingContext.nativeId(entity);
         Collection<String> labels = EntityUtils.labels(entity, metaData);
 
-        NodeBuilder nodeBuilder;
         final String primaryIndex = classInfo.primaryIndexField() != null ? classInfo.primaryIndexField().property() : null;
         if (id < 0) {
-//            Long entityIdRef = EntityUtils.identity(entity, metaData);
             nodeBuilder = compiler.newNode(id).addLabels(labels).setPrimaryIndex(primaryIndex);
             context.registerNewObject(id, entity);
         } else {
@@ -284,8 +287,11 @@ public class EntityGraphMapper implements EntityMapper {
             nodeBuilder.addLabels(labels).setPrimaryIndex(primaryIndex);
             removePreviousLabelsIfRequired(entity, classInfo, nodeBuilder);
         }
-        context.visit(entity, nodeBuilder);
+        context.visit(entity, nodeBuilder, horizon);
         LOGGER.debug("visiting: {}", entity);
+
+        updateNode(entity, context, nodeBuilder);
+
         return nodeBuilder;
     }
 
@@ -585,7 +591,7 @@ public class EntityGraphMapper implements EntityMapper {
         NodeBuilder tgtNodeBuilder = context.visitedNode(targetEntity);
 
         if (parent == targetEntity) {  // we approached this RE from its END-NODE during object mapping.
-            if (!context.visited(startEntity)) { // skip if we already visited the START_NODE
+            if (!context.visited(startEntity, horizon)) { // skip if we already visited the START_NODE
                 relNodes.source = targetEntity; // set up the nodes to link
                 relNodes.target = startEntity;
                 mapRelatedEntity(cypherCompiler, nodeBuilder, relationshipBuilder, horizon, relNodes);
@@ -593,7 +599,7 @@ public class EntityGraphMapper implements EntityMapper {
                 updateRelationship(context, tgtNodeBuilder, srcNodeBuilder, relationshipBuilder, relNodes);
             }
         } else { // we approached this RE from its START_NODE during object mapping.
-            if (!context.visited(targetEntity)) {  // skip if we already visited the END_NODE
+            if (!context.visited(targetEntity, horizon)) {  // skip if we already visited the END_NODE
                 relNodes.source = startEntity;  // set up the nodes to link
                 relNodes.target = targetEntity;
                 mapRelatedEntity(cypherCompiler, nodeBuilder, relationshipBuilder, horizon, relNodes);

--- a/core/src/main/java/org/neo4j/ogm/context/TransientRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/TransientRelationship.java
@@ -13,6 +13,7 @@
 
 package org.neo4j.ogm.context;
 
+import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.cypher.compiler.RelationshipBuilder;
 
 /**
@@ -51,15 +52,26 @@ public class TransientRelationship {
         this.tgtClass = tgtClass;
     }
 
-    public boolean equalsIgnoreDirection(Long src, RelationshipBuilder builder, Long tgt) {
+    public boolean equals(Long src, RelationshipBuilder builder, Long tgt) {
         Boolean singleton = builder.isSingleton();
         if (this.rel.equals(builder.type())) {
             if (singleton) {
-                if (this.src.equals(src) && this.tgt.equals(tgt)) {
-                    return true;
-                }
-                if (this.src.equals(tgt) && this.tgt.equals(src)) {
-                    return true;
+                if (builder.hasDirection(Relationship.OUTGOING)) {
+                    if (this.src.equals(src) && this.tgt.equals(tgt)) {
+                        return true;
+                    }
+                } else if (builder.hasDirection(Relationship.INCOMING)) {
+                    if (this.src.equals(tgt) && this.tgt.equals(src)) {
+                        return true;
+                    }
+                } else {
+                    // Implies outgoing so the direction is ignored
+                    if (this.src.equals(src) && this.tgt.equals(tgt)) {
+                        return true;
+                    }
+                    if (this.src.equals(tgt) && this.tgt.equals(src)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
@@ -30,7 +30,7 @@ public interface CompileContext {
 
     boolean removeRegisteredRelationship(Mappable mappable);
 
-    boolean visited(Object entity);
+    boolean visited(Object entity, int horizon);
 
     NodeBuilder visitedNode(Object entity);
 
@@ -44,7 +44,13 @@ public interface CompileContext {
 
     Collection<Object> registry();
 
-    void visit(Object entity, NodeBuilder nodeBuilder);
+    /**
+     * Stores nodeBuilder for given entity with horizon
+     *
+     * if the nodeBuilder for the entity is already present it will be overwritten (or the horizon will change)
+     * the caller should ensure it doesn't happen
+     */
+    void visit(Object entity, NodeBuilder nodeBuilder, int horizon);
 
     boolean visitedRelationshipEntity(Long relationshipIdentity);
 

--- a/test/src/test/java/org/neo4j/ogm/domain/social/Person.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/social/Person.java
@@ -57,4 +57,16 @@ public class Person {
     public void setName(String name) {
         this.name = name;
     }
+
+    public void addPersonILike(Person person) {
+        peopleILike.add(person);
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
+    }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/social/SocialIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/social/SocialIntegrationTest.java
@@ -314,4 +314,33 @@ public class SocialIntegrationTest extends MultiDriverTestClass {
         Collection<Person> people = session.loadAll(Person.class);
         assertThat(people).hasSize(5);
     }
+
+    @Test
+    public void shouldSaveAllDirectedRelationships() throws Exception {
+
+        Person a = new Person("A");
+        Person b = new Person("B");
+        Person c = new Person("C");
+        Person d = new Person("D");
+        Person e = new Person("E");
+
+        a.addPersonILike(b);
+        b.addPersonILike(c);
+
+        a.addPersonILike(d);
+        d.addPersonILike(e);
+
+        b.addPersonILike(d);
+        d.addPersonILike(b);
+
+        session.save(a);
+        session.clear();
+
+        Person loadedB = session.load(Person.class, b.getId());
+        assertThat(loadedB.getPeopleILike()).hasSize(2);
+
+        Person loadedD = session.load(Person.class, d.getId());
+        assertThat(loadedD.getPeopleILike()).hasSize(2);
+    }
+
 }


### PR DESCRIPTION
When a node is reached at horizon 0 it is marked as visited.
After reaching the node again, with horizon >0 its relationships
should be visited.

This commit stores the horizon in CypherContext and uses it to evaluate
if the traversal should continue.

## Related Issue
Fixes #407 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tests included
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [/] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [/] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [/] I have added tests to cover my changes.
- [/] All new and existing tests passed.
