### PR TITLE
Provide a new configuration option to use native types instead of conversion if applicable.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/driver/AbstractConfigurableDriver.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/AbstractConfigurableDriver.java
@@ -44,6 +44,8 @@ import org.neo4j.ogm.transaction.TransactionManager;
  */
 public abstract class AbstractConfigurableDriver implements Driver {
 
+    public static final ParameterConversion CONVERT_ALL_PARAMETERS_CONVERSION = ObjectMapperBasedParameterConversion.INSTANCE;
+
     private final ServiceLoader<CypherModificationProvider> cypherModificationProviderLoader =
         ServiceLoader.load(CypherModificationProvider.class);
 
@@ -54,7 +56,7 @@ public abstract class AbstractConfigurableDriver implements Driver {
      * Used for configuring the cypher modification providers. Defaults to {@link #getConfiguration()} and reads the
      * custom properties from the common {@link Configuration}.
      */
-    private final Supplier<Map<String, Object>> customPropertiesSupplier;
+    protected final Supplier<Map<String, Object>> customPropertiesSupplier;
     /**
      * Final Cypher modififcation loaded from all present providers.
      */

--- a/api/src/main/java/org/neo4j/ogm/driver/ObjectMapperBasedParameterConversion.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/ObjectMapperBasedParameterConversion.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.driver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.ogm.config.ObjectMapperFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * The "old" way of converting things. Based on Jacksons Object Mapper.
+ *
+ * @author Michael J. Simons
+ */
+enum ObjectMapperBasedParameterConversion implements ParameterConversion {
+
+    INSTANCE;
+
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.objectMapper();
+    private static final TypeReference<HashMap<String, Object>> MAP_TYPE_REF = new TypeReference<HashMap<String, Object>>() {
+    };
+
+    @Override
+    public Map<String, Object> convertParameters(final Map<String, Object> originalParameter) {
+        return OBJECT_MAPPER.convertValue(originalParameter, MAP_TYPE_REF);
+    }
+}

--- a/api/src/main/java/org/neo4j/ogm/driver/ParameterConversion.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/ParameterConversion.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.driver;
+
+import java.util.Map;
+
+/**
+ * Abstraction over the parameter conversion.
+ *
+ * @author Michael J. Simons
+ */
+public interface ParameterConversion {
+
+    Map<String, Object> convertParameters(Map<String, Object> originalParameter);
+}

--- a/api/src/main/java/org/neo4j/ogm/driver/ParameterConversionMode.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/ParameterConversionMode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.driver;
+
+import org.neo4j.ogm.config.ObjectMapperFactory;
+
+/**
+ * Custom configuration mode for controlling parameter conversion in custom Cypher queries.
+ *
+ * @author Michael J. Simons
+ */
+public enum ParameterConversionMode {
+    /**
+     * Convert all parameters to custom queries via Jacksons Object Mapper. The Object Mapper can be customized by registering custom modules
+     * to {@link ObjectMapperFactory#objectMapper()}.
+     */
+    CONVERT_ALL,
+
+    /**
+     * Convert only non-native parameters and use the Java-Driver only. Has only effect on the bolt-transport.
+     */
+    CONVERT_NON_NATIVE_ONLY;
+
+    public static final String CONFIG_PARAMETER_CONVERSION_MODE = ParameterConversionMode.class.getName();
+}

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/JavaDriverBasedParameterConversion.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/JavaDriverBasedParameterConversion.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.drivers.bolt.driver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.ogm.driver.AbstractConfigurableDriver;
+import org.neo4j.ogm.driver.ParameterConversion;
+
+/**
+ * This conversion mode first tries to map all parameters to a {@link Value} and uses them directly. For all non supported
+ * object types, it falls back to the default object mapper based conversion.
+ *
+ * @author Michael J. Simons
+ */
+enum JavaDriverBasedParameterConversion implements ParameterConversion {
+
+    INSTANCE;
+
+    private final ParameterConversion fallback = AbstractConfigurableDriver.CONVERT_ALL_PARAMETERS_CONVERSION;
+
+    @Override
+    public Map<String, Object> convertParameters(Map<String, Object> originalParameter) {
+
+        final Map<String, Object> convertedParameter = new HashMap<>(originalParameter.size());
+        final Map<String, Object> unconvertedParameter = new HashMap<>(originalParameter.size());
+
+        originalParameter.forEach((parameterKey, unconvertedValue) -> {
+            try {
+                Value convertedValue = Values.value(unconvertedValue);
+                convertedParameter.put(parameterKey, convertedValue);
+            } catch (ClientException e) {
+                unconvertedParameter.put(parameterKey, unconvertedValue);
+            }
+        });
+
+        convertedParameter.putAll(fallback.convertParameters(unconvertedParameter));
+        return convertedParameter;
+    }
+}

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/request/BoltRequest.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/request/BoltRequest.java
@@ -14,7 +14,6 @@
 package org.neo4j.ogm.drivers.bolt.request;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -23,7 +22,7 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.driver.v1.exceptions.DatabaseException;
 import org.neo4j.driver.v1.exceptions.TransientException;
-import org.neo4j.ogm.config.ObjectMapperFactory;
+import org.neo4j.ogm.driver.ParameterConversion;
 import org.neo4j.ogm.drivers.bolt.response.GraphModelResponse;
 import org.neo4j.ogm.drivers.bolt.response.GraphRowModelResponse;
 import org.neo4j.ogm.drivers.bolt.response.RestModelResponse;
@@ -47,9 +46,6 @@ import org.neo4j.ogm.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * @author vince
  * @author Luanne Misquitta
@@ -57,18 +53,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class BoltRequest implements Request {
 
-    private static final ObjectMapper mapper = ObjectMapperFactory.objectMapper();
     private static final Logger LOGGER = LoggerFactory.getLogger(BoltRequest.class);
 
     private final TransactionManager transactionManager;
 
-    private TypeReference<HashMap<String, Object>> MAP_TYPE_REF = new TypeReference<HashMap<String, Object>>() {
-    };
+    private final ParameterConversion parameterConversion;
 
     private final Function<String, String> cypherModification;
 
-    public BoltRequest(TransactionManager transactionManager, Function<String, String> cypherModification) {
+    public BoltRequest(TransactionManager transactionManager, ParameterConversion parameterConversion,
+        Function<String, String> cypherModification) {
         this.transactionManager = transactionManager;
+        this.parameterConversion = parameterConversion;
         this.cypherModification = cypherModification;
     }
 
@@ -148,15 +144,14 @@ public class BoltRequest implements Request {
     }
 
     private StatementResult executeRequest(Statement request) {
-        BoltTransaction tx;
         try {
-            Map<String, Object> parameterMap = mapper.convertValue(request.getParameters(), MAP_TYPE_REF);
+            Map<String, Object> parameterMap = parameterConversion.convertParameters(request.getParameters());
             String cypher = cypherModification.apply(request.getStatement());
             if(LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Request: {} with params {}", cypher, parameterMap);
             }
 
-            tx = (BoltTransaction) transactionManager.getCurrentTransaction();
+            BoltTransaction tx = (BoltTransaction) transactionManager.getCurrentTransaction();
             return tx.nativeBoltTransaction().run(cypher, parameterMap);
         } catch (ClientException | DatabaseException | TransientException ce) {
             throw new CypherException("Error executing Cypher", ce, ce.code(), ce.getMessage());

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedBasedParameterConversion.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/driver/EmbeddedBasedParameterConversion.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.drivers.embedded.driver;
+
+import static java.util.stream.Collectors.*;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.neo4j.ogm.driver.AbstractConfigurableDriver;
+import org.neo4j.ogm.driver.ParameterConversion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This conversion mode first tries to map all parameters to a {@link org.neo4j.values.storable.Value}. This method returns
+ * null if a conversion is not possible. For those parameters, the default fallback is used.
+ *
+ * @author Michael J. Simons
+ */
+enum EmbeddedBasedParameterConversion implements ParameterConversion {
+
+    INSTANCE;
+
+    private final Logger logger = LoggerFactory.getLogger(EmbeddedBasedParameterConversion.class);
+    private final ParameterConversion fallback = AbstractConfigurableDriver.CONVERT_ALL_PARAMETERS_CONVERSION;
+
+    private Predicate<Entry<String, Object>> canConvert;
+
+    EmbeddedBasedParameterConversion() {
+
+        // The infrastructure for the kernel based value utils is available since 3.3.x only.
+        try {
+            String fqnOfValues = "org.neo4j.values.storable.Values";
+            Method unsafeOf = Class.forName(fqnOfValues)
+                .getDeclaredMethod("unsafeOf", Object.class, boolean.class);
+
+            this.canConvert = new WrappedValuesUnsafeOf(unsafeOf);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            logger.warn("Cannot use native type conversion prior to Neo4j 3.3.x");
+            canConvert = anyObject -> false;
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertParameters(Map<String, Object> originalParameter) {
+
+        Map<Boolean, Map<String, Object>> allParameters = originalParameter.entrySet().stream()
+            .collect(partitioningBy(canConvert, Collectors.toMap(Entry::getKey, Entry::getValue)));
+
+        Map<String, Object> convertedParameters = new HashMap<>(originalParameter.size());
+        convertedParameters.putAll(allParameters.get(true));
+        convertedParameters.putAll(fallback.convertParameters(allParameters.get(false)));
+
+        return convertedParameters;
+    }
+
+    private static class WrappedValuesUnsafeOf implements Predicate<Entry<String, Object>> {
+        private final Method unsafeOf;
+
+        WrappedValuesUnsafeOf(Method unsafeOf) {
+            this.unsafeOf = unsafeOf;
+        }
+
+        @Override
+        public boolean test(Entry<String, Object> o) {
+            try {
+                return this.unsafeOf.invoke(null, o.getValue(), true) != null;
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                // InvocationTargetException is ignored on purpose, just try the default fallback then.
+            }
+            return false;
+        }
+    }
+}

--- a/test/src/main/java/org/neo4j/ogm/testutil/SingleDriverTestClass.java
+++ b/test/src/main/java/org/neo4j/ogm/testutil/SingleDriverTestClass.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.testutil;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.harness.ServerControls;
+import org.neo4j.harness.TestServerBuilders;
+import org.neo4j.ogm.driver.AbstractConfigurableDriver;
+import org.neo4j.ogm.session.SessionFactory;
+
+/**
+ * In contrast to the {@link MultiDriverTestClass}, this facilitates only the Neo4j Test Harness and provides access to
+ * a server through a configured Java driver respectively the embedded instanceof {@link #getGraphDatabaseService()}.<br>
+ * In cases needed, it offers also the {@link org.neo4j.driver.internal.util.ServerVersion} of the backing database.
+ *
+ * @author Michael J. Simons
+ */
+public abstract class SingleDriverTestClass {
+    static final Config DRIVER_CONFIG = Config.build().withoutEncryption().toConfig();
+
+    private static ServerControls serverControls;
+    private ServerVersion serverVersion;
+
+    @BeforeClass
+    public static void initializeNeo4j() {
+        serverControls = TestServerBuilders.newInProcessBuilder().newServer();
+    }
+
+    public GraphDatabaseService getGraphDatabaseService() {
+        return serverControls.graph();
+    }
+
+    /**
+     * Gets a new driver against the server controls. The caller is required to close this driver instance himself.
+     *
+     * @return A ready to use driver
+     */
+    public Driver getDriver() {
+        return GraphDatabase.driver(serverControls.boltURI(), DRIVER_CONFIG);
+    }
+
+    /**
+     * Opens a driver on the first use to get the servers version.
+     *
+     * @return
+     */
+    public ServerVersion getServerVersion() {
+        ServerVersion rv = serverVersion;
+        if (rv == null) {
+            synchronized (this) {
+                if (serverVersion == null) {
+                    try (Driver driver = getDriver()) {
+                        rv = serverVersion = ServerVersion.version(driver);
+                    }
+                }
+            }
+        }
+        return rv;
+    }
+
+    public boolean databaseSupportJava8TimeTypes() {
+        return getServerVersion()
+            .greaterThanOrEqual(ServerVersion.version("3.4.0"));
+    }
+
+    protected void doWithSessionFactoryOf(
+        AbstractConfigurableDriver ogmDriver, Class[] inBasePackageClasses,
+        Consumer<SessionFactory> consumerOfSessionFactory
+    ) {
+        String[] basePackages = Arrays.stream(inBasePackageClasses)
+            .map(Class::getName)
+            .toArray(String[]::new);
+
+        SessionFactory sessionFactory = null;
+        try {
+            sessionFactory = new SessionFactory(ogmDriver, basePackages);
+            consumerOfSessionFactory.accept(sessionFactory);
+        } finally {
+            if (sessionFactory != null) {
+                sessionFactory.close();
+            }
+        }
+    }
+
+    @AfterClass
+    public static void tearDownNeo4j() {
+        serverControls.close();
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/drivers/bolt/JavaBasedParameterConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/bolt/JavaBasedParameterConversionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.drivers.bolt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
+import static org.neo4j.ogm.driver.ParameterConversionMode.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.types.TypeSystem;
+import org.neo4j.ogm.driver.ParameterConversionMode;
+import org.neo4j.ogm.drivers.bolt.driver.BoltDriver;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.testutil.SingleDriverTestClass;
+
+/**
+ * @author Michael J. Simons
+ */
+public class JavaBasedParameterConversionTest extends SingleDriverTestClass {
+
+    @Test
+    public void shouldUseNativeTypesWhenNonNativeTypesOnlyIsActive() {
+
+        assumeTrue(driverSupportsLocalDate());
+        assumeTrue(databaseSupportJava8TimeTypes());
+
+        Map<String, Object> customConfiguration = new HashMap<>();
+        customConfiguration.put(ParameterConversionMode.CONFIG_PARAMETER_CONVERSION_MODE, CONVERT_NON_NATIVE_ONLY);
+
+        try (Driver driver = getDriver()) {
+
+            BoltDriver boltOgmDriver = new BoltDriver(driver, () -> customConfiguration);
+
+            doWithSessionFactoryOf(boltOgmDriver, new Class[] { JavaBasedParameterConversionTest.class },
+                sessionFactory -> {
+                    Session session = sessionFactory.openSession();
+
+                    LocalDateTime originalDateTime = LocalDateTime.of(2018, 10, 11, 15, 24);
+
+                    Map<String, Object> parameters = new HashMap<>();
+                    parameters.put("createdAt", originalDateTime);
+                    session.query("CREATE (n:Test {createdAt: $createdAt})", parameters);
+
+                    Record record = driver.session().run("MATCH (n:Test) RETURN n.createdAt as createdAt").single();
+                    Object createdAt = record.get("createdAt").asObject();
+                    assertThat(createdAt).isInstanceOf(LocalDateTime.class)
+                        .isEqualTo(originalDateTime);
+                });
+        }
+    }
+
+    private static boolean driverSupportsLocalDate() {
+
+        Class<TypeSystem> t = TypeSystem.class;
+        try {
+            return t.getDeclaredMethod("LOCAL_DATE_TIME") != null;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/drivers/embedded/EmbeddedBasedParameterConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/embedded/EmbeddedBasedParameterConversionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.drivers.embedded;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assume.*;
+import static org.neo4j.ogm.driver.ParameterConversionMode.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.ogm.drivers.embedded.driver.EmbeddedDriver;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.testutil.SingleDriverTestClass;
+
+/**
+ * @author Michael J. Simons
+ */
+public class EmbeddedBasedParameterConversionTest extends SingleDriverTestClass {
+
+    @Test
+    public void shouldUseNativeTypesWhenNonNativeTypesOnlyIsActive() {
+
+        assumeTrue(databaseSupportJava8TimeTypes());
+
+        Map<String, Object> customConfiguration = new HashMap<>();
+        customConfiguration.put(CONFIG_PARAMETER_CONVERSION_MODE, CONVERT_NON_NATIVE_ONLY);
+
+        GraphDatabaseService graphDatabaseService = getGraphDatabaseService();
+        EmbeddedDriver embeddedOgmDriver = new EmbeddedDriver(graphDatabaseService, () -> customConfiguration);
+
+        doWithSessionFactoryOf(embeddedOgmDriver, new Class[] { EmbeddedBasedParameterConversionTest.class },
+            sessionFactory -> {
+                Session session = sessionFactory.openSession();
+
+                LocalDateTime originalDateTime = LocalDateTime.of(2018, 10, 11, 15, 24);
+
+                Map<String, Object> parameters = new HashMap<>();
+                parameters.put("createdAt", originalDateTime);
+                session.query("CREATE (n:Test {createdAt: $createdAt})", parameters);
+
+                Object createdAt = graphDatabaseService.execute("MATCH (n:Test) RETURN n.createdAt AS createdAt").next()
+                    .get("createdAt");
+                assertThat(createdAt).isInstanceOf(LocalDateTime.class)
+                    .isEqualTo(originalDateTime);
+            });
+    }
+}


### PR DESCRIPTION
This allows skipping conversion of parameters if a native type is available for a given parameter. Can be used like this:

```
@Configuration
public class Neo4jConfiguration {
	@Bean
	public org.neo4j.ogm.config.Configuration configuration(Neo4jProperties properties) {
		var ogmConfiguration = properties.createConfiguration();
		ogmConfiguration.getCustomProperties()
			.put(ParameterConversionMode.CONFIG_KEY, ParameterConversionMode.CONVERT_NON_NATIVE_ONLY);
		return ogmConfiguration;
	}
}
```

I'd even make it the default for the bolt driver, but that would break things for people that now relying on having strings instead of the real datatypes inside their storage.