### PR TITLE
DATAGRAPH-933 - Fix determination of FieldInfo.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public class ClassInfo {
 
@@ -424,7 +425,7 @@ public class ClassInfo {
         if (propertyFields == null) {
             initPropertyFields();
         }
-        return propertyFields.get(propertyName.toLowerCase());
+        return propertyName == null ? null : propertyFields.get(propertyName.toLowerCase());
     }
 
     private synchronized void initPropertyFields() {

--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
@@ -31,6 +31,7 @@ import org.neo4j.ogm.annotation.Transient;
 
 /**
  * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class FieldsInfo {
 
@@ -101,6 +102,13 @@ public class FieldsInfo {
         return Collections.unmodifiableList(fields);
     }
 
+    /**
+     * Should not be used directly as it doesn't take property fields into account.
+     * @param name
+     * @return
+     * @deprecated since 3.1.1 use {@link ClassInfo#getFieldInfo(String)} instead.
+     */
+    @Deprecated
     public FieldInfo get(String name) {
         return fields.get(name);
     }

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
@@ -53,7 +53,7 @@ abstract class SessionDelegate {
             Filter.setNameFromProperty(filter, propertyName);
 
             ClassInfo classInfo = session.metaData().classInfo(entityType.getName());
-            FieldInfo fieldInfo = classInfo.fieldsInfo().get(filter.getPropertyName());
+            FieldInfo fieldInfo = classInfo.getFieldInfo(filter.getPropertyName());
             if (fieldInfo != null) {
                 filter.setPropertyConverter(fieldInfo.getPropertyConverter());
                 filter.setCompositeConverter(fieldInfo.getCompositeConverter());

--- a/test/src/test/java/org/neo4j/ogm/domain/music/Album.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/music/Album.java
@@ -13,11 +13,16 @@
 
 package org.neo4j.ogm.domain.music;
 
+import java.util.Date;
+
 import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
 import org.neo4j.ogm.annotation.Relationship;
+import org.neo4j.ogm.annotation.typeconversion.DateLong;
 
 /**
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 @NodeEntity(label = "l'album")
 public class Album {
@@ -33,6 +38,18 @@ public class Album {
 
     @Relationship(type = "GUEST_ALBUM", direction = "INCOMING")
     private Artist guestArtist; //we only tolerate one guest artist
+
+    private Date recordedAt;
+
+    @Property("releasedAt")
+    private Date released;
+
+    @DateLong
+    private Date enteredChartAt;
+
+    @Property("leftChartAt")
+    @DateLong
+    private Date leftChart;
 
     public Album() {
     }
@@ -75,5 +92,21 @@ public class Album {
 
     public Long getId() {
         return id;
+    }
+
+    public Date getReleased() {
+        return released;
+    }
+
+    public void setReleased(Date released) {
+        this.released = released;
+    }
+
+    public Date getRecordedAt() {
+        return recordedAt;
+    }
+
+    public void setRecordedAt(Date recordedAt) {
+        this.recordedAt = recordedAt;
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/session/delegates/SessionDelegateIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/delegates/SessionDelegateIntegrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.session.delegates;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.domain.music.Album;
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.neo4j.ogm.typeconversion.DateLongConverter;
+import org.neo4j.ogm.typeconversion.DateStringConverter;
+
+/**
+ * Integration tests for the session delegate.
+ *
+ * @author Michael J. Simons
+ */
+public class SessionDelegateIntegrationTest extends MultiDriverTestClass {
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.music");
+    }
+
+    @Before
+    public void init() throws IOException {
+        session = sessionFactory.openSession();
+    }
+
+    @Test // DATAGRAPH-933
+    public void shouldPickupCorrectFieldInfo() {
+
+        final Date filterValue = new Date();
+
+        final Filter recordedAtFilter = new Filter("recordedAt", ComparisonOperator.GREATER_THAN, filterValue);
+        final Filter releasedFilter = new Filter("released", ComparisonOperator.GREATER_THAN, filterValue);
+        final Filter releasedAtFilter = new Filter("releasedAt", ComparisonOperator.GREATER_THAN, filterValue);
+        final Filter enteredChartAtFilter = new Filter("enteredChartAt", ComparisonOperator.GREATER_THAN, filterValue);
+        final Filter leftChartFilter = new Filter("leftChart", ComparisonOperator.GREATER_THAN, filterValue);
+        final Filter leftChartAtFilter = new Filter("leftChartAt", ComparisonOperator.GREATER_THAN, filterValue);
+
+        final SessionDelegate sessionDelegate = new LoadByTypeDelegate((Neo4jSession) session);
+        sessionDelegate.resolvePropertyAnnotations(Album.class, Arrays.asList(
+            recordedAtFilter,
+            releasedFilter,
+            releasedAtFilter,
+            enteredChartAtFilter,
+            leftChartFilter,
+            leftChartAtFilter
+        ));
+
+        assertThat(recordedAtFilter.getPropertyConverter())
+            .as("Property converter %s should be used for Date fields without @Property-annotation",
+                DateStringConverter.class)
+            .isInstanceOf(DateStringConverter.class);
+        assertThat(releasedFilter.getPropertyConverter())
+            .as("Property converter %s should be used for Date fields with @Property-annotation referred by field name",
+                DateStringConverter.class)
+            .isInstanceOf(DateStringConverter.class);
+        assertThat(releasedAtFilter.getPropertyConverter())
+            .as("Property converter %s should be used for Date fields with @Property-annotation referred by property name",
+                DateStringConverter.class)
+            .isInstanceOf(DateStringConverter.class);
+
+        assertThat(enteredChartAtFilter.getPropertyConverter())
+            .as("Specified provider should be used")
+            .isInstanceOf(DateLongConverter.class);
+        assertThat(leftChartFilter.getPropertyConverter())
+            .as("Specified provider should be used")
+            .isInstanceOf(DateLongConverter.class);
+        assertThat(leftChartAtFilter.getPropertyConverter())
+            .as("Specified provider should be used")
+            .isInstanceOf(DateLongConverter.class);
+    }
+}


### PR DESCRIPTION
This fixes the determination of the FieldInfo for a given field or property so that handling of properties (that is, fields annotated with `@Property`) is in accordance to the OGM doc:

https://neo4j.com/docs/ogm-manual/current/reference/#reference:type-conversion:built-in.

_Can be merged into 3.0.x and 3.1.x, both compile and build._