### PR TITLE
Improve Log-Handling in Bolt-, Embedded- and HttpRequest.

### DIFF
--- a/http-driver/src/main/java/org/neo4j/ogm/drivers/http/request/HttpRequest.java
+++ b/http-driver/src/main/java/org/neo4j/ogm/drivers/http/request/HttpRequest.java
@@ -166,7 +166,9 @@ public class HttpRequest implements Request {
         request.setEntity(new StringEntity(cypher, "UTF-8"));
         request.setHeader("X-WRITE", readOnly ? "0" : "1");
 
-        LOGGER.info("Thread: {}, url: {}, request: {}", Thread.currentThread().getId(), url, cypher);
+        if(LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Thread: {}, url: {}, request: {}", Thread.currentThread().getId(), url, cypher);
+        }
 
         return execute(httpClient, request, credentials);
     }


### PR DESCRIPTION
At first I thought about only changing the log level (having all statements including parameters going to info by default is not only annoying, but can also leak data), but than decided to do a bit more cleanup.

- Logger is now static
- Statements and their parameters are only logged to debug

Closes #530.