### PR TITLE
Issue/datagraph 1093

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
@@ -204,6 +204,7 @@ public class Filter implements FilterWithRelationship {
 
     /**
      * Sets this filter to ignore the case in a property comparison when using the EQUALS operator.
+     *
      * @return the same filter instance
      * @throws IllegalStateException if the filters function is null, not a property comparison or the operator of the
      *                               is not an EQUALS-operator.
@@ -213,7 +214,8 @@ public class Filter implements FilterWithRelationship {
         if (!(this.function instanceof PropertyComparison)) {
             throw new IllegalStateException("ignoreCase is only supported for a filter based on property comparison");
         } else if (this.getComparisonOperator() != EQUALS) {
-            throw new IllegalStateException(String.format("ignoreCase is only supported for %s comparison", ComparisonOperator.EQUALS.name()));
+            throw new IllegalStateException(
+                String.format("ignoreCase is only supported for %s comparison", ComparisonOperator.EQUALS.name()));
         }
         this.function = new CaseInsensitiveEqualsComparison((PropertyComparison) this.function);
         return this;
@@ -463,7 +465,7 @@ public class Filter implements FilterWithRelationship {
         public String expression(final String nodeIdentifier) {
             final Filter filter = this.getFilter();
             return String.format("toLower(%s.`%s`) %s toLower({ `%s` }) ", nodeIdentifier, filter.getPropertyName(),
-                filter.getComparisonOperator().getValue(), filter.uniqueParameterName());
+                ComparisonOperator.EQUALS.getValue(), filter.uniqueParameterName());
         }
     }
 }

--- a/neo4j-ogm-docs/src/main/asciidoc/reference/filters.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/filters.adoc
@@ -12,14 +12,14 @@ In the example below, we're return a collection containing any satellites that a
 .Example of using a Filter
 [source,java]
 ----
-Collection<Satellite> satellites = session.loadAll(Satellite.class, new Filter("manned", EQUALS, true));
+Collection<Satellite> satellites = session.loadAll(Satellite.class, new Filter("manned", ComparisonOperator.EQUALS, true));
 ----
 
 .Example of chained Filters
 [source,java]
 ----
-Filter mannedFilter = new Filter("manned", equals, true);
-Filter landedFilter = new Filter("landed", equals, false);
+Filter mannedFilter = new Filter("manned", ComparisonOperator.EQUALS, true);
+Filter landedFilter = new Filter("landed", ComparisonOperator.EQUALS, false);
 
 Filters satelliteFilter = mannedFilter.and(landedFilter);
 ----

--- a/test/src/test/java/org/neo4j/ogm/cypher/FilterIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/FilterIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Michael J. Simons
  */
-public class FilterIntegrationTest  extends MultiDriverTestClass {
+public class FilterIntegrationTest extends MultiDriverTestClass {
 
     private static SessionFactory sessionFactory;
 
@@ -56,7 +56,8 @@ public class FilterIntegrationTest  extends MultiDriverTestClass {
     public void ignoreCaseShouldNotBeApplicableToComparisonOtherThanEquals() {
         final String emi = "EMI Studios, London";
         session.save(new Studio(emi));
-        assertThat(session.loadAll(Studio.class, new Filter("name", ComparisonOperator.EQUALS, "eMi Studios, London").ignoreCase(), 0))
+        final Filter nameFilter = new Filter("name", ComparisonOperator.EQUALS, "eMi Studios, London").ignoreCase();
+        assertThat(session.loadAll(Studio.class, nameFilter, 0))
             .hasSize(1)
             .extracting(Studio::getName)
             .containsExactly(emi);

--- a/test/src/test/java/org/neo4j/ogm/cypher/FilterIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/FilterIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.cypher;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.domain.music.Studio;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the generated filter fragments.
+ *
+ * @author Michael J. Simons
+ */
+public class FilterIntegrationTest  extends MultiDriverTestClass {
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.music");
+    }
+
+    @Before
+    public void init() throws IOException {
+        session = sessionFactory.openSession();
+    }
+
+    @After
+    public void clear() {
+        session.purgeDatabase();
+    }
+
+    @Test
+    public void ignoreCaseShouldNotBeApplicableToComparisonOtherThanEquals() {
+        final String emi = "EMI Studios, London";
+        session.save(new Studio(emi));
+        assertThat(session.loadAll(Studio.class, new Filter("name", ComparisonOperator.EQUALS, "eMi Studios, London").ignoreCase(), 0))
+            .hasSize(1)
+            .extracting(Studio::getName)
+            .containsExactly(emi);
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
@@ -48,7 +48,8 @@ public class FilterTest {
         filter.setBooleanOperator(BooleanOperator.AND);
         filter.setNegated(true);
         assertThat(filter.toCypher("n", true))
-            .isEqualTo("WHERE NOT(distance(point({latitude: n.latitude, longitude: n.longitude}),point({latitude:{lat}, longitude:{lon}})) < {distance} ) ");
+            .isEqualTo(
+                "WHERE NOT(distance(point({latitude: n.latitude, longitude: n.longitude}),point({latitude:{lat}, longitude:{lon}})) < {distance} ) ");
     }
 
     @Test

--- a/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
@@ -17,12 +17,22 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Iterator;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.neo4j.ogm.cypher.function.ContainsAnyComparison;
 import org.neo4j.ogm.cypher.function.DistanceComparison;
 import org.neo4j.ogm.cypher.function.DistanceFromPoint;
+import org.neo4j.ogm.cypher.function.PropertyComparison;
 
+/**
+ * @author Gerrit Meier
+ * @author Michael J. Simons
+ */
 public class FilterTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void toCypher() {
@@ -75,5 +85,51 @@ public class FilterTest {
         Iterator<Filter> iterator = andFilter.iterator();
         assertThat(iterator.next()).isEqualTo(filter1);
         assertThat(iterator.next()).isEqualTo(filter2);
+    }
+
+    @Test
+    public void isNullComparisionShouldWork() {
+        Filter filter = new Filter("thing", ComparisonOperator.IS_NULL);
+        filter.setBooleanOperator(BooleanOperator.AND);
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` IS NULL ");
+    }
+
+    @Test
+    public void isExistsComparisionShouldWork() {
+        Filter filter = new Filter("thing", ComparisonOperator.EXISTS);
+        filter.setBooleanOperator(BooleanOperator.AND);
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE EXISTS(n.`thing`) ");
+    }
+
+    @Test
+    public void isTrueComparisionShouldWork() {
+        Filter filter = new Filter("thing", ComparisonOperator.IS_TRUE);
+        filter.setBooleanOperator(BooleanOperator.AND);
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` = true ");
+    }
+
+    @Test
+    public void equalComparisionShouldWork() {
+        final String value = "someOtherThing";
+        Filter filter = new Filter("thing", ComparisonOperator.EQUALS, value);
+        filter.setFunction(new PropertyComparison(value));
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` = { `thing_0` } ");
+
+        filter = new Filter("thing", ComparisonOperator.EQUALS, value);
+        filter.ignoreCase();
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE toLower(n.`thing`) = toLower({ `thing_0` }) ");
+    }
+
+    @Test
+    public void ignoreCaseShouldNotBeApplicableToComparisonOtherThanEquals() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("ignoreCase is only supported for EQUALS comparison");
+
+        Filter filter = new Filter("thing", ComparisonOperator.IS_NULL);
+        filter.setBooleanOperator(BooleanOperator.AND);
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` IS NULL ");
+        filter.ignoreCase();
+
+        assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` IS NULL ");
     }
 }


### PR DESCRIPTION
Added `#ignoreCase` on `org.neo4j.ogm.cypher.Filter` that makes the filter case insensitive if it's a property comparison on a string.

This PR is needed to solve [DATAGRAPH-1093](https://jira.spring.io/browse/DATAGRAPH-1093).