### PR TITLE
Save predicate for non-iterable case

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
@@ -12,18 +12,17 @@
  */
 package org.neo4j.ogm.session.delegates;
 
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Predicate;
-
 import org.neo4j.ogm.context.EntityGraphMapper;
 import org.neo4j.ogm.context.WriteProtectionTarget;
-import org.neo4j.ogm.cypher.compiler.CompileContext;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.WriteProtectionStrategy;
 import org.neo4j.ogm.session.request.RequestExecutor;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * @author Vince Bickers
@@ -63,7 +62,7 @@ public class SaveDelegate extends SessionDelegate {
             }
 
             EntityGraphMapper mapper = new EntityGraphMapper(session.metaData(), session.context());
-            if(this.writeProtectionStrategy != null) {
+            if (this.writeProtectionStrategy != null) {
                 mapper.addWriteProtection(this.writeProtectionStrategy.get());
             }
             for (Object element : objects) {
@@ -84,11 +83,12 @@ public class SaveDelegate extends SessionDelegate {
                     eventsDelegate.preSave(object);
                 }
 
-                CompileContext context = new EntityGraphMapper(session.metaData(), session.context())
-                    .map(object, depth);
-
-                requestExecutor.executeSave(context);
-
+                EntityGraphMapper mapper = new EntityGraphMapper(session.metaData(), session.context());
+                if (this.writeProtectionStrategy != null) {
+                    mapper.addWriteProtection(this.writeProtectionStrategy.get());
+                }
+                mapper.map(object, depth);
+                requestExecutor.executeSave(mapper.compileContext());
                 if (session.eventsEnabled()) {
                     eventsDelegate.postSave();
                 }

--- a/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
@@ -343,7 +343,7 @@ public class BasicDriverTest extends MultiDriverTestClass {
     }
 
     /**
-//     * @see issue 119
+     * @see issue 119
      */
     @Test
     public void shouldWrapUnderlyingException() {

--- a/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
@@ -12,6 +12,14 @@
  */
 package org.neo4j.ogm.drivers;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -30,15 +38,6 @@ import org.neo4j.ogm.session.Utils;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.neo4j.ogm.transaction.Transaction;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 /**
  * This test class is converted from the AbstractDriverTestSuite to use the test harness in use by other tests.
  * <em>Do not rename this class to end with *Test, or certain test packages might try to execute it.</em>
@@ -52,8 +51,7 @@ public class BasicDriverTest extends MultiDriverTestClass {
 
     @BeforeClass
     public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.social",
-            "org.neo4j.ogm.domain.simpleNetwork.cisco");
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.social");
     }
 
     @Before


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Write protection checking was only added to the block that handles Iterables being passed into `session.save()` method

## Description
<!--- Describe your changes in detail -->
Feel free to decline this PR if you want. I just wanted to be able to easily point at the spot I saw needed a change in order to cover our use case. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Want to be able to have write protections for sub-structure underneath a single given node

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added UT 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
