### PR TITLE
Improve setting of BooleanOperator parameter in Filter.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 3.1.0-SNAPSHOT
 o Manually assigned conversion annotations should support lenient mode. #424
+o Improve setting of BooleanOperator parameter in Filter. #445
 
 3.0.2
 o Entity count returns incorrect result on abstract non-annotated type. #435

--- a/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
@@ -168,6 +168,27 @@ public class Filter {
     }
 
     /**
+     * Convenience method to chain filters using {@link BooleanOperator#AND}.
+     * @param filter to be chained
+     * @return new {@link Filters} object containing both filters.
+     */
+
+    public Filters and(Filter filter) {
+        filter.setBooleanOperator(BooleanOperator.AND);
+        return new Filters(this, filter);
+    }
+
+    /**
+     * Convenience method to chain filters using {@link BooleanOperator#OR}.
+     * @param filter to be chained.
+     * @return new {@link Filters} object containing both filters.
+     */
+    public Filters or(Filter filter) {
+        filter.setBooleanOperator(BooleanOperator.OR);
+        return new Filters(this, filter);
+    }
+
+    /**
      * @return <code>true</code> if this filter expression is to be negated when it's appended to the query, <code>false</code>
      * if not
      */

--- a/core/src/main/java/org/neo4j/ogm/cypher/Filters.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/Filters.java
@@ -62,6 +62,26 @@ public class Filters implements Iterable<Filter> {
         return this;
     }
 
+    /**
+     * Convenience method to add a filter using {@link BooleanOperator#AND}.
+     * @param filter to be chained.
+     * @return current {@link Filters} object with chained {@link Filter}.
+     */
+    public Filters and(Filter filter) {
+        filter.setBooleanOperator(BooleanOperator.AND);
+        return add(filter);
+    }
+
+    /**
+     * Convenience method to add a filter using {@link BooleanOperator#OR}.
+     * @param filter to be chained.
+     * @return current {@link Filters} object with chained {@link Filter}.
+     */
+    public Filters or(Filter filter) {
+        filter.setBooleanOperator(BooleanOperator.OR);
+        return add(filter);
+    }
+
     @Override
     public Iterator<Filter> iterator() {
         return filters.iterator();

--- a/neo4j-ogm-docs/src/main/asciidoc/reference/filters.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/filters.adoc
@@ -15,4 +15,13 @@ In the example below, we're return a collection containing any satellites that a
 Collection<Satellite> satellites = session.loadAll(Satellite.class, new Filter("manned", EQUALS, true));
 ----
 
+.Example of chained Filters
+[source,java]
+----
+Filter mannedFilter = new Filter("manned", equals, true);
+Filter landedFilter = new Filter("landed", equals, false);
+
+Filters satelliteFilter = mannedFilter.and(landedFilter);
+----
+
 WARNING: The filters should be considered as immutable. In previous versions, you could change filter values after instantiation, this is not the case anymore.

--- a/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
@@ -15,6 +15,8 @@ package org.neo4j.ogm.cypher;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Iterator;
+
 import org.junit.Test;
 import org.neo4j.ogm.cypher.function.ContainsAnyComparison;
 import org.neo4j.ogm.cypher.function.DistanceComparison;
@@ -47,5 +49,31 @@ public class FilterTest {
             .isEqualTo("WHERE ANY(collectionFields IN {`property_0`} WHERE collectionFields in n.`property`) ");
         assertThat(filter.parameters().get("property_0")).isEqualTo("test");
 
+    }
+
+    @Test
+    public void joinFiltersWithAndMethod() {
+        Filter filter1 = new Filter("property1", ComparisonOperator.EQUALS, "value1");
+        Filter filter2 = new Filter("property2", ComparisonOperator.EQUALS, "value2");
+
+        Filters andFilter = filter1.and(filter2);
+
+        assertThat(filter2.getBooleanOperator()).isEqualTo(BooleanOperator.AND);
+        Iterator<Filter> iterator = andFilter.iterator();
+        assertThat(iterator.next()).isEqualTo(filter1);
+        assertThat(iterator.next()).isEqualTo(filter2);
+    }
+
+    @Test
+    public void joinFiltersWithOrMethod() {
+        Filter filter1 = new Filter("property1", ComparisonOperator.EQUALS, "value1");
+        Filter filter2 = new Filter("property2", ComparisonOperator.EQUALS, "value2");
+
+        Filters andFilter = filter1.or(filter2);
+
+        assertThat(filter2.getBooleanOperator()).isEqualTo(BooleanOperator.OR);
+        Iterator<Filter> iterator = andFilter.iterator();
+        assertThat(iterator.next()).isEqualTo(filter1);
+        assertThat(iterator.next()).isEqualTo(filter2);
     }
 }


### PR DESCRIPTION
 to avoid calling `setBooleanOperator` on a `Filter` instance
 it is now possible to chain `Filter`s with convenience methods.

 To also support this for existing `Filters` both methods are also
 provided in this class.

 fixes #445