### PR TITLE
Remove Guava 21 as test-compile dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
         <httpclient>4.5.2</httpclient>
         <junit>4.12</junit>
         <assertj>3.8.0</assertj>
-        <guava>21.0</guava> <!-- only used in tests -->
         <slf4j>1.7.21</slf4j>
         <logback>1.1.7</logback>
         <mockito>2.2.29</mockito>
@@ -108,13 +107,6 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -79,12 +79,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.neo4j.test</groupId>
             <artifactId>neo4j-harness</artifactId>
             <version>${neo4j}</version>

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
@@ -13,7 +13,6 @@
 
 package org.neo4j.ogm.cypher.compiler;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Arrays;
@@ -54,6 +53,7 @@ import org.neo4j.ogm.session.request.RowStatementFactory;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class CompilerTest {
 
@@ -108,11 +108,11 @@ public class CompilerTest {
 
         Restaurant r1 = new Restaurant();
         r1.setName("La Strada Tooting");
-        r1.labels = newArrayList("Delicious", "Foreign");
+        r1.labels = Arrays.asList("Delicious", "Foreign");
 
         Restaurant r2 = new Restaurant();
         r2.setName("La Strada Brno");
-        r2.labels = newArrayList("Foreign", "Delicious");
+        r2.labels = Arrays.asList("Foreign", "Delicious");
 
         franchise.addBranch(new Branch(new Location(0.0, 0.0), franchise, r1));
         franchise.addBranch(new Branch(new Location(0.0, 0.0), franchise, r2));
@@ -525,7 +525,7 @@ public class CompilerTest {
         Teacher missJones = new Teacher("Miss Jones");
         missJones.setId(jonesId);
 
-        hillsRoad.setTeachers(newArrayList(missJones, mrWhite));
+        hillsRoad.setTeachers(Arrays.asList(missJones, mrWhite));
         assertThat(hillsRoad.getTeachers()).contains(mrWhite);
         assertThat(hillsRoad.getTeachers()).contains(missJones);
         assertThat(mrWhite.getSchool()).isEqualTo(hillsRoad);

--- a/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
@@ -12,13 +12,13 @@
  */
 package org.neo4j.ogm.drivers;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -36,13 +36,13 @@ import org.neo4j.ogm.session.Utils;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.neo4j.ogm.transaction.Transaction;
 
-import com.google.common.collect.Iterables;
-
 /**
- * This test class is converted from the AbstractDriverTestSuite to use the test harness in use by toher tests
+ * This test class is converted from the AbstractDriverTestSuite to use the test harness in use by other tests.
+ *
+ * <em>Do not rename this class to end with *Test, or certain test packages might try to execute it.</em>
  *
  * @author vince
- * Do not rename this class to end with *Test, or certain test packages might try to execute it.
+ * @author Michael J. Simons
  */
 public class BasicDriverTest extends MultiDriverTestClass {
 
@@ -75,7 +75,7 @@ public class BasicDriverTest extends MultiDriverTestClass {
         bilbo.befriend(frodo);
 
         // Get an Iterable which is not a Collection
-        Iterable<User> iterable = Iterables.concat(newArrayList(bilbo), newArrayList(frodo));
+        Iterable<User> iterable = Stream.of(bilbo, frodo)::iterator;
         assertThat(iterable).isNotInstanceOf(Collection.class);
 
         session.save(iterable);

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -13,10 +13,10 @@
 
 package org.neo4j.ogm.persistence.examples.cineasts.annotated;
 
-import static com.google.common.collect.Sets.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.net.MalformedURLException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -46,6 +46,7 @@ import org.neo4j.ogm.testutil.TestUtils;
  * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
 
@@ -884,14 +885,14 @@ public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
         pulpRating.setStars(3);
         pulpRating.setMovie(pulpFiction);
         pulpRating.setUser(frantisek);
-        pulpFiction.setRatings(newHashSet(pulpRating));
+        pulpFiction.setRatings(new HashSet<>(Arrays.asList(pulpRating)));
 
         Rating ootfRating = new Rating();
         ootfRating.setStars(3);
         ootfRating.setMovie(ootf);
         ootfRating.setUser(frantisek);
 
-        frantisek.setRatings(newHashSet(ootfRating, pulpRating));
+        frantisek.setRatings(new HashSet<>(Arrays.asList(ootfRating, pulpRating)));
 
         User otto = new User();
         otto.setName("Otto");
@@ -907,9 +908,9 @@ public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
         ootfRating2.setMovie(ootf);
         ootfRating2.setUser(otto);
 
-        pulpFiction.setRatings(newHashSet(pulpRating, pulpRating2));
-        ootf.setRatings(newHashSet(ootfRating, ootfRating2));
-        otto.setRatings(newHashSet(pulpRating2, ootfRating2));
+        pulpFiction.setRatings(new HashSet<>(Arrays.asList(pulpRating, pulpRating2)));
+        ootf.setRatings(new HashSet<>(Arrays.asList(ootfRating, ootfRating2)));
+        otto.setRatings(new HashSet<>(Arrays.asList(pulpRating2, ootfRating2)));
         session.save(otto);
 
         session.clear();

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/drink/DrinkIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/drink/DrinkIntegrationTest.java
@@ -13,10 +13,10 @@
 
 package org.neo4j.ogm.persistence.examples.drink;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Before;
@@ -33,6 +33,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 /**
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
 public class DrinkIntegrationTest extends MultiDriverTestClass {
 
@@ -90,7 +91,7 @@ public class DrinkIntegrationTest extends MultiDriverTestClass {
         Beverage pilsner = new Beverage("Pilsner Urquell");
         session.save(pilsner);
 
-        Collection<Beverage> beverages = session.loadAll(newArrayList(pilsner));
+        Collection<Beverage> beverages = session.loadAll(Arrays.asList(pilsner));
         assertThat(beverages).containsOnly(pilsner);
     }
 

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/numbers/Bucket.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/numbers/Bucket.java
@@ -13,14 +13,14 @@
 
 package org.neo4j.ogm.persistence.examples.numbers;
 
-import static com.google.common.collect.Lists.*;
-
+import java.util.Arrays;
 import java.util.List;
 
 import org.neo4j.ogm.annotation.NodeEntity;
 
 /**
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
 @NodeEntity
 public class Bucket {
@@ -28,7 +28,7 @@ public class Bucket {
     Long id;
 
     // collection with default value
-    List<Integer> numbers = newArrayList(1, 2, 3);
+    List<Integer> numbers = Arrays.asList(1, 2, 3);
 
     public Long getId() {
         return id;

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
@@ -13,7 +13,6 @@
 
 package org.neo4j.ogm.persistence.examples.restaurant;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
@@ -169,11 +168,11 @@ public class RestaurantIntegrationTest extends MultiDriverTestClass {
 
         Restaurant r1 = new Restaurant();
         r1.setName("La Strada Tooting");
-        r1.labels = newArrayList("Delicious", "Foreign");
+        r1.labels = Arrays.asList("Delicious", "Foreign");
 
         Restaurant r2 = new Restaurant();
         r2.setName("La Strada Brno");
-        r2.labels = newArrayList("Average", "Foreign");
+        r2.labels = Arrays.asList("Average", "Foreign");
 
         franchise.addBranch(new Branch(new Location(0.0, 0.0), franchise, r1));
         franchise.addBranch(new Branch(new Location(0.0, 0.0), franchise, r2));
@@ -181,8 +180,8 @@ public class RestaurantIntegrationTest extends MultiDriverTestClass {
         session.save(franchise);
 
         // remove labels, different label for each entity
-        r1.labels = newArrayList("Foreign");
-        r2.labels = newArrayList("Foreign");
+        r1.labels = Arrays.asList("Foreign");
+        r2.labels = Arrays.asList("Foreign");
         session.save(franchise);
 
         session.clear();

--- a/test/src/test/java/org/neo4j/ogm/persistence/identity/IdentityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/identity/IdentityTest.java
@@ -12,10 +12,10 @@
  */
 package org.neo4j.ogm.persistence.identity;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.neo4j.ogm.annotation.Relationship.*;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
  * methods on Java objects.
  *
  * @author vince
+ * @author Michael J. Simons
  */
 public class IdentityTest extends MultiDriverTestClass {
 
@@ -151,7 +152,7 @@ public class IdentityTest extends MultiDriverTestClass {
 
         Node nodeC = new Node();
 
-        nodeA.related = newArrayList(nodeB, nodeC);
+        nodeA.related = Arrays.asList(nodeB, nodeC);
 
         session.save(nodeA);
         logger.info("related: {}", nodeA.related);
@@ -181,7 +182,7 @@ public class IdentityTest extends MultiDriverTestClass {
         Node nodeA = new Node();
         Node nodeB = new Node();
 
-        nodeA.related = newArrayList(nodeB, nodeB);
+        nodeA.related = Arrays.asList(nodeB, nodeB);
 
         session.save(nodeA);
 

--- a/test/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadCapabilityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadCapabilityTest.java
@@ -13,7 +13,6 @@
 
 package org.neo4j.ogm.persistence.session.capability;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
@@ -40,6 +39,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 /**
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class LoadCapabilityTest extends MultiDriverTestClass {
 
@@ -706,13 +706,13 @@ public class LoadCapabilityTest extends MultiDriverTestClass {
 
         Collection<Artist> artists;
 
-        artists = session.loadAll(Artist.class, newArrayList(beatlesId, ledId, bonJoviId));
+        artists = session.loadAll(Artist.class, Arrays.asList(beatlesId, ledId, bonJoviId));
         assertThat(artists).containsExactly(beatles, led, bonJovi);
 
-        artists = session.loadAll(Artist.class, newArrayList(ledId, beatlesId, bonJoviId));
+        artists = session.loadAll(Artist.class, Arrays.asList(ledId, beatlesId, bonJoviId));
         assertThat(artists).containsExactly(led, beatles, bonJovi);
 
-        artists = session.loadAll(Artist.class, newArrayList(ledId, bonJoviId, beatlesId));
+        artists = session.loadAll(Artist.class, Arrays.asList(ledId, bonJoviId, beatlesId));
         assertThat(artists).containsExactly(led, bonJovi, beatles);
     }
 
@@ -730,13 +730,13 @@ public class LoadCapabilityTest extends MultiDriverTestClass {
 
         Collection<Artist> artists;
 
-        artists = session.loadAll(newArrayList(beatles, led, bonJovi));
+        artists = session.loadAll(Arrays.asList(beatles, led, bonJovi));
         assertThat(artists).containsExactly(beatles, led, bonJovi);
 
-        artists = session.loadAll(newArrayList(led, beatles, bonJovi));
+        artists = session.loadAll(Arrays.asList(led, beatles, bonJovi));
         assertThat(artists).containsExactly(led, beatles, bonJovi);
 
-        artists = session.loadAll(newArrayList(led, bonJovi, beatles));
+        artists = session.loadAll(Arrays.asList(led, bonJovi, beatles));
         assertThat(artists).containsExactly(led, bonJovi, beatles);
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/types/convertible/ConvertibleIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/types/convertible/ConvertibleIntegrationTest.java
@@ -12,7 +12,6 @@
  */
 package org.neo4j.ogm.persistence.types.convertible;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
@@ -211,7 +210,7 @@ public class ConvertibleIntegrationTest extends MultiDriverTestClass {
 
         LocalDate now = LocalDate.of(2017, 7, 23);
         LocalDate tomorrow = now.plusDays(1);
-        List<LocalDate> dateList = newArrayList(now, tomorrow);
+        List<LocalDate> dateList = Arrays.asList(now, tomorrow);
         memo.setDateList(dateList);
 
         session.save(memo);
@@ -252,7 +251,7 @@ public class ConvertibleIntegrationTest extends MultiDriverTestClass {
 
         LocalDateTime dateTime = LocalDateTime.of(2017, 7, 23, 1, 2, 3);
         LocalDateTime dateTime1 = dateTime.plusDays(1);
-        List<LocalDateTime> dateTimeList = newArrayList(dateTime, dateTime1);
+        List<LocalDateTime> dateTimeList = Arrays.asList(dateTime, dateTime1);
         memo.setDateTimeList(dateTimeList);
 
         session.save(memo);
@@ -294,7 +293,7 @@ public class ConvertibleIntegrationTest extends MultiDriverTestClass {
         LocalDateTime dateTime = LocalDateTime.of(2017, 7, 23, 1, 2, 3);
         OffsetDateTime offsetDateTime = OffsetDateTime.of(dateTime, ZoneOffset.ofHours(1));
         OffsetDateTime offsetDateTime1 = OffsetDateTime.of(dateTime.plusDays(1), ZoneOffset.ofHours(1));
-        ArrayList<OffsetDateTime> offsetDateTimeList = newArrayList(offsetDateTime, offsetDateTime1);
+        List<OffsetDateTime> offsetDateTimeList = Arrays.asList(offsetDateTime, offsetDateTime1);
         memo.setOffsetDateTimeList(offsetDateTimeList);
 
         session.save(memo);

--- a/test/src/test/java/org/neo4j/ogm/session/BookmarkTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/BookmarkTest.java
@@ -13,12 +13,13 @@
 
 package org.neo4j.ogm.session;
 
-import static com.google.common.collect.Sets.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
@@ -35,6 +36,7 @@ import org.neo4j.ogm.transaction.Transaction;
 
 /**
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
 @RunWith(MockitoJUnitRunner.class)
 public class BookmarkTest {
@@ -58,7 +60,7 @@ public class BookmarkTest {
 
     @Test
     public void shouldPassBookmarksToDriver() throws Exception {
-        Set<String> bookmarks = newHashSet("bookmark1", "bookmark2");
+        Set<String> bookmarks = new HashSet<>(Arrays.asList("bookmark1", "bookmark2"));
 
         Transaction transaction = session.beginTransaction(Transaction.Type.READ_ONLY, bookmarks);
 

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/CountStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/CountStatementsTest.java
@@ -13,9 +13,10 @@
 
 package org.neo4j.ogm.session.request.strategy.impl;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.neo4j.ogm.cypher.ComparisonOperator;
@@ -27,6 +28,7 @@ import org.neo4j.ogm.session.request.strategy.AggregateStatements;
 /**
  * @author Vince Bickers
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
 public class CountStatementsTest {
 
@@ -40,7 +42,7 @@ public class CountStatementsTest {
 
     @Test
     public void testCountNodesWithMultipleLabels() throws Exception {
-        assertThat(statements.countNodes(newArrayList("Person", "Candidate")).getStatement())
+        assertThat(statements.countNodes(Arrays.asList("Person", "Candidate")).getStatement())
             .isEqualTo("MATCH (n:`Person`:`Candidate`) RETURN COUNT(n)");
     }
 

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeEntityQueryPagingTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeEntityQueryPagingTest.java
@@ -12,8 +12,9 @@
  */
 package org.neo4j.ogm.session.request.strategy.impl;
 
-import static com.google.common.collect.Lists.*;
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.neo4j.ogm.cypher.ComparisonOperator;
@@ -24,6 +25,7 @@ import org.neo4j.ogm.cypher.query.PagingAndSortingQuery;
 
 /**
  * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class NodeEntityQueryPagingTest {
 
@@ -72,7 +74,7 @@ public class NodeEntityQueryPagingTest {
     @Test
     public void testFindAllByType() throws Exception {
         assertThat(
-            queryStatements.findAllByType("Raptor", newArrayList(1L, 2L), 1).setPagination(paging).getStatement())
+            queryStatements.findAllByType("Raptor", Arrays.asList(1L, 2L), 1).setPagination(paging).getStatement())
             .isEqualTo(
                 "MATCH (n:`Raptor`) WHERE ID(n) IN { ids } WITH n SKIP 4 LIMIT 2 MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
@@ -80,14 +82,14 @@ public class NodeEntityQueryPagingTest {
     @Test
     public void testFindAllByTypeZeroDepth() throws Exception {
         assertThat(
-            queryStatements.findAllByType("Raptor", newArrayList(1L, 2L), 0).setPagination(paging).getStatement())
+            queryStatements.findAllByType("Raptor", Arrays.asList(1L, 2L), 0).setPagination(paging).getStatement())
             .isEqualTo("MATCH (n:`Raptor`) WHERE ID(n) IN { ids } WITH n SKIP 4 LIMIT 2 RETURN n");
     }
 
     @Test
     public void testFindAllByTypeInfiniteDepth() throws Exception {
         assertThat(
-            queryStatements.findAllByType("Raptor", newArrayList(1L, 2L), -1).setPagination(paging).getStatement())
+            queryStatements.findAllByType("Raptor", Arrays.asList(1L, 2L), -1).setPagination(paging).getStatement())
             .isEqualTo(
                 "MATCH (n:`Raptor`) WHERE ID(n) IN { ids } WITH n SKIP 4 LIMIT 2 MATCH p=(n)-[*0..]-(m) RETURN p, ID(n)");
     }

--- a/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/request/strategy/impl/RelationshipQueryStatementsTest.java
@@ -12,10 +12,11 @@
  */
 package org.neo4j.ogm.session.request.strategy.impl;
 
-import static com.google.common.collect.Lists.*;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 import static org.neo4j.ogm.cypher.ComparisonOperator.*;
+
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.neo4j.ogm.cypher.BooleanOperator;
@@ -31,6 +32,7 @@ import org.neo4j.ogm.session.request.strategy.QueryStatements;
  * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
 public class RelationshipQueryStatementsTest {
 
@@ -104,7 +106,7 @@ public class RelationshipQueryStatementsTest {
     @Test
     public void testFindAllByTypePrimaryIndex() throws Exception {
         PagingAndSortingQuery query = primaryQuery
-            .findAllByType("ORBITS", newArrayList("test-uuid-1", "test-uuid-2"), 2);
+            .findAllByType("ORBITS", Arrays.asList("test-uuid-1", "test-uuid-2"), 2);
 
         assertThat(query.getStatement())
             .isEqualTo("MATCH ()-[r0:`ORBITS`]-() WHERE r0.`uuid` IN {ids}  " +
@@ -114,7 +116,7 @@ public class RelationshipQueryStatementsTest {
                 "WITH r0,startPaths + endPaths  AS paths " +
                 "UNWIND paths AS p RETURN DISTINCT p, ID(r0)");
 
-        assertThat(query.getParameters()).contains(entry("ids", newArrayList("test-uuid-1", "test-uuid-2")));
+        assertThat(query.getParameters()).contains(entry("ids", Arrays.asList("test-uuid-1", "test-uuid-2")));
     }
 
     @Test


### PR DESCRIPTION
All functions used can easily replaced by Java core API, we don’t need an additional 2,5Mb dependency.

For reference see card on Trello.
Can be merged into 3.0.x as well.