### PR TITLE
Fix for #461 for 2.1.x branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.1.6-SNAPSHOT
+o Use all static labels from hierarchy for load/query/delete statements,  #461
+
 2.1.5
 --------------
 o Expose connection.liveness.check.timeout driver property to fix connection problems with firewalls. See #358.

--- a/core/src/main/java/org/neo4j/ogm/MetaData.java
+++ b/core/src/main/java/org/neo4j/ogm/MetaData.java
@@ -16,6 +16,7 @@ package org.neo4j.ogm;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -214,6 +214,17 @@ public class ClassInfo {
         return collectLabels(new ArrayList<String>());
     }
 
+    public Collection<String> types() {
+        Collection<String> types = staticLabels();
+        if (types.isEmpty()) {
+
+            // this is a weird corner case where we query by non annotated abstract class / interface
+            types.add(neo4jName());
+        }
+        return types;
+    }
+
+
     public String neo4jName() {
         if (neo4jName == null) {
             try {

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
@@ -12,13 +12,11 @@
  */
 package org.neo4j.ogm.session.delegates;
 
-import java.lang.reflect.Field;
 import java.util.*;
 
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.query.CypherQuery;
 import org.neo4j.ogm.cypher.query.DefaultRowModelRequest;
-import org.neo4j.ogm.entity.io.FieldWriter;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.model.RowModel;
@@ -141,7 +139,7 @@ public class DeleteDelegate implements Capability.Delete {
     public <T> void deleteAll(Class<T> type) {
         ClassInfo classInfo = session.metaData().classInfo(type.getName());
         if (classInfo != null) {
-            Statement request = getDeleteStatementsBasedOnType(type).delete(session.entityType(classInfo.name()));
+            Statement request = getDeleteStatementsBasedOnType(type).deleteAllByType(classInfo.types());
             RowModelRequest query = new DefaultRowModelRequest(request.getStatement(), request.getParameters());
             session.notifyListeners(new PersistenceEvent(type, Event.TYPE.PRE_DELETE));
             try (Response<RowModel> response = session.requestHandler().execute(query)) {
@@ -169,7 +167,7 @@ public class DeleteDelegate implements Capability.Delete {
             if (classInfo.isRelationshipEntity()) {
                 query = new RelationshipDeleteStatements().deleteAndList(classInfo.neo4jName(), filters);
             } else {
-                query = new NodeDeleteStatements().deleteAndList(classInfo.neo4jName(), filters);
+                query = new NodeDeleteStatements().deleteAndList(classInfo.types(), filters);
             }
 
             if (listResults) {

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -156,8 +156,7 @@ public class ExecuteQueriesDelegate implements Capability.ExecuteQueries {
             String type = classInfo.neo4jName();
             countStatement = new CountStatements().countEdges(start, type, end);
         } else {
-            Collection<String> labels = classInfo.staticLabels();
-            countStatement = new CountStatements().countNodes(labels);
+            countStatement = new CountStatements().countNodes(classInfo.types());
         }
         try (Response<RowModel> response = session.requestHandler().execute((RowModelRequest) countStatement)) {
             RowModel queryResult = response.next();
@@ -179,7 +178,7 @@ public class ExecuteQueriesDelegate implements Capability.ExecuteQueries {
             if (classInfo.isRelationshipEntity()) {
                 query = new CountStatements().countEdges(classInfo.neo4jName(), filters);
             } else {
-                query = new CountStatements().countNodes(classInfo.neo4jName(), filters);
+                query = new CountStatements().countNodes(classInfo.types(), filters);
             }
             return count(query, classInfo.isRelationshipEntity());
         }

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
@@ -48,7 +48,7 @@ public class LoadByIdsDelegate implements Capability.LoadByIds {
     @Override
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, SortOrder sortOrder, Pagination pagination, int depth) {
 
-        String entityType = session.entityType(type.getName());
+        Collection<String> entityType = session.metaData().classInfo(type.getName()).types();
         QueryStatements queryStatements = session.queryStatementsFor(type);
 
         PagingAndSortingQuery qry = queryStatements.findAllByType(entityType, ids, depth)

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
@@ -49,8 +49,11 @@ public class LoadByTypeDelegate implements Capability.LoadByType {
     @Override
     public <T> Collection<T> loadAll(Class<T> type, Filters filters, SortOrder sortOrder, Pagination pagination, int depth) {
 
-        //session.ensureTransaction();
-        String entityType = session.entityType(type.getName());
+        ClassInfo classInfo = session.metaData().classInfo(type.getName());
+        if (classInfo == null) {
+            throw new IllegalArgumentException(type + " is not a managed entity.");
+        }
+
         QueryStatements queryStatements = session.queryStatementsFor(type);
 
         session.resolvePropertyAnnotations(type, sortOrder);
@@ -61,7 +64,7 @@ public class LoadByTypeDelegate implements Capability.LoadByType {
         // though they are at the moment because of the problems with "graph" response format.
         if (filters.isEmpty()) {
 
-            PagingAndSortingQuery qry = queryStatements.findByType(entityType, depth)
+            PagingAndSortingQuery qry = queryStatements.findByType(classInfo.types(), depth)
                     .setSortOrder(sortOrder)
                     .setPagination(pagination);
 
@@ -80,7 +83,7 @@ public class LoadByTypeDelegate implements Capability.LoadByType {
 
             session.resolvePropertyAnnotations(type, filters);
 
-            PagingAndSortingQuery query = queryStatements.findByType(entityType, filters, depth)
+            PagingAndSortingQuery query = queryStatements.findByType(classInfo.types(), filters, depth)
                     .setSortOrder(sortOrder)
                     .setPagination(pagination);
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -13,6 +13,7 @@
 package org.neo4j.ogm.session.delegates;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.context.GraphEntityMapper;
@@ -57,7 +58,7 @@ public class LoadOneDelegate implements Capability.LoadOne {
         }
 
         QueryStatements queryStatements = session.queryStatementsFor(type);
-        PagingAndSortingQuery qry = queryStatements.findOneByType(session.entityType(type.getName()), id,depth);
+        PagingAndSortingQuery qry = queryStatements.findOneByType(classInfo.types(), id,depth);
 
         try (Response<GraphModel> response = session.requestHandler().execute((GraphModelRequest) qry)) {
             new GraphEntityMapper(session.metaData(), session.context()).map(type, response);

--- a/core/src/main/java/org/neo4j/ogm/session/request/PrincipalNodeMatchClause.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/PrincipalNodeMatchClause.java
@@ -30,7 +30,7 @@ public class PrincipalNodeMatchClause implements MatchClause {
 		this.label = label;
 
 		clause = new StringBuilder();
-		clause.append(String.format("MATCH (n:`%s`) ", this.label));
+		clause.append(String.format("MATCH (n%s) ", this.label));
 	}
 
 	@Override

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/DeleteStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/DeleteStatements.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.query.CypherQuery;
+import org.neo4j.ogm.request.Statement;
 
 
 /**
@@ -64,6 +65,8 @@ public interface DeleteStatements {
      */
     CypherQuery delete(String type);
 
+    CypherQuery deleteAllByType(Collection<String> labels);
+
     /**
      * construct queries to delete all objects with the specified label or relationship type and return a count of deleted objects
      * @param type the label attached to the object, or the relationship type
@@ -87,6 +90,8 @@ public interface DeleteStatements {
 
     CypherQuery delete(String type, Iterable<Filter> filters);
 
+    CypherQuery delete(Collection<String> label, Iterable<Filter> filters);
+
     /**
      * construct queries to delete all objects with the specified label that match the specified filters and return a count of deleted objects
      * @param type the label value or relationship type to filter on
@@ -95,6 +100,8 @@ public interface DeleteStatements {
      */
 
     CypherQuery deleteAndCount(String type, Iterable<Filter> filters);
+
+    CypherQuery deleteAndCount(Collection<String> label, Iterable<Filter> filters);
 
     /**
      * construct queries to delete all objects with the specified label that match the specified filters and return a list of deleted object ids
@@ -105,4 +112,5 @@ public interface DeleteStatements {
 
     CypherQuery deleteAndList(String type, Iterable<Filter> filters);
 
+    CypherQuery deleteAndList(Collection<String> labels, Iterable<Filter> filters);
 }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/QueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/QueryStatements.java
@@ -45,6 +45,8 @@ public interface QueryStatements<ID extends Serializable> {
      */
     PagingAndSortingQuery findOneByType(String label, ID id, int depth);
 
+    PagingAndSortingQuery findOneByType(Collection<String> labels, ID id, int depth);
+
     /**
      * construct a query to fetch all objects
      * @return a {@link PagingAndSortingQuery}
@@ -68,6 +70,7 @@ public interface QueryStatements<ID extends Serializable> {
      */
     PagingAndSortingQuery findAllByType(String type, Collection<ID> ids, int depth);
 
+    PagingAndSortingQuery findAllByType(Collection<String> types, Collection<ID> ids, int depth);
     /**
      * construct queries to fetch all objects with the specified label or relationship type
      * @param type the label attached to the object, or the relationship type
@@ -75,6 +78,8 @@ public interface QueryStatements<ID extends Serializable> {
      * @return a {@link PagingAndSortingQuery}
      */
     PagingAndSortingQuery findByType(String type, int depth);
+
+    PagingAndSortingQuery findByType(Collection<String> type, int depth);
 
     /**
      * construct queries to fetch all objects with the specified label that match the specified filters
@@ -85,5 +90,7 @@ public interface QueryStatements<ID extends Serializable> {
      */
 
     PagingAndSortingQuery findByType(String type, Filters filters, int depth);
+
+    PagingAndSortingQuery findByType(Collection<String> type, Filters filters, int depth);
 
 }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/CountStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/CountStatements.java
@@ -14,6 +14,7 @@
 package org.neo4j.ogm.session.request.strategy.impl;
 
 
+import java.util.Collection;
 import java.util.Collections;
 
 import org.neo4j.ogm.cypher.Filter;
@@ -23,6 +24,10 @@ import org.neo4j.ogm.session.Utils;
 import org.neo4j.ogm.session.request.FilteredQuery;
 import org.neo4j.ogm.session.request.FilteredQueryBuilder;
 import org.neo4j.ogm.session.request.strategy.AggregateStatements;
+
+import static java.util.Collections.singleton;
+
+import static org.neo4j.ogm.session.request.strategy.impl.TypesUtil.labelsToType;
 
 /**
  * Encapsulates Cypher statements used to execute aggregation queries.
@@ -45,17 +50,17 @@ public class CountStatements implements AggregateStatements {
 
     @Override
     public CypherQuery countNodes(Iterable<String> labels) {
-        StringBuilder cypherLabels = new StringBuilder();
-        for (String label : labels) {
-            cypherLabels.append(":`").append(label).append('`');
-        }
-        return new DefaultRowModelRequest(String.format("MATCH (n%s) RETURN COUNT(n)", cypherLabels.toString()),
-                Collections.<String, String> emptyMap());
+        String type = labelsToType(labels);
+        return new DefaultRowModelRequest(String.format("MATCH (n%s) RETURN COUNT(n)", type), Collections.<String, String> emptyMap());
     }
 
     @Override
     public CypherQuery countNodes(String label, Iterable<Filter> filters) {
-        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(label, filters);
+        return countNodes(singleton(label), filters);
+    }
+
+    public CypherQuery countNodes(Collection<String> labels, Iterable<Filter> filters) {
+        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(labelsToType(labels), filters);
         query.setReturnClause(" RETURN COUNT(n)");
         return new DefaultRowModelRequest(query.statement(), query.parameters());
     }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeDeleteStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/NodeDeleteStatements.java
@@ -22,6 +22,10 @@ import org.neo4j.ogm.session.request.FilteredQuery;
 import org.neo4j.ogm.session.request.FilteredQueryBuilder;
 import org.neo4j.ogm.session.request.strategy.DeleteStatements;
 
+import static java.util.Collections.singleton;
+
+import static org.neo4j.ogm.session.request.strategy.impl.TypesUtil.labelsToType;
+
 /**
  * @author Luanne Misquitta
  */
@@ -55,7 +59,13 @@ public class NodeDeleteStatements implements DeleteStatements {
 
     @Override
     public CypherQuery delete(String label) {
-        return new DefaultRowModelRequest(String.format("MATCH (n:`%s`) OPTIONAL MATCH (n)-[r0]-() DELETE r0, n", label), Utils.map());
+        return deleteAllByType(singleton(label));
+    }
+
+    @Override
+    public CypherQuery deleteAllByType(Collection<String> labels) {
+        String type = labelsToType(labels);
+        return new DefaultRowModelRequest(String.format("MATCH (n%s) OPTIONAL MATCH (n)-[r0]-() DELETE r0, n", type), Utils.map());
     }
 
     @Override
@@ -70,21 +80,37 @@ public class NodeDeleteStatements implements DeleteStatements {
 
     @Override
     public CypherQuery delete(String label, Iterable<Filter> filters) {
-        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(label, filters);
+        return delete(singleton(label), filters);
+    }
+
+    @Override
+    public CypherQuery delete(Collection<String> label, Iterable<Filter> filters) {
+        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(labelsToType(label), filters);
         query.setReturnClause(" OPTIONAL MATCH (n)-[r0]-() DELETE r0, n");
         return new DefaultRowModelRequest(query.statement(), query.parameters());
     }
 
     @Override
     public CypherQuery deleteAndCount(String label, Iterable<Filter> filters) {
-        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(label, filters);
+        return deleteAndCount(singleton(label), filters);
+    }
+
+    @Override
+    public CypherQuery deleteAndCount(Collection<String> label, Iterable<Filter> filters) {
+        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(labelsToType(label), filters);
         query.setReturnClause(" OPTIONAL MATCH (n)-[r0]-() DELETE r0, n RETURN COUNT(n)");
         return new DefaultRowModelRequest(query.statement(), query.parameters());
     }
 
     @Override
     public CypherQuery deleteAndList(String label, Iterable<Filter> filters) {
-        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(label, filters);
+        return deleteAndList(singleton(label), filters);
+    }
+
+    @Override
+    public CypherQuery deleteAndList(Collection<String> labels, Iterable<Filter> filters) {
+        FilteredQuery query = FilteredQueryBuilder.buildNodeQuery(labelsToType(labels), filters);
         query.setReturnClause(" OPTIONAL MATCH (n)-[r0]-() DELETE r0, n RETURN ID(n)");
-        return new DefaultRowModelRequest(query.statement(), query.parameters());    }
+        return new DefaultRowModelRequest(query.statement(), query.parameters());
+    }
 }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipDeleteStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipDeleteStatements.java
@@ -24,6 +24,8 @@ import org.neo4j.ogm.session.request.FilteredQuery;
 import org.neo4j.ogm.session.request.FilteredQueryBuilder;
 import org.neo4j.ogm.session.request.strategy.DeleteStatements;
 
+import static org.neo4j.ogm.session.request.strategy.impl.TypesUtil.checkSingleType;
+
 /**
  * @author Luanne Misquitta
  * @author Jasper Blues
@@ -57,6 +59,12 @@ public class RelationshipDeleteStatements implements DeleteStatements {
     }
 
     @Override
+    public CypherQuery deleteAllByType(Collection<String> labels) {
+        checkSingleType(labels);
+        return delete(labels.iterator().next());
+    }
+
+    @Override
     public CypherQuery deleteAndCount(String type) {
         return new DefaultRowModelRequest(String.format("MATCH (n)-[r0:`%s`]-() DELETE r0 RETURN COUNT(r0)", type), Utils.map());
     }
@@ -74,6 +82,12 @@ public class RelationshipDeleteStatements implements DeleteStatements {
     }
 
     @Override
+    public CypherQuery delete(Collection<String> labels, Iterable<Filter> filters) {
+        checkSingleType(labels);
+        return delete(labels.iterator().next(), filters);
+    }
+
+    @Override
     public CypherQuery deleteAndCount(String type, Iterable<Filter> filters) {
         FilteredQuery query = FilteredQueryBuilder.buildRelationshipQuery(type, filters);
         query.setReturnClause(" DELETE r0 RETURN COUNT(r0)");
@@ -81,9 +95,20 @@ public class RelationshipDeleteStatements implements DeleteStatements {
     }
 
     @Override
+    public CypherQuery deleteAndCount(Collection<String> labels, Iterable<Filter> filters) {
+        checkSingleType(labels);
+        return deleteAndCount(labels.iterator().next(), filters);
+    }
+
+    @Override
     public CypherQuery deleteAndList(String type, Iterable<Filter> filters) {
         FilteredQuery query = FilteredQueryBuilder.buildRelationshipQuery(type, filters);
         query.setReturnClause(" DELETE r0 RETURN ID(r0)");
         return new DefaultRowModelRequest(query.statement(), query.parameters());
+    }
+
+    @Override
+    public CypherQuery deleteAndList(Collection<String> labels, Iterable<Filter> filters) {
+        return deleteAndList(labels.iterator().next(), filters);
     }
 }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatements.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatements.java
@@ -26,6 +26,8 @@ import org.neo4j.ogm.session.request.FilteredQuery;
 import org.neo4j.ogm.session.request.FilteredQueryBuilder;
 import org.neo4j.ogm.session.request.strategy.QueryStatements;
 
+import static org.neo4j.ogm.session.request.strategy.impl.TypesUtil.checkSingleType;
+
 /**
  * @author Luanne Misquitta
  */
@@ -137,4 +139,28 @@ public class RelationshipQueryStatements<ID extends Serializable> implements Que
     private int max(int depth) {
 		return Math.max(0, depth);
 	}
+
+    @Override
+    public PagingAndSortingQuery findOneByType(Collection<String> types, ID id, int depth) {
+        checkSingleType(types);
+        return findOneByType(types.iterator().next(), id, depth);
+    }
+
+    @Override
+    public PagingAndSortingQuery findAllByType(Collection<String> types, Collection<ID> ids, int depth) {
+        checkSingleType(types);
+        return findAllByType(types.iterator().next(), ids, depth);
+    }
+
+    @Override
+    public PagingAndSortingQuery findByType(Collection<String> types, int depth) {
+        checkSingleType(types);
+        return findByType(types.iterator().next(), depth);
+    }
+
+    @Override
+    public PagingAndSortingQuery findByType(Collection<String> types, Filters filters, int depth) {
+        checkSingleType(types);
+        return findByType(types.iterator().next(), filters, depth);
+    }
 }

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/TypesUtil.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/TypesUtil.java
@@ -1,0 +1,37 @@
+package org.neo4j.ogm.session.request.strategy.impl;
+
+import java.util.Collection;
+
+/**
+ * @author Frantisek Hartman
+ */
+class TypesUtil {
+
+    /**
+     * Concatenate and escape labels
+     * <p>
+     * For use in MATCH queries when type is needed.
+     * <p>
+     * E.g. for "[Person","Entity"] labels the result will be ":`Person`:`Entity`"
+     *
+     * @param labels labels to
+     *
+     * @return concatenated labels
+     */
+    static String labelsToType(Iterable<String> labels) {
+        StringBuilder cypherLabels = new StringBuilder();
+        for (String label : labels) {
+            cypherLabels.append(":`").append(label).append('`');
+        }
+        return cypherLabels.toString();
+    }
+
+    /**
+     * Checks that given types collection contains exactly one element, throw {@link IllegalArgumentException} if not
+     */
+    static void checkSingleType(Collection<String> types) {
+        if (types.size() != 1) {
+            throw new IllegalArgumentException("Multiple types passed where single type is expected, types=" + types);
+        }
+    }
+}

--- a/core/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -110,7 +110,7 @@ public class EntityGraphMapperTest extends MultiDriverTestClass {
     @Test
     public void updateObjectPropertyAndLabel() {
 
-        Result executionResult = getDatabase().execute("CREATE (s:Student {name:'Sheila Smythe'}) RETURN id(s) AS id");
+        Result executionResult = getDatabase().execute("CREATE (s:Student:DomainObject {name:'Sheila Smythe'}) RETURN id(s) AS id");
         Long sid = Long.valueOf(executionResult.next().get("id").toString());
 
         Student sheila = session.load(Student.class, sid);

--- a/core/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/core/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -691,56 +691,6 @@ public class ClassHierarchiesIntegrationTest extends MultiDriverTestClass {
     }
 
     @Test
-    public void shouldReadHierarchy4() {
-        getDatabase().execute("CREATE (:Female {name:'Daniela'})," +
-                "(:Male {name:'Michal'})," +
-                "(:Bloke:Male {name:'Adam'})");
-
-        Female daniela = new Female("Daniela");
-        Male michal = new Male("Michal");
-        Bloke adam = new Bloke("Adam");
-
-        Collection<Male> males = session.loadAll(Male.class);
-        Collection<Female> females = session.loadAll(Female.class);
-        Collection<Bloke> blokes = session.loadAll(Bloke.class);
-
-        assertEquals(2, males.size());
-        assertTrue(males.containsAll(Arrays.asList(michal, adam)));
-
-        assertEquals(1, females.size());
-        assertTrue(females.contains(daniela));
-
-        assertEquals(1, blokes.size());
-        assertTrue(blokes.contains(adam));
-    }
-
-    @Test
-    // the logic of this test is debatable. the domain model and persisted schema are not the same.
-    public void shouldReadHierarchy5() {
-
-        getDatabase().execute("CREATE (:Female {name:'Daniela'})," +
-                "(:Male {name:'Michal'})," +
-                "(:Bloke {name:'Adam'})");
-
-        Female daniela = new Female("Daniela");
-        Male michal = new Male("Michal");
-        Bloke adam = new Bloke("Adam");
-
-        Collection<Male> males = session.loadAll(Male.class);
-        Collection<Female> females = session.loadAll(Female.class);
-        Collection<Bloke> blokes = session.loadAll(Bloke.class);
-
-        assertEquals(1, males.size());
-        assertTrue(males.containsAll(Arrays.asList(michal)));
-
-        assertEquals(1, females.size());
-        assertTrue(females.contains(daniela));
-
-        assertEquals(1, blokes.size());
-        assertTrue(blokes.contains(adam));
-    }
-
-    @Test
     public void shouldNotReadHierarchy() {
         getDatabase().execute("CREATE (:Person {name:'Daniela'})");
         assertEquals(0, session.loadAll(Person.class).size());

--- a/core/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/core/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -55,7 +55,7 @@ public class NodeQueryStatementsTest {
 
 		// Also assert that an empty label is the same as using the typeless variant
 		assertEquals(queryStatements.findOneByType("", 0L, 2).getStatement(), queryStatements.findOne(0L, 2).getStatement());
-		assertEquals(queryStatements.findOneByType(null, 0L, 2).getStatement(), queryStatements.findOne(0L, 2).getStatement());
+		assertEquals(queryStatements.findOneByType((String) null, 0L, 2).getStatement(), queryStatements.findOne(0L, 2).getStatement());
 	}
 
 	@Test

--- a/core/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
+++ b/core/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
@@ -57,7 +57,7 @@ public class RelationshipQueryStatementsTest {
         // Also assert that an empty type is the same as the untyped findOne(..)
         assertEquals(query.findOneByType("", 0L, 2).getStatement(),
                 query.findOne(0L, 2).getStatement());
-        assertEquals(query.findOneByType(null, 0L, 2).getStatement(),
+        assertEquals(query.findOneByType((String) null, 0L, 2).getStatement(),
                 query.findOne(0L, 2).getStatement());
     }
 


### PR DESCRIPTION
Fix for #461.

Uses `ClassInfo#staticLabels` in MATCH clauses for nodes.

This ended up much larger than I thought it would be. If you come up with simpler way of doing this feel free to suggest.

The most problematic part was passing multiple labels to `*QueryStatements`, there were 3 options:
1. change String to Collection<String> - this would change *a lot of* tests, also unrelated ones
1. pass full type information through current `String label` (e.g. ``:`Person`:`Entity```) Again this would mean changing all tests
1. Overload methods and call them only when needed - this is what I went with.

There are some subtle changes in behaviour - see changes in `ClassHierarchiesIntegrationTest`. I think they are acceptable.

The fix is for 2.1.x only. The code around `*QueryStatements` has diverged significantly in 3.x. Will submit different PR for that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
