### PR TITLE
Add support for lenient conversion.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.1.0-SNAPSHOT
+o Manually assigned conversion annotations should support lenient mode. #424
+
 3.0.2
 o Entity count returns incorrect result on abstract non-annotated type. #435
 o Fix classpath scanning issue with Play framework. #429

--- a/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/DateString.java
+++ b/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/DateString.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
  * Applicable to `java.util.Date` and `java.time.Instant`
  *
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -35,5 +36,12 @@ public @interface DateString {
     String ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
     String value() default ISO_8601;
+
+    /**
+     * Toggle lenient conversion mode by setting this flag to true (defaults to false).
+     * Has to be supported by the corresponding converter.
+     * @return flag that represents the desired conversion mode.
+     */
+    boolean lenient() default false;
 }
 

--- a/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/EnumString.java
+++ b/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/EnumString.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
 
 /**
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -30,5 +31,12 @@ public @interface EnumString {
     String TYPE = "value";
 
     Class<? extends Enum> value();
+
+    /**
+     * Toggle lenient conversion mode by setting this flag to true (defaults to false).
+     * Has to be supported by the corresponding converter.
+     * @return flag that represents the desired conversion mode.
+     */
+    boolean lenient() default false;
 }
 

--- a/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/NumberString.java
+++ b/core/src/main/java/org/neo4j/ogm/annotation/typeconversion/NumberString.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
 
 /**
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -30,5 +31,12 @@ public @interface NumberString {
     String TYPE = "value";
 
     Class<? extends Number> value();
+
+    /**
+     * Toggle lenient conversion mode by setting this flag to true (defaults to false).
+     * Has to be supported by the corresponding converter.
+     * @return flag that represents the desired conversion mode.
+     */
+    boolean lenient() default false;
 }
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/ObjectAnnotations.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ObjectAnnotations.java
@@ -30,6 +30,7 @@ import org.neo4j.ogm.typeconversion.NumberStringConverter;
 
 /**
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 public class ObjectAnnotations {
 
@@ -81,7 +82,7 @@ public class ObjectAnnotations {
         AnnotationInfo dateStringConverterInfo = get(DateString.class);
         if (dateStringConverterInfo != null) {
             String format = dateStringConverterInfo.get(DateString.FORMAT, DateString.ISO_8601);
-            return new DateStringConverter(format);
+            return new DateStringConverter(format, isLenientConversion(dateStringConverterInfo));
         }
 
         AnnotationInfo enumStringConverterInfo = get(EnumString.class);
@@ -89,7 +90,7 @@ public class ObjectAnnotations {
             String classDescriptor = enumStringConverterInfo.get(EnumString.TYPE, null);
             try {
                 Class clazz = Class.forName(classDescriptor, false, Thread.currentThread().getContextClassLoader());
-                return new EnumStringConverter(clazz);
+                return new EnumStringConverter(clazz, isLenientConversion(enumStringConverterInfo));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -100,13 +101,18 @@ public class ObjectAnnotations {
             String classDescriptor = numberStringConverterInfo.get(NumberString.TYPE, null);
             try {
                 Class clazz = Class.forName(classDescriptor, false, Thread.currentThread().getContextClassLoader());
-                return new NumberStringConverter(clazz);
+                return new NumberStringConverter(clazz, isLenientConversion(numberStringConverterInfo));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         }
 
         return null;
+    }
+
+    private boolean isLenientConversion(AnnotationInfo converterInfo) {
+        String lenientConversionKey = "lenient";
+        return Boolean.parseBoolean(converterInfo.get(lenientConversionKey));
     }
 
     public boolean has(Class<?> clazz) {

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/DateStringConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/DateStringConverter.java
@@ -18,6 +18,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * By default the OGM will map date objects to UTC-based ISO8601 compliant
  * String values when being stored as a node / relationship property
@@ -28,13 +30,21 @@ import java.util.TimeZone;
  * {@link org.neo4j.ogm.annotation.typeconversion.DateLong} will read and write dates as Long values in the database.
  *
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 public class DateStringConverter implements AttributeConverter<Date, String> {
 
-    private String format;
+    private final String format;
+    private final boolean lenient;
 
     public DateStringConverter(String userDefinedFormat) {
         this.format = userDefinedFormat;
+        this.lenient = false;
+    }
+
+    public DateStringConverter(String userDefinedFormat, boolean lenient) {
+        this.format = userDefinedFormat;
+        this.lenient = lenient;
     }
 
     @Override
@@ -48,8 +58,9 @@ public class DateStringConverter implements AttributeConverter<Date, String> {
 
     @Override
     public Date toEntityAttribute(String value) {
-        if (value == null)
+        if (value == null || (lenient && StringUtils.isBlank(value))) {
             return null;
+        }
         try {
             SimpleDateFormat simpleDateFormat = new SimpleDateFormat(format);
             simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/EnumStringConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/EnumStringConverter.java
@@ -13,6 +13,8 @@
 
 package org.neo4j.ogm.typeconversion;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * By default the OGM will map enum objects to and from
  * the string value returned by enum.name()
@@ -23,13 +25,21 @@ package org.neo4j.ogm.typeconversion;
  * simply by changing the declaration order in the enum set.
  *
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 public class EnumStringConverter implements AttributeConverter<Enum, String> {
 
     private final Class<? extends Enum> enumClass;
+    private final boolean lenient;
 
     public EnumStringConverter(Class<? extends Enum> enumClass) {
         this.enumClass = enumClass;
+        this.lenient = false;
+    }
+
+    public EnumStringConverter(Class<? extends Enum> enumClass, boolean lenient) {
+        this.enumClass = enumClass;
+        this.lenient = lenient;
     }
 
     @Override
@@ -41,8 +51,9 @@ public class EnumStringConverter implements AttributeConverter<Enum, String> {
 
     @Override
     public Enum toEntityAttribute(String value) {
-        if (value == null)
+        if (value == null || (lenient && StringUtils.isBlank(value))) {
             return null;
+        }
         return Enum.valueOf(enumClass, value);
     }
 }

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/NumberStringConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/NumberStringConverter.java
@@ -13,6 +13,8 @@
 
 package org.neo4j.ogm.typeconversion;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * The NumberStringConverter can be used to convert any java object that extends
  * java.lang.Number to and from its String representation.
@@ -20,13 +22,21 @@ package org.neo4j.ogm.typeconversion;
  * entity attributes using this converter.
  *
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 public class NumberStringConverter implements AttributeConverter<Number, String> {
 
     private final Class<? extends Number> numberClass;
+    private final boolean lenient;
 
     public NumberStringConverter(Class<? extends Number> numberClass) {
         this.numberClass = numberClass;
+        this.lenient = false;
+    }
+
+    public NumberStringConverter(Class<? extends Number> numberClass, boolean lenient) {
+        this.numberClass = numberClass;
+        this.lenient = lenient;
     }
 
     @Override
@@ -38,7 +48,7 @@ public class NumberStringConverter implements AttributeConverter<Number, String>
 
     @Override
     public Number toEntityAttribute(String value) {
-        if (value == null)
+        if (value == null || (lenient && StringUtils.isBlank(value)))
             return null;
         try {
             return numberClass.getDeclaredConstructor(String.class).newInstance(value);

--- a/neo4j-ogm-docs/src/main/asciidoc/reference/conversion.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/conversion.adoc
@@ -51,6 +51,22 @@ Collections of primitive or convertible values are also automatically mapped by 
 [NOTE]
 Collections are not supported for `java.time.Instant` and `java.time.LocalDate`.
 
+=== Lenient conversion
+It is possible to explicitly assign the build-in converter annotations to the corresponding fields.
+This provides the advantage of being able to use the `lenient` attribute that will get be read by the converters.
+The supported annotations are `@DateString`, `@EnumString` and `@NumberString`.
+.Example of lenient converter usage
+[source, java]
+----
+public class MyEntity {
+
+    @DateString(lenient = true)
+    private Date entityDate;
+}
+----
+
+The lenient feature is currently only supported by string-based converters to allow the conversion of blank strings from the database.
+
 [[reference:type-conversion:custom]]
 == Custom Type Conversion
 

--- a/test/src/test/java/org/neo4j/ogm/domain/convertible/date/Memo.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/convertible/date/Memo.java
@@ -23,6 +23,7 @@ import org.neo4j.ogm.annotation.typeconversion.DateString;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class Memo {
 
@@ -38,6 +39,12 @@ public class Memo {
 
     @DateString("yyyy-MM-dd")
     private Date actioned;
+
+    @DateString
+    private Date modified;
+
+    @DateString(lenient = true)
+    private Date legacyDate;
 
     @DateLong
     private Date closed;
@@ -81,6 +88,22 @@ public class Memo {
 
     public void setActioned(Date actioned) {
         this.actioned = actioned;
+    }
+
+    public Date getModified() {
+        return modified;
+    }
+
+    public void setModified(Date modified) {
+        this.modified = modified;
+    }
+
+    public Date getLegacyDate() {
+        return legacyDate;
+    }
+
+    public void setLegacyDate(Date legacyDate) {
+        this.legacyDate = legacyDate;
     }
 
     public Date getClosed() {

--- a/test/src/test/java/org/neo4j/ogm/domain/convertible/enums/Algebra.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/convertible/enums/Algebra.java
@@ -13,8 +13,11 @@
 
 package org.neo4j.ogm.domain.convertible.enums;
 
+import org.neo4j.ogm.annotation.typeconversion.EnumString;
+
 /**
  * @author Vince Bickers
+ * @author Gerrit Meier
  */
 public class Algebra {
 
@@ -22,11 +25,33 @@ public class Algebra {
 
     private NumberSystem numberSystem;
 
+    @EnumString(value = Operation.class)
+    private Operation operation;
+
+    @EnumString(value = Operation.class, lenient = true)
+    private Operation operationLenient;
+
     public NumberSystem getNumberSystem() {
         return numberSystem;
     }
 
     public void setNumberSystem(NumberSystem numberSystem) {
         this.numberSystem = numberSystem;
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(Operation operation) {
+        this.operation = operation;
+    }
+
+    public Operation getOperationLenient() {
+        return operationLenient;
+    }
+
+    public void setOperationLenient(Operation operationLenient) {
+        this.operationLenient = operationLenient;
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/convertible/enums/Operation.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/convertible/enums/Operation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.domain.convertible.enums;
+
+/**
+ * @author Gerrit Meier
+ */
+
+public enum Operation {
+
+    ADDITION,
+    SUBTRACTION,
+    MULTIPLICATION,
+    DIVISION
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/convertible/numbers/Account.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/convertible/numbers/Account.java
@@ -17,9 +17,12 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 
+import org.neo4j.ogm.annotation.typeconversion.NumberString;
+
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class Account {
 
@@ -27,6 +30,13 @@ public class Account {
     private BigDecimal balance;
     private BigInteger facility;
     private BigDecimal[] deposits;
+
+    @NumberString(value = Integer.class)
+    private Integer futureBalance;
+
+    @NumberString(value = Integer.class, lenient = true)
+    private Integer futureBalanceLenient;
+
     private List<BigInteger> loans;
     private short code;
     private Float limit;
@@ -61,6 +71,22 @@ public class Account {
 
     public void setDeposits(BigDecimal[] deposits) {
         this.deposits = deposits;
+    }
+
+    public Integer getFutureBalance() {
+        return futureBalance;
+    }
+
+    public void setFutureBalance(Integer futureBalance) {
+        this.futureBalance = futureBalance;
+    }
+
+    public Integer getFutureBalanceLenient() {
+        return futureBalanceLenient;
+    }
+
+    public void setFutureBalanceLenient(Integer futureBalanceLenient) {
+        this.futureBalanceLenient = futureBalanceLenient;
     }
 
     public List<BigInteger> getLoans() {

--- a/test/src/test/java/org/neo4j/ogm/metadata/ClassPathScannerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/ClassPathScannerTest.java
@@ -44,7 +44,7 @@ public class ClassPathScannerTest {
     public void nestedDirectoryShouldBeScanned() {
         final DomainInfo domainInfo = DomainInfo.create("org.neo4j.ogm.domain.convertible");
 
-        assertThat(domainInfo.getClassInfoMap()).hasSize(20);
+        assertThat(domainInfo.getClassInfoMap()).hasSize(21);
 
         Set<String> classNames = domainInfo.getClassInfoMap().keySet();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.bytes.Photo")).isTrue();
@@ -57,6 +57,7 @@ public class ClassPathScannerTest {
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.Gender")).isTrue();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.NumberSystem")).isTrue();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.NumberSystemDomainConverter")).isTrue();
+        assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.Operation")).isTrue();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.Person")).isTrue();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.Tag")).isTrue();
         assertThat(classNames.contains("org.neo4j.ogm.domain.convertible.enums.TagEntity")).isTrue();

--- a/test/src/test/java/org/neo4j/ogm/typeconversion/DateConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/typeconversion/DateConversionTest.java
@@ -15,6 +15,7 @@ package org.neo4j.ogm.typeconversion;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -30,6 +31,7 @@ import org.neo4j.ogm.metadata.MetaData;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class DateConversionTest {
 
@@ -170,5 +172,53 @@ public class DateConversionTest {
         assertThat(methodInfo.hasPropertyConverter()).isTrue();
         AttributeConverter attributeConverter = methodInfo.getPropertyConverter();
         assertThat(attributeConverter.toGraphProperty(null)).isEqualTo(null);
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test
+    public void assertFieldDateConversionWithExplicitAnnotation() {
+        FieldInfo fieldInfo = memoInfo.propertyField("modified");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.getClass().isAssignableFrom(DateStringConverter.class)).isTrue();
+        assertThat(attributeConverter.toGraphProperty(new Date(0))).isEqualTo("1970-01-01T00:00:00.000Z");
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test
+    public void assertFieldDateConversionWithExplicitAnnotationWorksForNullGraphValue() {
+        FieldInfo fieldInfo = memoInfo.propertyField("modified");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.getClass().isAssignableFrom(DateStringConverter.class)).isTrue();
+        assertThat(attributeConverter.toEntityAttribute(null)).isNull();
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test(expected = RuntimeException.class)
+    public void assertFieldDateConversionWithExplicitAnnotationFailsForEmptyGraphValue() {
+        FieldInfo fieldInfo = memoInfo.propertyField("modified");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.getClass().isAssignableFrom(DateStringConverter.class)).isTrue();
+        assertThat(attributeConverter.toEntityAttribute("")).isNull();
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test
+    public void assertFieldLenientDateConversionWithExplicitAnnotationWorksForEmptyGraphValue() {
+        FieldInfo fieldInfo = memoInfo.propertyField("legacyDate");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.getClass().isAssignableFrom(DateStringConverter.class)).isTrue();
+        assertThat(attributeConverter.toEntityAttribute("")).isNull();
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/typeconversion/EnumConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/typeconversion/EnumConversionTest.java
@@ -23,6 +23,7 @@ import org.neo4j.ogm.domain.convertible.enums.Algebra;
 import org.neo4j.ogm.domain.convertible.enums.Education;
 import org.neo4j.ogm.domain.convertible.enums.Gender;
 import org.neo4j.ogm.domain.convertible.enums.NumberSystem;
+import org.neo4j.ogm.domain.convertible.enums.Operation;
 import org.neo4j.ogm.domain.convertible.enums.Person;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
@@ -31,6 +32,7 @@ import org.neo4j.ogm.metadata.MetaData;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class EnumConversionTest {
 
@@ -184,5 +186,29 @@ public class EnumConversionTest {
     public void shouldNotRegisterEnumWhenTypeContainsEnumType() {
         FieldInfo fieldInfo = tagEntityInfo.relationshipFieldByName("tags");
         assertThat(fieldInfo.hasPropertyConverter()).isFalse();
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnEmptyGraphProperty() {
+        FieldInfo fieldInfo = algebraInfo.propertyField("operation");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.toEntityAttribute("")).isNull();
+    }
+
+    /**
+     * @see issue #424
+     */
+    @Test
+    public void shouldWorkOnEmptyGraphPropertyWithLenientConversionEnabled() {
+        FieldInfo fieldInfo = algebraInfo.propertyField("operationLenient");
+        assertThat(fieldInfo.hasPropertyConverter()).isTrue();
+
+        AttributeConverter attributeConverter = fieldInfo.getPropertyConverter();
+        assertThat(attributeConverter.toEntityAttribute("")).isNull();
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/typeconversion/NumberConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/typeconversion/NumberConversionTest.java
@@ -28,6 +28,7 @@ import org.neo4j.ogm.metadata.MetaData;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class NumberConversionTest {
 
@@ -142,5 +143,17 @@ public class NumberConversionTest {
         MetaData metaData = new MetaData("org.neo4j.ogm.domain.restaurant");
         ClassInfo restaurantInfo = metaData.classInfo("Restaurant");
         assertThat(restaurantInfo.propertyField("location").hasCompositeConverter()).isTrue();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void assertConvertingEmptyGraphPropertyFails() {
+        AttributeConverter converter = accountInfo.propertyField("futureBalance").getPropertyConverter();
+        assertThat(converter.toEntityAttribute("")).isEqualTo(null);
+    }
+
+    @Test
+    public void assertConvertingEmptyGraphPropertyWorksCorrectlyWithLenientConverter() {
+        AttributeConverter converter = accountInfo.propertyField("futureBalanceLenient").getPropertyConverter();
+        assertThat(converter.toEntityAttribute("")).isEqualTo(null);
     }
 }


### PR DESCRIPTION
Every explicit String based conversion (at the moment DateString,
EnumString and NumberString) has an attribute named lenient now.
This attribute (default false) can be used to lower the strictness
of the conversion.

Fixes #424
