### PR TITLE
Feature/persistence ctors

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/GraphRowListModelMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphRowListModelMapper.java
@@ -24,6 +24,7 @@ import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.model.GraphRowListModel;
 import org.neo4j.ogm.model.GraphRowModel;
 import org.neo4j.ogm.response.Response;
+import org.neo4j.ogm.session.EntityInstantiator;
 
 /**
  * @author vince
@@ -32,10 +33,13 @@ public class GraphRowListModelMapper implements ResponseMapper<GraphRowListModel
 
     private final MetaData metaData;
     private final MappingContext mappingContext;
+    private EntityInstantiator entityInstantiator;
 
-    public GraphRowListModelMapper(MetaData metaData, MappingContext mappingContext) {
+    public GraphRowListModelMapper(MetaData metaData, MappingContext mappingContext,
+        EntityInstantiator entityInstantiator) {
         this.metaData = metaData;
         this.mappingContext = mappingContext;
+        this.entityInstantiator = entityInstantiator;
     }
 
     public <T> Iterable<T> map(Class<T> type, Response<GraphRowListModel> response) {
@@ -46,7 +50,7 @@ public class GraphRowListModelMapper implements ResponseMapper<GraphRowListModel
 
         Set<Long> nodeIds = new LinkedHashSet<>();
         Set<Long> edgeIds = new LinkedHashSet<>();
-        GraphEntityMapper ogm = new GraphEntityMapper(metaData, mappingContext);
+        GraphEntityMapper ogm = new GraphEntityMapper(metaData, mappingContext, entityInstantiator);
 
         GraphRowListModel graphRowsModel;
 

--- a/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
@@ -26,6 +26,7 @@ import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.metadata.reflect.EntityAccessManager;
 import org.neo4j.ogm.metadata.reflect.EntityFactory;
 import org.neo4j.ogm.model.RowModel;
+import org.neo4j.ogm.session.EntityInstantiator;
 import org.neo4j.ogm.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,11 +49,11 @@ public class SingleUseEntityMapper {
      * Constructs a new {@link SingleUseEntityMapper} based on the given mapping {@link MetaData}.
      *
      * @param mappingMetaData The {@link MetaData} to use for performing mappings
-     * @param entityFactory   The entity factory to use.
+     * @param entityInstantiator   The entity factory to use.
      */
-    public SingleUseEntityMapper(MetaData mappingMetaData, EntityFactory entityFactory) {
+    public SingleUseEntityMapper(MetaData mappingMetaData, EntityInstantiator entityInstantiator) {
         this.metadata = mappingMetaData;
-        this.entityFactory = new EntityFactory(mappingMetaData);
+        this.entityFactory = new EntityFactory(mappingMetaData, entityInstantiator);
     }
 
     /**
@@ -70,13 +71,13 @@ public class SingleUseEntityMapper {
             properties.put(columnNames[i], rowModel.getValues()[i]);
         }
 
-        T entity = this.entityFactory.newObject(type);
+        T entity = this.entityFactory.newObject(type, properties);
         setPropertiesOnEntity(entity, properties);
         return entity;
     }
 
     public <T> T map(Class<T> type, Map<String, Object> row) {
-        T entity = this.entityFactory.newObject(type);
+        T entity = this.entityFactory.newObject(type, row);
         setPropertiesOnEntity(entity, row);
         return entity;
     }

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityFactory.java
@@ -11,7 +11,6 @@
 
 package org.neo4j.ogm.metadata.reflect;
 
-import java.lang.reflect.Constructor;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,8 +19,9 @@ import org.neo4j.ogm.exception.core.BaseClassNotFoundException;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.MetaData;
-import org.neo4j.ogm.model.Edge;
 import org.neo4j.ogm.model.Node;
+import org.neo4j.ogm.model.Property;
+import org.neo4j.ogm.session.EntityInstantiator;
 
 /**
  * A metadata-driven factory class for creating node and relationship entities.
@@ -33,14 +33,17 @@ public class EntityFactory {
     private final Map<String, String> taxaLeafClass = new HashMap<>();
 
     private final MetaData metadata;
+    private EntityInstantiator entityInstantiator;
 
     /**
      * Constructs a new {@link EntityFactory} driven by the specified {@link MetaData}.
      *
      * @param metadata The mapping {@link MetaData}
+     * @param entityInstantiator The instantiation mechanism to be used.
      */
-    public EntityFactory(MetaData metadata) {
+    public EntityFactory(MetaData metadata, EntityInstantiator entityInstantiator) {
         this.metadata = metadata;
+        this.entityInstantiator = entityInstantiator;
     }
 
     /**
@@ -54,31 +57,12 @@ public class EntityFactory {
      * @throws MappingException if it's not possible to resolve or instantiate a class from the given argument
      */
     public <T> T newObject(Node nodeModel) {
-        return instantiateObjectFromTaxa(nodeModel.getLabels());
-    }
+        Map<String, Object> map = new HashMap<>();
 
-    /**
-     * Constructs a new object based on the class mapped to the type in the given {@link org.neo4j.ogm.model.Edge}.
-     *
-     * @param <T>       The class of object to return
-     * @param edgeModel The {@link org.neo4j.ogm.model.Edge} from which to determine the type
-     * @return A new instance of the class that corresponds to the relationship type, never <code>null</code>
-     * @throws MappingException if it's not possible to resolve or instantiate a class from the given argument
-     */
-    public <T> T newObject(Edge edgeModel) {
-        return instantiateObjectFromTaxa(edgeModel.getType());
-    }
-
-    /**
-     * Constructs a new object based on the {@link ClassInfo}.
-     *
-     * @param <T>       The class of object to return
-     * @param classInfo The {@link ClassInfo} from which to determine the type
-     * @return A new instance of the class that corresponds to the classinfo type, never <code>null</code>
-     * @throws MappingException if it's not possible to resolve or instantiate a class from the given argument
-     */
-    public <T> T newObject(ClassInfo classInfo) {
-        return (T) instantiate(classInfo.getUnderlyingClass());
+        for (Property<String, Object> property : nodeModel.getPropertyList()) {
+            map.put(property.getKey(), property.getValue());
+        }
+        return instantiateObjectFromTaxa(nodeModel.getLabels(), map);
     }
 
     /**
@@ -89,11 +73,11 @@ public class EntityFactory {
      * @return A new instance of the specified {@link Class}
      * @throws MappingException if it's not possible to instantiate the given class for any reason
      */
-    public <T> T newObject(Class<T> clarse) {
-        return instantiate(clarse);
+    public <T> T newObject(Class<T> clarse, Map<String, Object> map) {
+        return instantiate(clarse, map);
     }
 
-    private <T> T instantiateObjectFromTaxa(String... taxa) {
+    private <T> T instantiateObjectFromTaxa(String[] taxa, Map<String, Object> propertyValues) {
         if (taxa == null || taxa.length == 0) {
             throw new BaseClassNotFoundException("<null>");
         }
@@ -102,7 +86,7 @@ public class EntityFactory {
 
         @SuppressWarnings("unchecked")
         Class<T> loadedClass = (Class<T>) metadata.classInfo(fqn).getUnderlyingClass();
-        return instantiate(loadedClass);
+        return instantiate(loadedClass, propertyValues);
     }
 
     private String resolve(String... taxa) {
@@ -120,13 +104,7 @@ public class EntityFactory {
         return fqn;
     }
 
-    private static <T> T instantiate(Class<T> loadedClass) {
-        try {
-            Constructor<T> defaultConstructor = loadedClass.getDeclaredConstructor();
-            defaultConstructor.setAccessible(true);
-            return defaultConstructor.newInstance();
-        } catch (SecurityException | IllegalArgumentException | ReflectiveOperationException e) {
-            throw new MappingException("Unable to instantiate " + loadedClass, e);
-        }
+    private <T> T instantiate(Class<T> loadedClass, Map<String, Object> propertyValues) {
+        return entityInstantiator.createInstance(loadedClass, propertyValues);
     }
 }

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityFactory.java
@@ -27,6 +27,7 @@ import org.neo4j.ogm.session.EntityInstantiator;
  * A metadata-driven factory class for creating node and relationship entities.
  *
  * @author Adam George
+ * @author Nicolas Mervaillie
  */
 public class EntityFactory {
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/ReflectionEntityInstantiator.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/ReflectionEntityInstantiator.java
@@ -17,12 +17,16 @@ import java.lang.reflect.Constructor;
 import java.util.Map;
 
 import org.neo4j.ogm.exception.core.MappingException;
+import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.session.EntityInstantiator;
 
 /**
  * Simple instantiator that uses the no-arg constructor, without using property values.
  */
 public class ReflectionEntityInstantiator implements EntityInstantiator {
+
+    public ReflectionEntityInstantiator(MetaData metadata) {
+    }
 
     /**
      * {@inheritDoc}

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/ReflectionEntityInstantiator.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/ReflectionEntityInstantiator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.metadata.reflect;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import org.neo4j.ogm.exception.core.MappingException;
+import org.neo4j.ogm.session.EntityInstantiator;
+
+/**
+ * Simple instantiator that uses the no-arg constructor, without using property values.
+ */
+public class ReflectionEntityInstantiator implements EntityInstantiator {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T createInstance(Class<T> clazz, Map<String, Object> propertyValues) {
+        try {
+            Constructor<T> defaultConstructor = clazz.getDeclaredConstructor();
+            defaultConstructor.setAccessible(true);
+            return defaultConstructor.newInstance();
+        } catch (SecurityException | IllegalArgumentException | ReflectiveOperationException e) {
+            throw new MappingException("Unable to find default constructor to instantiate " + clazz, e);
+        }
+    }
+}

--- a/core/src/main/java/org/neo4j/ogm/session/EntityInstantiator.java
+++ b/core/src/main/java/org/neo4j/ogm/session/EntityInstantiator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.session;
+
+import java.util.Map;
+
+/**
+ * Interface to be implemented to override entity instances creation.
+ * This is mainly designed for SDN, Spring data commons having some infrastructure code to do fancy
+ * object instantiation using persistence constructors and ASM low level bytecode generation.
+ */
+public interface EntityInstantiator {
+
+    /**
+     * Creates an instance of a given class.
+     *
+     * @param clazz          The class to materialize.
+     * @param propertyValues Properties of the object (needed for constructors with args)
+     * @param <T>            Type to create
+     * @return The created instance.
+     */
+    <T> T createInstance(Class<T> clazz, Map<String, Object> propertyValues);
+}

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -100,7 +100,7 @@ public class Neo4jSession implements Session {
         this.mappingContext = new MappingContext(metaData);
         this.txManager = new DefaultTransactionManager(this, driver);
         this.loadStrategy = LoadStrategy.PATH_LOAD_STRATEGY;
-        this.entityInstantiator = new ReflectionEntityInstantiator();
+        this.entityInstantiator = new ReflectionEntityInstantiator(metaData);
     }
 
     public Neo4jSession(MetaData metaData, Driver driver, List<EventListener> eventListeners,

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -36,6 +36,7 @@ import org.neo4j.ogm.metadata.AnnotationInfo;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.metadata.MetaData;
+import org.neo4j.ogm.metadata.reflect.ReflectionEntityInstantiator;
 import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.request.Request;
 import org.neo4j.ogm.session.delegates.DeleteDelegate;
@@ -84,6 +85,7 @@ public class Neo4jSession implements Session {
     private final GraphIdDelegate graphIdDelegate = new GraphIdDelegate(this);
 
     private LoadStrategy loadStrategy;
+    private EntityInstantiator entityInstantiator;
 
     private Driver driver;
     private String bookmark;
@@ -98,14 +100,16 @@ public class Neo4jSession implements Session {
         this.mappingContext = new MappingContext(metaData);
         this.txManager = new DefaultTransactionManager(this, driver);
         this.loadStrategy = LoadStrategy.PATH_LOAD_STRATEGY;
+        this.entityInstantiator = new ReflectionEntityInstantiator();
     }
 
     public Neo4jSession(MetaData metaData, Driver driver, List<EventListener> eventListeners,
-        LoadStrategy loadStrategy) {
+        LoadStrategy loadStrategy, EntityInstantiator entityInstantiator) {
         this(metaData, driver);
         registeredEventListeners.addAll(eventListeners);
 
         this.loadStrategy = loadStrategy;
+        this.entityInstantiator = entityInstantiator;
     }
 
     @Override
@@ -655,6 +659,10 @@ public class Neo4jSession implements Session {
     @Override
     public LoadStrategy getLoadStrategy() {
         return loadStrategy;
+    }
+
+    public EntityInstantiator getEntityInstantiator() {
+        return entityInstantiator;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -25,6 +25,7 @@ import org.neo4j.ogm.exception.core.ConfigurationException;
 import org.neo4j.ogm.id.IdStrategy;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.MetaData;
+import org.neo4j.ogm.metadata.reflect.ReflectionEntityInstantiator;
 import org.neo4j.ogm.session.event.EventListener;
 
 /**
@@ -43,6 +44,7 @@ public class SessionFactory {
     private final List<EventListener> eventListeners;
 
     private LoadStrategy loadStrategy = LoadStrategy.SCHEMA_LOAD_STRATEGY;
+    private EntityInstantiator entityInstantiator;
 
     /**
      * Constructs a new {@link SessionFactory} by initialising the object-graph mapping meta-data from the given list of domain
@@ -81,6 +83,7 @@ public class SessionFactory {
         AutoIndexManager autoIndexManager = new AutoIndexManager(this.metaData, driver, configuration);
         autoIndexManager.build();
         this.eventListeners = new CopyOnWriteArrayList<>();
+        this.entityInstantiator = new ReflectionEntityInstantiator();
     }
 
     private Driver newDriverInstance(String driverClassName) {
@@ -103,6 +106,7 @@ public class SessionFactory {
         this.metaData = new MetaData(packages);
         this.driver = driver;
         this.eventListeners = new CopyOnWriteArrayList<>();
+        this.entityInstantiator = new ReflectionEntityInstantiator();
     }
 
     /**
@@ -122,7 +126,7 @@ public class SessionFactory {
      * @return A new {@link Session}
      */
     public Session openSession() {
-        return new Neo4jSession(metaData, driver, eventListeners, loadStrategy);
+        return new Neo4jSession(metaData, driver, eventListeners, loadStrategy, entityInstantiator);
     }
 
     /**
@@ -164,6 +168,10 @@ public class SessionFactory {
      */
     public void setLoadStrategy(LoadStrategy loadStrategy) {
         this.loadStrategy = loadStrategy;
+    }
+
+    public void setEntityInstantiator(EntityInstantiator entityInstantiator) {
+        this.entityInstantiator = entityInstantiator;
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -83,7 +83,7 @@ public class SessionFactory {
         AutoIndexManager autoIndexManager = new AutoIndexManager(this.metaData, driver, configuration);
         autoIndexManager.build();
         this.eventListeners = new CopyOnWriteArrayList<>();
-        this.entityInstantiator = new ReflectionEntityInstantiator();
+        this.entityInstantiator = new ReflectionEntityInstantiator(metaData);
     }
 
     private Driver newDriverInstance(String driverClassName) {
@@ -106,7 +106,7 @@ public class SessionFactory {
         this.metaData = new MetaData(packages);
         this.driver = driver;
         this.eventListeners = new CopyOnWriteArrayList<>();
-        this.entityInstantiator = new ReflectionEntityInstantiator();
+        this.entityInstantiator = new ReflectionEntityInstantiator(metaData);
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -94,7 +94,8 @@ public class ExecuteQueriesDelegate {
         validateQuery(cypher, parameters, readOnly);
 
         RestModelRequest request = new DefaultRestModelRequest(cypher, parameters);
-        ResponseMapper mapper = new RestModelMapper(new GraphEntityMapper(session.metaData(), session.context()),
+        ResponseMapper mapper = new RestModelMapper(new GraphEntityMapper(session.metaData(), session.context()
+            , session.getEntityInstantiator()),
             session.metaData());
 
         try (Response<RestModel> response = session.requestHandler().execute(request)) {
@@ -115,7 +116,8 @@ public class ExecuteQueriesDelegate {
         if (type != null && session.metaData().classInfo(type.getSimpleName()) != null) {
             GraphModelRequest request = new DefaultGraphModelRequest(cypher, parameters);
             try (Response<GraphModel> response = session.requestHandler().execute(request)) {
-                return new GraphEntityMapper(session.metaData(), session.context()).map(type, response);
+                return new GraphEntityMapper(session.metaData(), session.context()
+                    , session.getEntityInstantiator()).map(type, response);
             }
         } else {
             RowModelRequest request = new DefaultRowModelRequest(cypher, parameters);

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
@@ -65,7 +65,8 @@ public class LoadByIdsDelegate {
 
         GraphModelRequest request = new DefaultGraphModelRequest(qry.getStatement(), qry.getParameters());
         try (Response<GraphModel> response = session.requestHandler().execute(request)) {
-            Iterable<T> mapped = new GraphEntityMapper(session.metaData(), session.context()).map(type, response);
+            Iterable<T> mapped = new GraphEntityMapper(session.metaData(), session.context(),
+                session.getEntityInstantiator()).map(type, response);
 
             if (sortOrder.sortClauses().isEmpty()) {
                 return sortResultsByIds(type, ids, mapped);

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
@@ -74,13 +74,15 @@ public class LoadByTypeDelegate {
             DefaultGraphRowListModelRequest graphRowListModelRequest = new DefaultGraphRowListModelRequest(
                 query.getStatement(), query.getParameters());
             try (Response<GraphRowListModel> response = session.requestHandler().execute(graphRowListModelRequest)) {
-                return (Collection<T>) new GraphRowListModelMapper(session.metaData(), session.context())
+                return (Collection<T>) new GraphRowListModelMapper(session.metaData(), session.context(),
+                    session.getEntityInstantiator())
                     .map(type, response);
             }
         } else {
             GraphModelRequest request = new DefaultGraphModelRequest(query.getStatement(), query.getParameters());
             try (Response<GraphModel> response = session.requestHandler().execute(request)) {
-                return (Collection<T>) new GraphEntityMapper(session.metaData(), session.context()).map(type, response);
+                return (Collection<T>) new GraphEntityMapper(session.metaData(), session.context()
+                    , session.getEntityInstantiator()).map(type, response);
             }
         }
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -74,7 +74,8 @@ public class LoadOneDelegate {
 
         GraphModelRequest request = new DefaultGraphModelRequest(qry.getStatement(), qry.getParameters());
         try (Response<GraphModel> response = session.requestHandler().execute(request)) {
-            new GraphEntityMapper(session.metaData(), session.context()).map(type, response);
+            new GraphEntityMapper(session.metaData(), session.context(), session.getEntityInstantiator())
+                .map(type, response);
             return lookup(type, id);
         }
     }

--- a/test/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
+++ b/test/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
@@ -39,10 +39,10 @@ public class SingleUseEntityMapperTest {
     //	}
 
     @Test
-    public void shouldMapFromMap() throws Exception {
+    public void shouldMapFromMap() {
 
         Collection<Object> toReturn = new ArrayList<>();
-        SingleUseEntityMapper entityMapper = new SingleUseEntityMapper(metaData, new ReflectionEntityInstantiator());
+        SingleUseEntityMapper entityMapper = new SingleUseEntityMapper(metaData, new ReflectionEntityInstantiator(metaData));
 
         Iterable<Map<String, Object>> results = getQueryResults();
 

--- a/test/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
+++ b/test/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.neo4j.ogm.metadata.MetaData;
-import org.neo4j.ogm.metadata.reflect.EntityFactory;
+import org.neo4j.ogm.metadata.reflect.ReflectionEntityInstantiator;
 
 /**
  * TODO: This test doesn't assert anything.
@@ -42,7 +42,7 @@ public class SingleUseEntityMapperTest {
     public void shouldMapFromMap() throws Exception {
 
         Collection<Object> toReturn = new ArrayList<>();
-        SingleUseEntityMapper entityMapper = new SingleUseEntityMapper(metaData, new EntityFactory(metaData));
+        SingleUseEntityMapper entityMapper = new SingleUseEntityMapper(metaData, new ReflectionEntityInstantiator());
 
         Iterable<Map<String, Object>> results = getQueryResults();
 

--- a/test/src/test/java/org/neo4j/ogm/metadata/reflect/EntityFactoryTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/reflect/EntityFactoryTest.java
@@ -15,14 +15,14 @@ package org.neo4j.ogm.metadata.reflect;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.HashMap;
+
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.ogm.domain.canonical.ArbitraryRelationshipEntity;
 import org.neo4j.ogm.domain.social.Individual;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.response.model.NodeModel;
-import org.neo4j.ogm.response.model.RelationshipModel;
 
 /**
  * @author Adam George
@@ -34,16 +34,12 @@ public class EntityFactoryTest {
     @Before
     public void setUp() {
         this.entityFactory = new EntityFactory(
-            new MetaData("org.neo4j.ogm.domain.social", "org.neo4j.ogm.domain.canonical"));
+            new MetaData("org.neo4j.ogm.domain.social", "org.neo4j.ogm.domain.canonical"),
+            new ReflectionEntityInstantiator());
     }
 
     @Test
     public void shouldConstructObjectOfParticularTypeUsingItsDefaultZeroArgConstructor() {
-        RelationshipModel personRelationshipModel = new RelationshipModel();
-        personRelationshipModel.setType("MEMBER_OF");
-        ArbitraryRelationshipEntity gary = this.entityFactory.newObject(personRelationshipModel);
-        assertThat(gary).isNotNull();
-
         NodeModel personNodeModel = new NodeModel();
         personNodeModel.setLabels(new String[] { "Individual" });
         Individual sheila = this.entityFactory.newObject(personNodeModel);
@@ -56,14 +52,6 @@ public class EntityFactoryTest {
         personNodeModel.setLabels(new String[] { "Female", "Individual", "Lass" });
         Individual ourLass = this.entityFactory.newObject(personNodeModel);
         assertThat(ourLass).isNotNull();
-    }
-
-    @Test(expected = MappingException.class)
-    public void shouldFailIfZeroArgConstructorIsNotPresent() {
-        RelationshipModel edge = new RelationshipModel();
-        edge.setId(49L);
-        edge.setType("ClassWithoutZeroArgumentConstructor");
-        this.entityFactory.newObject(edge);
     }
 
     @Test
@@ -84,7 +72,7 @@ public class EntityFactoryTest {
 
     @Test
     public void shouldConstructObjectIfExplicitlyGivenClassToInstantiate() {
-        Individual instance = this.entityFactory.newObject(Individual.class);
+        Individual instance = this.entityFactory.newObject(Individual.class, new HashMap<>());
         assertThat(instance).as("The resultant instance shouldn't be null").isNotNull();
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/metadata/reflect/EntityFactoryTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/reflect/EntityFactoryTest.java
@@ -33,9 +33,8 @@ public class EntityFactoryTest {
 
     @Before
     public void setUp() {
-        this.entityFactory = new EntityFactory(
-            new MetaData("org.neo4j.ogm.domain.social", "org.neo4j.ogm.domain.canonical"),
-            new ReflectionEntityInstantiator());
+        MetaData metadata = new MetaData("org.neo4j.ogm.domain.social", "org.neo4j.ogm.domain.canonical");
+        this.entityFactory = new EntityFactory(metadata, new ReflectionEntityInstantiator(metadata));
     }
 
     @Test

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
@@ -367,7 +367,7 @@ public class PizzaIntegrationTest extends MultiDriverTestClass {
         try {
             session.load(Pizza.class, pizza.getId());
         } catch (MappingException e) {
-            assertThat(e.getCause().getMessage())
+            assertThat(e.getMessage())
                 .isEqualTo("Multiple classes found in type hierarchy that map to: [Pizza, Studio]");
         }
     }


### PR DESCRIPTION
## Description

These changes make support persistence constructors possible in SDN.

It introduces a pluggable instantiation mechanism, so that SDN entity instantiators from SDN can be used in OGM.
It also passes node and rel attributes to the instantiation mechanism so they can be passed as constructor arguments.

There are no specific tests for this because OGM by itself has no support (yet) to instantiate through constructors ; it is a spring data commons feature. Additional tests are made in SDN to check behavior.

## Related Issue

#448 
https://jira.spring.io/browse/DATAGRAPH-1056
