### PR TITLE
Issue #467: @Id does not work with @Convert

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -170,7 +170,7 @@ public class MappingContext {
 
         ClassInfo classInfo = metaData.classInfo(entity);
         if (classInfo.hasPrimaryIndexField()) {
-            LabelPrimaryId key = new LabelPrimaryId(classInfo, classInfo.primaryIndexField().readProperty(entity));
+            LabelPrimaryId key = new LabelPrimaryId(classInfo, classInfo.primaryIndexField().read(entity));
             primaryIdToNativeId.put(key, identity);
         }
 
@@ -262,6 +262,18 @@ public class MappingContext {
 
     public Object getRelationshipEntity(Long relationshipId) {
         return relationshipEntityRegister.get(relationshipId);
+    }
+
+    /**
+     * Check if the context contains the nativeId for an entity
+     *
+     * @param classInfo classInfo of the relationship entity (it is needed to because primary id may not be unique
+     *                  across all relationship types)
+     * @param id        primary id of the entity
+     * @return True if nativeId is already in the context
+     */
+    boolean containsNativeId(ClassInfo classInfo, Object id) {
+        return primaryIdToNativeId.containsKey(new LabelPrimaryId(classInfo, id)) ;
     }
 
     /**
@@ -495,7 +507,7 @@ public class MappingContext {
             return EntityUtils.identity(entity, metaData);
         } else {
             FieldInfo fieldInfo = classInfo.primaryIndexField();
-            Object primaryId = fieldInfo.readProperty(entity);
+            Object primaryId = fieldInfo.read(entity);
 
             if (primaryId == null) {
                 throw new MappingException("Field with primary id is null for entity " + entity);

--- a/test/src/test/java/org/neo4j/ogm/domain/annotations/ids/ValidAnnotations.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/annotations/ids/ValidAnnotations.java
@@ -60,6 +60,12 @@ public class ValidAnnotations {
         public UUID identifier;
     }
 
+    public static class UuidAndGenerationType {
+        @Id @GeneratedValue(strategy = UuidStrategy.class)
+        @Convert(UuidStringConverter.class)
+        public UUID identifier;
+    }
+
     public static class BasicChild extends Basic {
     }
 


### PR DESCRIPTION
Fix for #467 

## Description
- Normalizing `MappingContext` to use `FieldInfo.read` every time it creates
a `LabelPrimaryId`
- Adding tests to reproduce the problem that this issue causes and
validate the changes

## Related Issue
Issue #467 

## Motivation and Context
This is required so `MappingContext` always instantiate a consistent `LabelPrimaryId` skipping conversions, this will prevent misses when converting from primary IDs to native IDs that leads to errors when creating nodes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Two unit tests were created to reproduce the problem and validate the change. See `MappingContextTest`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
