### PR TITLE
#488 - Cannot update labels if entity is loaded in a new session

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
+++ b/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
@@ -13,9 +13,11 @@
 
 package org.neo4j.ogm.context;
 
-import static java.util.Objects.*;
-
 import org.neo4j.ogm.metadata.ClassInfo;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Pair of label and primary id to use for lookups by primary key in MappingContext and CypherContext
@@ -33,11 +35,11 @@ class LabelPrimaryId {
     /**
      * Create LabelPrimaryId
      *
-     * @param classInfo class info containign the primary id
+     * @param classInfo class info containing the primary id
      * @param id        the value of the id
      */
     public LabelPrimaryId(ClassInfo classInfo, Object id) {
-        this.label = classInfo.primaryIndexField().containingClassInfo().neo4jName();
+        this.label = classInfo.neo4jName();
         this.id = requireNonNull(id);
     }
 
@@ -49,32 +51,22 @@ class LabelPrimaryId {
         return id;
     }
 
+
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         LabelPrimaryId that = (LabelPrimaryId) o;
-
-        if (!label.equals(that.label))
-            return false;
-        return id.equals(that.id);
+        return Objects.equals(label, that.label) && Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        int result = label.hashCode();
-        result = 31 * result + id.hashCode();
-        return result;
+        return Objects.hash(label, id);
     }
 
     @Override
     public String toString() {
-        return "LabelPrimaryId{" +
-            "label='" + label + '\'' +
-            ", id=" + id +
-            '}';
+        return String.format("LabelPrimaryId{label='%s', id=%s}", label, id);
     }
 }

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -13,22 +13,6 @@
 
 package org.neo4j.ogm.metadata;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import org.neo4j.ogm.annotation.*;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.exception.core.MetadataException;
@@ -38,6 +22,14 @@ import org.neo4j.ogm.id.UuidStrategy;
 import org.neo4j.ogm.utils.ClassUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Maintains object to graph mapping details at the class (type) level
@@ -543,7 +535,7 @@ public class ClassInfo {
      * @return Set of  FieldInfo objects describing the required relationship field, or empty set if it doesn't exist.
      */
     public Set<FieldInfo> candidateRelationshipFields(String relationshipName, String relationshipDirection,
-        boolean strict) {
+                                                      boolean strict) {
         Set<FieldInfo> candidateFields = new HashSet<>();
         for (FieldInfo fieldInfo : relationshipFields()) {
             String relationship = strict ? fieldInfo.relationshipTypeAnnotation() : fieldInfo.relationship();
@@ -703,7 +695,7 @@ public class ClassInfo {
      * @return {@link List} of {@link MethodInfo}, never <code>null</code>
      */
     public List<FieldInfo> findIterableFields(Class iteratedType, String relationshipType, String relationshipDirection,
-        boolean strict) {
+                                              boolean strict) {
         List<FieldInfo> fieldInfos = new ArrayList<>();
         for (FieldInfo fieldInfo : findIterableFields(iteratedType)) {
             String relationship = strict ? fieldInfo.relationshipTypeAnnotation() : fieldInfo.relationship();
@@ -980,16 +972,14 @@ public class ClassInfo {
         if (isPostLoadMethodMapped) {
             return postLoadMethod;
         }
-        if (!isPostLoadMethodMapped) {
-            for (MethodInfo methodInfo : methodsInfo().methods()) {
-                if (methodInfo.hasAnnotation(PostLoad.class.getName())) {
-                    isPostLoadMethodMapped = true;
-                    postLoadMethod = methodInfo;
-                    return postLoadMethod;
-                }
+        for (MethodInfo methodInfo : methodsInfo().methods()) {
+            if (methodInfo.hasAnnotation(PostLoad.class.getName())) {
+                isPostLoadMethodMapped = true;
+                postLoadMethod = methodInfo;
+                return postLoadMethod;
             }
-            isPostLoadMethodMapped = true;
         }
+        isPostLoadMethodMapped = true;
         return null;
     }
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/MethodsInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MethodsInfo.java
@@ -35,18 +35,19 @@ public class MethodsInfo {
     public MethodsInfo(Class<?> cls) {
         this.methods = new HashMap<>();
 
-        for (Method method : cls.getDeclaredMethods()) {
-            final int modifiers = method.getModifiers();
-            if (!Modifier.isTransient(modifiers) && !Modifier.isFinal(modifiers) && !Modifier.isStatic(modifiers)) {
-                ObjectAnnotations objectAnnotations = new ObjectAnnotations();
-                final Annotation[] declaredAnnotations = method.getDeclaredAnnotations();
-                for (Annotation annotation : declaredAnnotations) {
-                    AnnotationInfo info = new AnnotationInfo(annotation);
-                    objectAnnotations.put(info.getName(), info);
+        do {
+            for (Method method : cls.getDeclaredMethods()) {
+                final int modifiers = method.getModifiers();
+                if (!Modifier.isTransient(modifiers) && !Modifier.isFinal(modifiers) && !Modifier.isStatic(modifiers)) {
+                    ObjectAnnotations objectAnnotations = new ObjectAnnotations();
+                    for (Annotation annotation : method.getDeclaredAnnotations()) {
+                        AnnotationInfo info = new AnnotationInfo(annotation);
+                        objectAnnotations.put(info.getName(), info);
+                    }
+                    methods.put(method.getName(), new MethodInfo(method, objectAnnotations));
                 }
-                methods.put(method.getName(), new MethodInfo(method, objectAnnotations));
             }
-        }
+        } while ((cls = cls.getSuperclass()) != null);
     }
 
     public MethodsInfo(Map<String, MethodInfo> methods) {

--- a/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -13,11 +13,6 @@
 
 package org.neo4j.ogm.session;
 
-import static java.util.Objects.*;
-
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.neo4j.ogm.autoindex.AutoIndexManager;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.driver.Driver;
@@ -27,6 +22,11 @@ import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.metadata.reflect.ReflectionEntityInstantiator;
 import org.neo4j.ogm.session.event.EventListener;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This is the main initialization point of OGM. Used to create {@link Session} instances for interacting with Neo4j.
@@ -81,9 +81,7 @@ public class SessionFactory {
         this.driver = newDriverInstance(configuration.getDriverClassName());
         this.driver.configure(configuration);
         this.eventListeners = new CopyOnWriteArrayList<>();
-        Neo4jSession session = (Neo4jSession) openSession();
-        AutoIndexManager autoIndexManager = new AutoIndexManager(this.metaData, configuration, session);
-        autoIndexManager.build();
+        new AutoIndexManager(this.metaData, configuration, this);
         this.entityInstantiator = new ReflectionEntityInstantiator(metaData);
     }
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -93,7 +93,7 @@ public class LoadOneDelegate {
             if (primaryIndex == null) {
                 ref = session.context().getNodeEntity((Long) id);
             } else {
-                ref = session.context().getNodeEntityById(typeInfo, id);
+                ref = session.context().getEntityById(typeInfo, id);
             }
         } else {
             if (primaryIndex == null) {
@@ -101,7 +101,7 @@ public class LoadOneDelegate {
                 // But we know this will always be Long.
                 ref = session.context().getRelationshipEntity((Long) id);
             } else {
-                ref = session.context().getRelationshipEntityById(typeInfo, id);
+                ref = session.context().getEntityById(typeInfo, id);
             }
         }
         try {

--- a/test/src/test/java/org/neo4j/ogm/autoindex/BaseAutoIndexManagerTestClass.java
+++ b/test/src/test/java/org/neo4j/ogm/autoindex/BaseAutoIndexManagerTestClass.java
@@ -13,19 +13,7 @@
 
 package org.neo4j.ogm.autoindex;
 
-import static com.google.common.collect.Lists.*;
-import static java.util.stream.Collectors.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.StreamSupport;
-
+import com.google.common.collect.ObjectArrays;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -37,16 +25,28 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.metadata.MetaData;
-import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.SessionFactory;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ObjectArrays;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Must not end with "Test" so it does not run on TC.
+ *
  * @author Frantisek Hartman
  */
 public abstract class BaseAutoIndexManagerTestClass extends MultiDriverTestClass {
@@ -204,9 +204,7 @@ public abstract class BaseAutoIndexManagerTestClass extends MultiDriverTestClass
                 .generatedIndexesOutputFilename(file.getName())
                 .build();
 
-            Neo4jSession session = (Neo4jSession) sessionFactory.openSession();
-            AutoIndexManager indexManager = new AutoIndexManager(metaData, configuration, session);
-            indexManager.build();
+            new AutoIndexManager(metaData, configuration, sessionFactory);
 
             assertThat(file.exists()).isTrue();
             try (InputStream is = new FileInputStream(file)) {
@@ -221,9 +219,7 @@ public abstract class BaseAutoIndexManagerTestClass extends MultiDriverTestClass
 
     void runAutoIndex(String mode) {
         Configuration configuration = getBaseConfiguration().autoIndex(mode).build();
-        Neo4jSession session = (Neo4jSession) sessionFactory.openSession();
-        AutoIndexManager indexManager = new AutoIndexManager(metaData, configuration, session);
-        indexManager.build();
+        new AutoIndexManager(metaData, configuration, sessionFactory);
     }
 
     void executeForIndexes(Consumer<List<IndexDefinition>> consumer) {

--- a/test/src/test/java/org/neo4j/ogm/context/REMappingContextTest.java
+++ b/test/src/test/java/org/neo4j/ogm/context/REMappingContextTest.java
@@ -48,7 +48,7 @@ public class REMappingContextTest {
         Object entity = context.getRelationshipEntity(1L);
         assertThat(entity).isSameAs(likes);
 
-        Object entityById = context.getRelationshipEntityById(metaData.classInfo(likes), "test-uuid");
+        Object entityById = context.getEntityById(metaData.classInfo(likes), "test-uuid");
         assertThat(entityById).isSameAs(likes);
     }
 
@@ -58,7 +58,7 @@ public class REMappingContextTest {
 
         context.clear();
 
-        Object entity = context.getRelationshipEntityById(metaData.classInfo(likes), "test-uuid");
+        Object entity = context.getEntityById(metaData.classInfo(likes), "test-uuid");
         assertThat(entity).isNull();
     }
 

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/AnotherEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/AnotherEntity.java
@@ -1,0 +1,23 @@
+package org.neo4j.ogm.domain.abstraction;
+
+public abstract class AnotherEntity extends Entity {
+
+    protected String anotherValue;
+
+    public AnotherEntity() {
+        super();
+    }
+
+    public AnotherEntity(String uuid) {
+        super(uuid);
+    }
+
+    public String getAnotherValue() {
+        return anotherValue;
+    }
+
+    public void setAnotherValue(String anotherValue) {
+        this.anotherValue = anotherValue;
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildA.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildA.java
@@ -1,0 +1,40 @@
+package org.neo4j.ogm.domain.abstraction;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ChildA extends Entity {
+
+    private String value;
+
+    private Set<AnotherEntity> children = new HashSet<>();
+
+    public ChildA() {
+        super();
+    }
+
+    public ChildA(String uuid) {
+        super(uuid);
+    }
+
+    public ChildA add(AnotherEntity childB) {
+        children.add(childB);
+        return this;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Set<AnotherEntity> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Set<AnotherEntity> children) {
+        this.children = children;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildB.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildB.java
@@ -14,7 +14,6 @@ public class ChildB extends AnotherEntity {
 
     @Override
     public void postLoad() {
-        // FIXME - #414 - @PostLoad is not called in child overrided method (this method does not execute)
         value = uuid.hashCode();
     }
 

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildB.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildB.java
@@ -1,0 +1,29 @@
+package org.neo4j.ogm.domain.abstraction;
+
+public class ChildB extends AnotherEntity {
+
+    private Integer value;
+
+    public ChildB() {
+        super();
+    }
+
+    public ChildB(String uuid) {
+        super(uuid);
+    }
+
+    @Override
+    public void postLoad() {
+        // FIXME - #414 - @PostLoad is not called in child overrided method (this method does not execute)
+        value = uuid.hashCode();
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildC.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/ChildC.java
@@ -1,0 +1,13 @@
+package org.neo4j.ogm.domain.abstraction;
+
+public class ChildC extends AnotherEntity {
+
+    public ChildC() {
+        super();
+    }
+
+    public ChildC(String uuid) {
+        super(uuid);
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/Entity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/Entity.java
@@ -1,0 +1,62 @@
+package org.neo4j.ogm.domain.abstraction;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.Labels;
+import org.neo4j.ogm.annotation.PostLoad;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.UUID.randomUUID;
+
+public abstract class Entity {
+
+    @Id
+    protected String uuid;
+
+    @Labels
+    protected Set<String> labels = new HashSet<>();
+
+    public Entity() {
+        uuid = randomUUID().toString();
+    }
+
+    public Entity(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @PostLoad
+    public void postLoad() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Entity entity = (Entity) o;
+        return Objects.equals(uuid, entity.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public Set<String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Set<String> labels) {
+        this.labels = labels;
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/abstraction/Entity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/abstraction/Entity.java
@@ -30,6 +30,18 @@ public abstract class Entity {
     public void postLoad() {
     }
 
+    public void addLabel(Object... labels) {
+        for (Object label : labels) {
+            this.labels.add(label.toString());
+        }
+    }
+
+    public void removeLabel(Object... labels) {
+        for (Object label : labels) {
+            this.labels.remove(label.toString());
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/test/src/test/java/org/neo4j/ogm/domain/pizza/Pizza.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/pizza/Pizza.java
@@ -13,14 +13,14 @@
 
 package org.neo4j.ogm.domain.pizza;
 
+import org.neo4j.ogm.annotation.Labels;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.neo4j.ogm.annotation.Labels;
-import org.neo4j.ogm.annotation.NodeEntity;
-import org.neo4j.ogm.annotation.Relationship;
 
 /**
  * An entity that contains multiple relationships and RE's with the same relationship type and direction.
@@ -63,6 +63,20 @@ public class Pizza {
         this.crust = crust;
         this.toppings = toppings;
     }
+
+
+    public void addLabel(Object... labels) {
+        for (Object label : labels) {
+            this.labels.add(label.toString());
+        }
+    }
+
+    public void removeLabel(Object... labels) {
+        for (Object label : labels) {
+            this.labels.remove(label.toString());
+        }
+    }
+
 
     public Long getId() {
         return id;

--- a/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.persistence.abstraction;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.domain.abstraction.*;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for entity abstractions
+ */
+public class EntityAbstractionTest extends MultiDriverTestClass {
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        // #437 - Disabled AutoIndex must not break initialization because of Entity containing annotation @Id
+        sessionFactory = new SessionFactory(getBaseConfiguration().build(), "org.neo4j.ogm.domain.abstraction");
+    }
+
+    @Before
+    public void setUp() {
+        session = sessionFactory.openSession();
+        session.purgeDatabase();
+    }
+
+    @Test
+    public void shouldNotSaveEntityLabelAndMustRetrieveChildA() {
+        ChildA a = new ChildA();
+        a.setValue("ChildA");
+        session.save(a);
+        session.clear();
+
+        assertThat(session.loadAll(Entity.class)).isEmpty();
+        assertThat(session.load(Entity.class, a.getUuid())).isNull();
+
+        ChildA dbA = session.load(ChildA.class, a.getUuid());
+        assertThat(dbA).isNotNull();
+        assertThat(dbA.getValue()).isEqualTo("ChildA");
+    }
+
+    @Test
+    public void shouldNotSaveEntityLabelAndMustRetrieveChildAChildren() {
+        ChildA a = new ChildA();
+        ChildB b1 = new ChildB();
+        ChildB b2 = new ChildB();
+        ChildC c1 = new ChildC();
+        a.add(b1);
+        a.add(b2);
+        a.add(c1);
+        session.save(a);
+        session.clear();
+
+        assertThat(session.loadAll(Entity.class)).isEmpty();
+        assertThat(session.loadAll(AnotherEntity.class)).isEmpty();
+        a.getChildren().forEach(c -> assertThat(session.load(AnotherEntity.class, c.getUuid())).isNull());
+
+        Set<AnotherEntity> children = session.load(ChildA.class, a.getUuid()).getChildren();
+        assertThat(children).contains(b1, b2, c1);
+
+//        FIXME - #414 - @PostLoad is not called in child overrided method (see ChildB)
+//        children.stream().filter(c -> c instanceof ChildB).forEach(b -> assertThat(((ChildB) b).getValue()).isNotNull());
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
@@ -83,4 +83,45 @@ public class EntityAbstractionTest extends MultiDriverTestClass {
         // #414 - @PostLoad is not called in child's overridden method (see ChildB postLoad method)
         children.stream().filter(c -> c instanceof ChildB).forEach(b -> assertThat(((ChildB) b).getValue()).isNotNull());
     }
+
+    @Test
+    public void shouldUpdateLabelWhenLoadingEntityInSameSession() {
+        ChildA a = new ChildA();
+        a.addLabel("A0");
+        session.save(a);
+        session.clear();
+
+        ChildA dbA = session.load(ChildA.class, a.getUuid());
+        assertThat(dbA.getLabels().size()).isEqualTo(1);
+        assertThat(dbA.getLabels()).contains("A0");
+        dbA.removeLabel("A0");
+        dbA.addLabel("A1");
+        session.save(dbA);
+        session.clear();
+
+        dbA = session.load(ChildA.class, a.getUuid());
+        assertThat(dbA.getLabels().size()).isEqualTo(1);
+        assertThat(dbA.getLabels()).contains("A1");
+    }
+
+    @Test
+    public void shouldUpdateLabelWhenLoadingEntityInNewSession() {
+        ChildA a = new ChildA();
+        a.addLabel("A0");
+        session.save(a);
+        Session newSession = sessionFactory.openSession();
+
+        ChildA dbA = newSession.load(ChildA.class, a.getUuid());
+        assertThat(dbA.getLabels().size()).isEqualTo(1);
+        assertThat(dbA.getLabels()).contains("A0");
+        dbA.removeLabel("A0");
+        dbA.addLabel("A1");
+        newSession.save(dbA);
+        newSession.clear();
+
+        dbA = newSession.load(ChildA.class, a.getUuid());
+        assertThat(dbA.getLabels().size()).isEqualTo(1);
+        assertThat(dbA.getLabels()).contains("A1");
+    }
+
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/abstraction/EntityAbstractionTest.java
@@ -80,7 +80,7 @@ public class EntityAbstractionTest extends MultiDriverTestClass {
         Set<AnotherEntity> children = session.load(ChildA.class, a.getUuid()).getChildren();
         assertThat(children).contains(b1, b2, c1);
 
-//        FIXME - #414 - @PostLoad is not called in child overrided method (see ChildB)
-//        children.stream().filter(c -> c instanceof ChildB).forEach(b -> assertThat(((ChildB) b).getValue()).isNotNull());
+        // #414 - @PostLoad is not called in child's overridden method (see ChildB postLoad method)
+        children.stream().filter(c -> c instanceof ChildB).forEach(b -> assertThat(((ChildB) b).getValue()).isNotNull());
     }
 }


### PR DESCRIPTION
## Description
- Merging primaryId mapping for both nodes and relationship
- Remembering identity with existing ID without calling nativeId method
- Reusing identity update logic for both nodes and relationships
- Creating tests in EntityAbstractionTest and PizzaIntegrationTest
- Testing label updates with graphId and different primaryId using `@Id`

NOTE:
- Those changes depend on #485. Please, do not review it until #485 is approved and merged.

## Related Issue
#488 - Cannot update labels if entity using `@Id` is loaded in a different session

## Motivation and Context
Please, read #488 

## How Has This Been Tested?
Using existing test case in addition to new tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
