### PR TITLE
Fix of issue #486

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/query/SortClause.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/SortClause.java
@@ -13,6 +13,8 @@
 
 package org.neo4j.ogm.cypher.query;
 
+import java.lang.invoke.SwitchPoint;
+
 /**
  * @author Luanne Misquitta
  */
@@ -20,6 +22,7 @@ public class SortClause {
 
     private final SortOrder.Direction direction;
     private final String[] properties;
+    public final SwitchPoint alreadyEscaped = new SwitchPoint();
 
     public SortClause(SortOrder.Direction direction, String... properties) {
         this.direction = direction;

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -16,6 +16,7 @@ package org.neo4j.ogm.session;
 import static java.util.Collections.*;
 
 import java.io.Serializable;
+import java.lang.invoke.SwitchPoint;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -683,6 +684,7 @@ public class Neo4jSession implements Session {
                     for (int i = 0; i < sortClause.getProperties().length; i++) {
                         sortClause.getProperties()[i] = String
                             .format(escapedProperty, resolvePropertyName(entityType, sortClause.getProperties()[i]));
+                        SwitchPoint.invalidateAll(new SwitchPoint[]{sortClause.alreadyEscaped});
                     }
             }
         }

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -110,7 +110,7 @@ public class Neo4jSession implements Session {
     }
 
     public Neo4jSession(MetaData metaData, Driver driver, List<EventListener> eventListeners,
-        LoadStrategy loadStrategy, EntityInstantiator entityInstantiator) {
+                        LoadStrategy loadStrategy, EntityInstantiator entityInstantiator) {
         this(metaData, driver);
         registeredEventListeners.addAll(eventListeners);
 
@@ -260,7 +260,7 @@ public class Neo4jSession implements Session {
 
     @Override
     public <T> Collection<T> loadAll(Class<T> type, Filter filter, SortOrder sortOrder, Pagination pagination,
-        int depth) {
+                                     int depth) {
         return loadByTypeHandler.loadAll(type, filter, sortOrder, pagination, depth);
     }
 
@@ -301,7 +301,7 @@ public class Neo4jSession implements Session {
 
     @Override
     public <T> Collection<T> loadAll(Class<T> type, Filters filters, SortOrder sortOrder, Pagination pagination,
-        int depth) {
+                                     int depth) {
         return loadByTypeHandler.loadAll(type, filters, sortOrder, pagination, depth);
     }
 
@@ -327,7 +327,7 @@ public class Neo4jSession implements Session {
 
     @Override
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, SortOrder sortOrder,
-        int depth) {
+                                                              int depth) {
         return loadByIdsHandler.loadAll(type, ids, sortOrder, depth);
     }
 
@@ -338,19 +338,19 @@ public class Neo4jSession implements Session {
 
     @Override
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, Pagination paging,
-        int depth) {
+                                                              int depth) {
         return loadByIdsHandler.loadAll(type, ids, paging, depth);
     }
 
     @Override
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, SortOrder sortOrder,
-        Pagination pagination) {
+                                                              Pagination pagination) {
         return loadByIdsHandler.loadAll(type, ids, sortOrder, pagination);
     }
 
     @Override
     public <T, ID extends Serializable> Collection<T> loadAll(Class<T> type, Collection<ID> ids, SortOrder sortOrder,
-        Pagination pagination, int depth) {
+                                                              Pagination pagination, int depth) {
         return loadByIdsHandler.loadAll(type, ids, sortOrder, pagination, depth);
     }
 
@@ -400,10 +400,10 @@ public class Neo4jSession implements Session {
     }
 
     /*
-    *----------------------------------------------------------------------------------------------------------
-    * ExecuteQueriesDelegate
-    *----------------------------------------------------------------------------------------------------------
-    */
+     *----------------------------------------------------------------------------------------------------------
+     * ExecuteQueriesDelegate
+     *----------------------------------------------------------------------------------------------------------
+     */
     @Override
     public <T> T queryForObject(Class<T> type, String cypher, Map<String, ?> parameters) {
         return executeQueriesDelegate.queryForObject(type, cypher, parameters);
@@ -435,10 +435,10 @@ public class Neo4jSession implements Session {
     }
 
     /*
-    *----------------------------------------------------------------------------------------------------------
-    * DeleteDelegate
-    *----------------------------------------------------------------------------------------------------------
-    */
+     *----------------------------------------------------------------------------------------------------------
+     * DeleteDelegate
+     *----------------------------------------------------------------------------------------------------------
+     */
     @Override
     public void purgeDatabase() {
         deleteDelegate.purgeDatabase();
@@ -460,10 +460,10 @@ public class Neo4jSession implements Session {
     }
 
     /*
-    *----------------------------------------------------------------------------------------------------------
-    * SaveDelegate
-    *----------------------------------------------------------------------------------------------------------
-    */
+     *----------------------------------------------------------------------------------------------------------
+     * SaveDelegate
+     *----------------------------------------------------------------------------------------------------------
+     */
     @Override
     public <T> void save(T object) {
         saveDelegate.save(object);
@@ -475,10 +475,10 @@ public class Neo4jSession implements Session {
     }
 
     /*
-    *----------------------------------------------------------------------------------------------------------
-    * TransactionsDelegate
-    *----------------------------------------------------------------------------------------------------------
-    */
+     *----------------------------------------------------------------------------------------------------------
+     * TransactionsDelegate
+     *----------------------------------------------------------------------------------------------------------
+     */
     @Override
     public Transaction beginTransaction() {
         return txManager.openTransaction();
@@ -501,19 +501,19 @@ public class Neo4jSession implements Session {
     }
 
     /**
-     * @see Neo4jSession#doInTransaction(TransactionalUnitOfWork, org.neo4j.ogm.transaction.Transaction.Type)
      * @param function The code to execute.
-     * @param txType Transaction type, readonly or not.
+     * @param txType   Transaction type, readonly or not.
+     * @see Neo4jSession#doInTransaction(TransactionalUnitOfWork, org.neo4j.ogm.transaction.Transaction.Type)
      */
     public void doInTransaction(TransactionalUnitOfWorkWithoutResult function, Transaction.Type txType) {
-        doInTransaction( () -> {
+        doInTransaction(() -> {
             function.doInTransaction();
             return null;
         }, txType);
     }
 
     public void doInTransaction(TransactionalUnitOfWorkWithoutResult function, boolean forceTx, Transaction.Type txType) {
-        doInTransaction( () -> {
+        doInTransaction(() -> {
             function.doInTransaction();
             return null;
         }, forceTx, txType);
@@ -527,9 +527,10 @@ public class Neo4jSession implements Session {
      * For internal use only. Opens a new transaction if necessary before running statements
      * in case an explicit transaction does not exist. It is designed to be the central point
      * for handling exceptions coming from the DB and apply commit / rollback rules.
+     *
      * @param function The callback to execute.
-     * @param <T> The result type.
-     * @param txType Transaction type, readonly or not.
+     * @param <T>      The result type.
+     * @param txType   Transaction type, readonly or not.
      * @return The result of the transaction function.
      */
     public <T> T doInTransaction(TransactionalUnitOfWork<T> function, boolean forceTx, Transaction.Type txType) {
@@ -554,7 +555,7 @@ public class Neo4jSession implements Session {
             throw e;
         } catch (Throwable e) {
             logger.warn("Error executing query : {}. Rolling back transaction.", e.getMessage());
-            if(transactionManager().canRollback()) {
+            if (transactionManager().canRollback()) {
                 transaction.rollback();
             }
             throw e;
@@ -574,7 +575,7 @@ public class Neo4jSession implements Session {
      *----------------------------------------------------------------------------------------------------------
      * GraphIdDelegate
      *----------------------------------------------------------------------------------------------------------
-    */
+     */
     @Override
     public Long resolveGraphIdFor(Object possibleEntity) {
         return graphIdDelegate.resolveGraphIdFor(possibleEntity);
@@ -678,10 +679,11 @@ public class Neo4jSession implements Session {
 
         if (sortOrder != null) {
             for (SortClause sortClause : sortOrder.sortClauses()) {
-                for (int i = 0; i < sortClause.getProperties().length; i++) {
-                    sortClause.getProperties()[i] = String
-                        .format(escapedProperty, resolvePropertyName(entityType, sortClause.getProperties()[i]));
-                }
+                if (!sortClause.alreadyEscaped.hasBeenInvalidated())
+                    for (int i = 0; i < sortClause.getProperties().length; i++) {
+                        sortClause.getProperties()[i] = String
+                            .format(escapedProperty, resolvePropertyName(entityType, sortClause.getProperties()[i]));
+                    }
             }
         }
     }


### PR DESCRIPTION
Added a non reversible flag to SortClause to avoid more escaping 

## Description
A `SwitchPoint` was added to prevent multiple properties escaping. It is invalidated after each clause escaping.

## Related Issue
#486 - SortOrder escaping bug

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
