### PR TITLE
Handle property fields that cannot be persisted as property fields

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/exception/core/InvalidPropertyFieldException.java
+++ b/core/src/main/java/org/neo4j/ogm/exception/core/InvalidPropertyFieldException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.exception.core;
+
+import org.neo4j.ogm.metadata.FieldInfo;
+
+/**
+ * {@link RuntimeException} that indicates a field that possibly should be persisted as a property
+ * but cannot be persisted as such, maybe due to a missing converter.
+ *
+ * @author Michael J. Simons
+ */
+public class InvalidPropertyFieldException extends MetadataException {
+
+    private final String domainClassName;
+    private final String fieldName;
+
+    public InvalidPropertyFieldException(FieldInfo invalidField) {
+        super(String.format("'%s#%s' is not persistable as property but has not been marked as transient.",
+            invalidField.containingClassInfo().name(), invalidField.getName()));
+
+        this.domainClassName = invalidField.containingClassInfo().name();
+        this.fieldName = invalidField.getName();
+    }
+
+    /**
+     * @return The fully qualified name of the class containing the field.
+     */
+    public String getDomainClassName() {
+        return domainClassName;
+    }
+
+    /**
+     * @return The name of the problematic field.
+     */
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/forum/LeadMembership.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/forum/LeadMembership.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+
+package org.neo4j.ogm.domain.forum;
+
+import java.time.Year;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity("Lead")
+public class LeadMembership extends Membership {
+    @Property
+    private Year yearOfRegistration;
+
+    public Year getYearOfRegistration() {
+        return yearOfRegistration;
+    }
+
+    public void setYearOfRegistration(Year yearOfRegistration) {
+        this.yearOfRegistration = yearOfRegistration;
+    }
+
+    @Override
+    public boolean getCanPost() {
+        return false;
+    }
+
+    @Override
+    public boolean getCanComment() {
+        return false;
+    }
+
+    @Override
+    public boolean getCanFollow() {
+        return false;
+    }
+
+    @Override
+    public IMembership[] getUpgrades() {
+        return new IMembership[0];
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
@@ -15,6 +15,7 @@ package org.neo4j.ogm.metadata;
 
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.rules.ExpectedException.none;
 import static org.neo4j.ogm.annotation.Relationship.*;
 
 import java.util.Collection;
@@ -22,7 +23,9 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.neo4j.ogm.domain.cineasts.partial.Knows;
 import org.neo4j.ogm.domain.cineasts.partial.Rating;
 import org.neo4j.ogm.domain.cineasts.partial.Role;
@@ -31,10 +34,15 @@ import org.neo4j.ogm.domain.forum.Member;
 import org.neo4j.ogm.domain.forum.activity.Activity;
 import org.neo4j.ogm.domain.forum.activity.Post;
 import org.neo4j.ogm.domain.pizza.Pizza;
+import org.neo4j.ogm.exception.core.InvalidPropertyFieldException;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.utils.EntityUtils;
 
 public class ClassInfoTest {
+
+    @Rule
+    public final ExpectedException expectedException = none();
+
 
     private MetaData metaData;
 
@@ -87,6 +95,15 @@ public class ClassInfoTest {
                 count--;
         }
         assertThat(count).isEqualTo(0);
+    }
+
+    @Test // see GH-506
+    public void invalidPropertyFieldsShouldGiveBetterError() {
+
+        this.expectedException.expect(InvalidPropertyFieldException.class);
+        this.expectedException.expectMessage("'org.neo4j.ogm.domain.forum.LeadMembership#yearOfRegistration' is not persistable as property but has not been marked as transient.");
+
+        metaData.classInfo("Lead").propertyFields();
     }
 
     @Test

--- a/test/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
@@ -18,8 +18,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
+ * see DATAGRAPH-590 - Metadata resolves to an abstract class for an interface
+ *
  * @author Vince Bickers
- * @see DATAGRAPH-590 - Metadata resolves to an abstract class for an interface
+ * @author Michael J. Simons
  */
 public class DomainInfoTest {
 
@@ -36,7 +38,7 @@ public class DomainInfoTest {
         ClassInfo classInfo = domainInfo.getClassSimpleName("IMembership");
 
         assertThat(classInfo).isNotNull();
-        assertThat(classInfo.directImplementingClasses()).hasSize(4);
+        assertThat(classInfo.directImplementingClasses()).hasSize(5);
     }
 
     @Test


### PR DESCRIPTION
This commit prevents null pointer exceptions when a field has been marked as property but cannot be actually persisted as a property. Instead it throws a decent exception indicating the underlying problem.

The changes are applicable to OGM 3.0.4 as well. I plan on upgrade SDNs exception translator accordingly.

I find this problem very much annoying, especially for a SDN novice: It took me quiet some time to figure out that my field was a `@Property` but the OGM failed me with a NPE. 

I personally would even suggest to throw that exception in all cases where the field should be persisted as property and not only don't persist anything (that is the case if is not especially annotated and not part of a relationship), but I stopped there because it would change behavior to a large extend.