### PR TITLE
GH-528 - Don’t try to persist typed relationships as properties.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.annotation.Transient;
 
 /**
@@ -60,8 +61,10 @@ public class FieldsInfo {
                                     ParameterizedType parameterizedTypeArgument = (ParameterizedType) typeArgument;
                                     typeParameterDescriptor = parameterizedTypeArgument.getRawType().getTypeName();
                                     break;
-                                } else if (typeArgument instanceof TypeVariable
-                                    || typeArgument instanceof WildcardType) {
+                                } else if ((typeArgument instanceof TypeVariable || typeArgument instanceof WildcardType)
+                                    // The type parameter descriptor doesn't matter if we're dealing with an explicit relationship
+                                    // We must not try to persist it as a property if the user explicitly asked for storing it as a node.
+                                    && !objectAnnotations.has(Relationship.class))  {
                                     typeParameterDescriptor = Object.class.getName();
                                     break;
                                 } else if (typeArgument instanceof Class) {

--- a/test/src/test/java/org/neo4j/ogm/domain/typed_relationships/SomeEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/typed_relationships/SomeEntity.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.domain.typed_relationships;
+
+import java.util.List;
+
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+
+public class SomeEntity {
+
+    private Long id;
+
+    @Relationship(type = "IRRELEVANT", direction = Relationship.INCOMING)
+    private TypedEntity<?> thing;
+
+    @Relationship(type = "ALSO_IRRELEVANT", direction = Relationship.INCOMING)
+    private List<TypedEntity<?>> moreThings;
+
+    protected List<String> someOtherStuff;
+
+    public Long getId() {
+        return id;
+    }
+
+    public TypedEntity<?> getThing() {
+        return thing;
+    }
+
+    public void setThing(TypedEntity<?> thing) {
+        this.thing = thing;
+    }
+
+    public List<TypedEntity<?>> getMoreThings() {
+        return moreThings;
+    }
+
+    public void setMoreThings(List<TypedEntity<?>> moreThings) {
+        this.moreThings = moreThings;
+    }
+
+    public List<String> getSomeOtherStuff() {
+        return someOtherStuff;
+    }
+
+    public void setSomeOtherStuff(List<String> someOtherStuff) {
+        this.someOtherStuff = someOtherStuff;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/typed_relationships/TypedEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/typed_relationships/TypedEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.domain.typed_relationships;
+
+/**
+ * @author Michael J. Simons
+ */
+public class TypedEntity<T> {
+
+    private Long id;
+
+    private T someThing;
+
+    @SuppressWarnings({ "unused" })
+    public TypedEntity() {
+    }
+
+    public TypedEntity(T someThing) {
+        this.someThing = someThing;
+    }
+
+    public T getSomeThing() {
+        return someThing;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/session/delegates/SessionDelegateIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/delegates/SessionDelegateIntegrationTest.java
@@ -23,7 +23,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.domain.generic_hierarchy.ConcreteChild;
 import org.neo4j.ogm.domain.music.Album;
+import org.neo4j.ogm.domain.typed_relationships.SomeEntity;
+import org.neo4j.ogm.domain.typed_relationships.TypedEntity;
 import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
@@ -43,8 +46,9 @@ public class SessionDelegateIntegrationTest extends MultiDriverTestClass {
     private Session session;
 
     @BeforeClass
-    public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.music");
+    public static void createSessionFactory() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.music",
+            "org.neo4j.ogm.domain.typed_relationships");
     }
 
     @Before
@@ -96,5 +100,26 @@ public class SessionDelegateIntegrationTest extends MultiDriverTestClass {
         assertThat(leftChartAtFilter.getPropertyConverter())
             .as("Specified provider should be used")
             .isInstanceOf(DateLongConverter.class);
+    }
+
+    @Test // GH-528
+    public void shouldDealWithTypedRelationships() {
+        SomeEntity someEntity = new SomeEntity();
+
+        someEntity.setThing(new TypedEntity<>(42.21));
+        someEntity.setMoreThings(Arrays.asList(new TypedEntity<>("Die halbe Wahrheit"), new TypedEntity<>("21")));
+        someEntity.setSomeOtherStuff(Arrays.asList("A", "B", "C"));
+
+        session.save(someEntity);
+        session.clear();
+
+        someEntity = session.load(SomeEntity.class, someEntity.getId());
+        assertThat(someEntity.getThing().getSomeThing())
+            .isEqualTo(42.21);
+        assertThat(someEntity.getMoreThings())
+            .extracting(t -> (String) t.getSomeThing())
+            .containsExactlyInAnyOrder("Die halbe Wahrheit", "21");
+        assertThat(someEntity.getSomeOtherStuff())
+            .containsExactlyInAnyOrder("A", "B", "C");
     }
 }


### PR DESCRIPTION
That should fix this NPE #528. 

I'm quite convinced that I don't break other usages, but I'd like your feedback anyway:

If we end up with an Object.class type description and having `@Relationship` in place, we can be quite sure that this should not be modeled as property.

Alas, the fix in the long term must be lies in fixing `org.neo4j.ogm.metadata.FieldInfo#persistableAsProperty` but that has even more implications.