### PR TITLE
Make possible to load a relationship referring to a non annotated abs…

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityCollector.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityCollector.java
@@ -46,8 +46,8 @@ class EntityCollector {
      * @param targetId id of target element
      * @param target The element to add to the collection that will eventually be set on the owning type
      */
-    public void collectRelationship(Long sourceId, String relationshipType, String relationshipDirection, long relationshipId, long targetId, Object target) {
-        record(sourceId, target, relationshipType, relationshipDirection, new TargetTriple(relationshipId, targetId, target));
+    public void collectRelationship(Long sourceId, Class startPropertyType, String relationshipType, String relationshipDirection, long relationshipId, long targetId, Object target) {
+        record(sourceId, startPropertyType, relationshipType, relationshipDirection, new TargetTriple(relationshipId, targetId, target));
     }
 
     /**
@@ -60,16 +60,16 @@ class EntityCollector {
      * @param targetId id of target element
      * @param target The element to add to the collection that will eventually be set on the owning type
      */
-    public void collectRelationship(Long sourceId, String relationshipType, String relationshipDirection, long targetId, Object target) {
-        record(sourceId, target, relationshipType, relationshipDirection, new TargetTriple(targetId, target));
+    public void collectRelationship(Long sourceId, Class startPropertyType, String relationshipType, String relationshipDirection, long targetId, Object target) {
+        record(sourceId, startPropertyType, relationshipType, relationshipDirection, new TargetTriple(targetId, target));
     }
 
-    private void record(Long owningEntityId, Object collectibleElement, String relationshipType, String relationshipDirection, TargetTriple triple) {
+    private void record(Long owningEntityId, Class startPropertyType, String relationshipType, String relationshipDirection, TargetTriple triple) {
         this.collected.computeIfAbsent(owningEntityId, k -> new HashMap<>());
         DirectedRelationship directedRelationship = new DirectedRelationship(relationshipType, relationshipDirection);
         this.collected.get(owningEntityId).computeIfAbsent(directedRelationship, k -> new HashMap<>());
-        this.collected.get(owningEntityId).get(directedRelationship).computeIfAbsent(collectibleElement.getClass(), k -> new HashSet<>());
-        this.collected.get(owningEntityId).get(directedRelationship).get(collectibleElement.getClass()).add(triple);
+        this.collected.get(owningEntityId).get(directedRelationship).computeIfAbsent(startPropertyType, k -> new HashSet<>());
+        this.collected.get(owningEntityId).get(directedRelationship).get(startPropertyType).add(triple);
     }
 
     public void forCollectedEntities(CollectedHandler handler) {

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -16,21 +16,40 @@ package org.neo4j.ogm.metadata;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.neo4j.ogm.annotation.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.Labels;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.PostLoad;
+import org.neo4j.ogm.annotation.Property;
+import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+import org.neo4j.ogm.annotation.Transient;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.exception.core.MetadataException;
 import org.neo4j.ogm.id.IdStrategy;
 import org.neo4j.ogm.id.InternalIdStrategy;
 import org.neo4j.ogm.id.UuidStrategy;
-import org.neo4j.ogm.session.Neo4jException;
 import org.neo4j.ogm.utils.ClassUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Maintains object to graph mapping details at the class (type) level
@@ -222,7 +241,9 @@ public class ClassInfo {
                 neo4jName = annotationInfo.get(RelationshipEntity.TYPE, simpleName().toUpperCase());
                 return neo4jName;
             }
-            neo4jName = simpleName();
+            if (!isAbstract) {
+                neo4jName = simpleName();
+            }
         }
         return neo4jName;
     }

--- a/core/src/main/java/org/neo4j/ogm/metadata/schema/Node.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/schema/Node.java
@@ -15,6 +15,7 @@ package org.neo4j.ogm.metadata.schema;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Node in a {@link Schema}
@@ -28,7 +29,7 @@ public interface Node {
      *
      * @return label
      */
-    String label();
+    Optional<String> label();
 
     /**
      * Labels this node has, usually only 1

--- a/core/src/main/java/org/neo4j/ogm/metadata/schema/NodeImpl.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/schema/NodeImpl.java
@@ -13,13 +13,12 @@
 
 package org.neo4j.ogm.metadata.schema;
 
-import org.neo4j.ogm.metadata.schema.*;
-import org.neo4j.ogm.metadata.schema.Relationship;
-import org.neo4j.ogm.utils.RelationshipUtils;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+
+import org.neo4j.ogm.utils.RelationshipUtils;
 
 /**
  * Node represents nodes in the schema
@@ -38,8 +37,8 @@ class NodeImpl implements Node {
     }
 
     @Override
-    public String label() {
-        return label;
+    public Optional<String> label() {
+        return Optional.ofNullable(label);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
@@ -19,6 +19,9 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.neo4j.ogm.context.GraphEntityMapper;
 import org.neo4j.ogm.cypher.query.DefaultGraphModelRequest;
 import org.neo4j.ogm.cypher.query.Pagination;
@@ -39,7 +42,7 @@ import org.neo4j.ogm.utils.EntityUtils;
  */
 public class LoadByIdsDelegate {
 
-
+    private static final Logger LOG = LoggerFactory.getLogger(LoadByIdsDelegate.class);
     private final Neo4jSession session;
 
     public LoadByIdsDelegate(Neo4jSession session) {
@@ -48,10 +51,15 @@ public class LoadByIdsDelegate {
 
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, SortOrder sortOrder, Pagination pagination, int depth) {
 
-        String entityType = session.entityType(type.getName());
+        String entityLabel = session.entityType(type.getName());
+        if (entityLabel == null) {
+            LOG.warn("Unable to find database label for entity " + type.getName()
+                + " : no results will be returned. Make sure the class is registered, "
+                + "and not abstract without @NodeEntity annotation");
+        }
         QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
 
-        PagingAndSortingQuery qry = queryStatements.findAllByType(entityType, ids, depth)
+        PagingAndSortingQuery qry = queryStatements.findAllByType(entityLabel, ids, depth)
                 .setSortOrder(sortOrder)
                 .setPagination(pagination);
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
@@ -12,19 +12,23 @@
  */
 package org.neo4j.ogm.session.delegates;
 
+import java.util.Collection;
+
 import org.neo4j.ogm.context.GraphEntityMapper;
 import org.neo4j.ogm.context.GraphRowListModelMapper;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
-import org.neo4j.ogm.cypher.query.*;
+import org.neo4j.ogm.cypher.query.DefaultGraphModelRequest;
+import org.neo4j.ogm.cypher.query.DefaultGraphRowListModelRequest;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.PagingAndSortingQuery;
+import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.model.GraphModel;
 import org.neo4j.ogm.model.GraphRowListModel;
 import org.neo4j.ogm.request.GraphModelRequest;
 import org.neo4j.ogm.response.Response;
 import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.request.strategy.QueryStatements;
-
-import java.util.Collection;
 
 /**
  * @author Vince Bickers

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
@@ -14,6 +14,9 @@ package org.neo4j.ogm.session.delegates;
 
 import java.util.Collection;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.neo4j.ogm.context.GraphEntityMapper;
 import org.neo4j.ogm.context.GraphRowListModelMapper;
 import org.neo4j.ogm.cypher.Filter;
@@ -36,6 +39,7 @@ import org.neo4j.ogm.session.request.strategy.QueryStatements;
  */
 public class LoadByTypeDelegate {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LoadByTypeDelegate.class);
     private final Neo4jSession session;
 
     public LoadByTypeDelegate(Neo4jSession session) {
@@ -45,17 +49,22 @@ public class LoadByTypeDelegate {
     public <T> Collection<T> loadAll(Class<T> type, Filters filters, SortOrder sortOrder, Pagination pagination, int depth) {
 
         //session.ensureTransaction();
-        String entityType = session.entityType(type.getName());
+        String entityLabel = session.entityType(type.getName());
+        if (entityLabel == null) {
+            LOG.warn("Unable to find database label for entity " + type.getName()
+                + " : no results will be returned. Make sure the class is registered, "
+                + "and not abstract without @NodeEntity annotation");
+        }
         QueryStatements queryStatements = session.queryStatementsFor(type, depth);
 
         session.resolvePropertyAnnotations(type, sortOrder);
 
         PagingAndSortingQuery query;
         if (filters.isEmpty()) {
-            query = queryStatements.findByType(entityType, depth);
+            query = queryStatements.findByType(entityLabel, depth);
         } else {
             session.resolvePropertyAnnotations(type, filters);
-            query = queryStatements.findByType(entityType, filters, depth);
+            query = queryStatements.findByType(entityLabel, filters, depth);
         }
 
         query.setSortOrder(sortOrder)

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -12,6 +12,11 @@
  */
 package org.neo4j.ogm.session.delegates;
 
+import java.io.Serializable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.context.GraphEntityMapper;
 import org.neo4j.ogm.cypher.query.DefaultGraphModelRequest;
@@ -23,10 +28,6 @@ import org.neo4j.ogm.request.GraphModelRequest;
 import org.neo4j.ogm.response.Response;
 import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.request.strategy.QueryStatements;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
 
 /**
  * @author Vince Bickers
@@ -63,7 +64,13 @@ public class LoadOneDelegate {
         }
 
         QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
-        PagingAndSortingQuery qry = queryStatements.findOneByType(session.entityType(type.getName()), id, depth);
+        String entityType = session.entityType(type.getName());
+        if (entityType == null) {
+            logger.warn("Unable to find database label for entity " + type.getName()
+                + " : no results will be returned. Make sure the class is registered, "
+                + "and not abstract without @NodeEntity annotation");
+        }
+        PagingAndSortingQuery qry = queryStatements.findOneByType(entityType, id, depth);
 
         GraphModelRequest request = new DefaultGraphModelRequest(qry.getStatement(), qry.getParameters());
         try (Response<GraphModel> response = session.requestHandler().execute(request)) {

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaLoadClauseBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaLoadClauseBuilder.java
@@ -13,12 +13,12 @@
 
 package org.neo4j.ogm.session.request.strategy.impl;
 
+import java.util.Map;
+
 import org.neo4j.ogm.metadata.schema.Node;
 import org.neo4j.ogm.metadata.schema.Relationship;
 import org.neo4j.ogm.metadata.schema.Schema;
 import org.neo4j.ogm.session.request.strategy.LoadClauseBuilder;
-
-import java.util.Map;
 
 import static org.neo4j.ogm.annotation.Relationship.INCOMING;
 import static org.neo4j.ogm.annotation.Relationship.OUTGOING;
@@ -120,9 +120,12 @@ public class SchemaLoadClauseBuilder implements LoadClauseBuilder {
 
         sb.append("(");
         sb.append(toNodeVar);
-        sb.append(":`");
-        sb.append(toNode.label());
-        sb.append("`) | [ ");
+        if (toNode.label() != null) {
+            sb.append(":`");
+            sb.append(toNode.label());
+            sb.append("`");
+        }
+        sb.append(") | [ ");
 //        sb.append(") | { rel: ");
         sb.append(relVar);
         sb.append(", ");
@@ -143,7 +146,9 @@ public class SchemaLoadClauseBuilder implements LoadClauseBuilder {
     }
 
     private String variableName(Node node, int level) {
-        return "" + Character.toLowerCase(node.label().charAt(0)) + level;
+        String label = node.label();
+        char name = (label != null) ? label.charAt(0) : 'x';
+        return "" + Character.toLowerCase(name) + level;
     }
 
     private void appendRel(StringBuilder sb, String variable, String type, String start, String end) {

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaLoadClauseBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaLoadClauseBuilder.java
@@ -120,9 +120,9 @@ public class SchemaLoadClauseBuilder implements LoadClauseBuilder {
 
         sb.append("(");
         sb.append(toNodeVar);
-        if (toNode.label() != null) {
+        if (toNode.label().isPresent()) {
             sb.append(":`");
-            sb.append(toNode.label());
+            sb.append(toNode.label().get());
             sb.append("`");
         }
         sb.append(") | [ ");
@@ -146,8 +146,8 @@ public class SchemaLoadClauseBuilder implements LoadClauseBuilder {
     }
 
     private String variableName(Node node, int level) {
-        String label = node.label();
-        char name = (label != null) ? label.charAt(0) : 'x';
+        String label = node.label().orElse("x");
+        char name = label.charAt(0);
         return "" + Character.toLowerCase(name) + level;
     }
 

--- a/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
+++ b/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
@@ -144,7 +144,7 @@ public class DomainInfoSchemaBuilderTest {
         schema = new DomainInfoSchemaBuilder(domainInfo).build();
 
         Node entity = schema.findNode("Entity");
-        assertThat(entity.label()).isEqualTo("Entity");
+        assertThat(entity.label().get()).isEqualTo("Entity");
         assertThat(entity.labels()).containsExactly("Entity");
 
         schema.findNode("Company");

--- a/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
+++ b/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
@@ -13,17 +13,18 @@
 
 package org.neo4j.ogm.metadata.schema;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
+
 import org.neo4j.ogm.metadata.DomainInfo;
 import org.neo4j.ogm.metadata.schema.inheritance.Associated;
 import org.neo4j.ogm.metadata.schema.simple.Mortal;
-import org.neo4j.ogm.metadata.schema.simple.Organisation;
 import org.neo4j.ogm.metadata.schema.simple.Vertex;
 
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
 import static org.neo4j.ogm.annotation.Relationship.INCOMING;
 import static org.neo4j.ogm.annotation.Relationship.OUTGOING;
 
@@ -134,6 +135,12 @@ public class DomainInfoSchemaBuilderTest {
         assertThat(organisations.type()).isEqualTo("FOUNDED");
         assertThat(organisations.direction(person)).isEqualTo(OUTGOING);
         assertThat(organisations.other(person)).isEqualTo(schema.findNode("Organisation"));
+
+        Node entity = schema.findNode("Entity");
+        assertThat(entity.label()).isEqualTo("Entity");
+
+        Node company = schema.findNode("Company");
+        assertThat(company).as("Abstract non annotated classes should be ignored").isNull();
     }
 
     @Test

--- a/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
+++ b/core/src/test/java/org/neo4j/ogm/metadata/schema/DomainInfoSchemaBuilderTest.java
@@ -135,12 +135,19 @@ public class DomainInfoSchemaBuilderTest {
         assertThat(organisations.type()).isEqualTo("FOUNDED");
         assertThat(organisations.direction(person)).isEqualTo(OUTGOING);
         assertThat(organisations.other(person)).isEqualTo(schema.findNode("Organisation"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void givenNonAnnotatedAbstractClass_thenThrowException() {
+
+        DomainInfo domainInfo = DomainInfo.create(org.neo4j.ogm.metadata.schema.inheritance.Person.class.getPackage().getName());
+        schema = new DomainInfoSchemaBuilder(domainInfo).build();
 
         Node entity = schema.findNode("Entity");
         assertThat(entity.label()).isEqualTo("Entity");
+        assertThat(entity.labels()).containsExactly("Entity");
 
-        Node company = schema.findNode("Company");
-        assertThat(company).as("Abstract non annotated classes should be ignored").isNull();
+        schema.findNode("Company");
     }
 
     @Test

--- a/core/src/test/java/org/neo4j/ogm/metadata/schema/inheritance/Company.java
+++ b/core/src/test/java/org/neo4j/ogm/metadata/schema/inheritance/Company.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.metadata.schema.inheritance;
+
+/**
+ * @author Nicolas Mervaillie
+ */
+public abstract class Company extends Entity {
+}

--- a/core/src/test/java/org/neo4j/ogm/metadata/schema/inheritance/Organisation.java
+++ b/core/src/test/java/org/neo4j/ogm/metadata/schema/inheritance/Organisation.java
@@ -13,16 +13,16 @@
 
 package org.neo4j.ogm.metadata.schema.inheritance;
 
+import java.util.Set;
+
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
-
-import java.util.Set;
 
 /**
  * @author Frantisek Hartman
  */
 @NodeEntity
-public class Organisation extends Entity {
+public class Organisation extends Company {
 
     @Relationship(type = "ASSOCIATED_WITH")
     Set<Associated> associations;

--- a/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -704,8 +704,10 @@ public class ClassHierarchiesIntegrationTest extends MultiDriverTestClass {
         Collection<Female> females = session.loadAll(Female.class);
         Collection<Bloke> blokes = session.loadAll(Bloke.class);
 
-        assertThat(entities).hasSize(3);
-        assertThat(entities.containsAll(Arrays.asList(daniela, michal, adam))).isTrue();
+        // to be consistent with the fact that non annotated abstract classes are not managed,
+        // this should not be loaded even if the nodes have the Entity label.
+        // see #404
+        assertThat(entities).isEmpty();
 
         assertThat(people).hasSize(3);
         assertThat(people.containsAll(Arrays.asList(daniela, michal, adam))).isTrue();


### PR DESCRIPTION
…tract class. Fixes #404

Change request generation to ignore label of end node if the end node type
is a non annotated abstract class.

This also required to change the way how simple relationship values are written :
not according to target entity type but according to the collection type
which can be broader than specific target type.

Untested with rich relationships and with other directions for now.