### PR TITLE
Fix loading by parent class / interface for custom id.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
+++ b/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
@@ -27,6 +27,7 @@ import org.neo4j.ogm.metadata.ClassInfo;
  *
  * @author Frantisek Hartman
  * @author Jonathan D'Orleans
+ * @author Gerrit Meier
  */
 class LabelPrimaryId {
 
@@ -39,17 +40,9 @@ class LabelPrimaryId {
      * @param classInfo class info containing the primary id
      * @param id        the value of the id
      */
-    public LabelPrimaryId(ClassInfo classInfo, Object id) {
+    LabelPrimaryId(ClassInfo classInfo, Object id) {
         this.label = classInfo.neo4jName();
         this.id = requireNonNull(id);
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public Object getId() {
-        return id;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -13,7 +13,15 @@
 
 package org.neo4j.ogm.context;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.neo4j.ogm.annotation.NodeEntity;
@@ -88,6 +96,12 @@ public class MappingContext {
      */
     public Object getNodeEntityById(ClassInfo classInfo, Object id) {
 
+        // immediately return if the requests class cannot represent a node in the graph
+        if ((classInfo.isInterface() || classInfo.isAbstract())
+            && classInfo.annotationsInfo().get(NodeEntity.class) == null) {
+            return null;
+        }
+
         // direct match
         Object node = primaryIndexNodeRegister.get(new LabelPrimaryId(classInfo, id));
         if (node != null) {
@@ -95,15 +109,10 @@ public class MappingContext {
         }
 
         // the retrieved node is an implementation/extension of the abstract type / interface queried for.
-        Deque<ClassInfo> queue = new LinkedList<>(classInfo.directSubclasses());
-
+        Queue<ClassInfo> queue = new LinkedList<>(classInfo.directSubclasses());
         while (!queue.isEmpty()) {
 
-            ClassInfo subClassInfo = queue.pop();
-
-            if (subClassInfo.annotationsInfo().get(NodeEntity.class) ==null) {
-                continue;
-            }
+            ClassInfo subClassInfo = queue.poll();
 
             node = primaryIndexNodeRegister.get(new LabelPrimaryId(subClassInfo, id));
             if (node != null) {

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -249,7 +249,7 @@ public class ClassInfo {
         return labelNames;
     }
 
-    List<ClassInfo> directSubclasses() {
+    public List<ClassInfo> directSubclasses() {
         return directSubclasses;
     }
 

--- a/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/MostBasicEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/MostBasicEntity.java
@@ -1,0 +1,22 @@
+package org.neo4j.ogm.domain.hierarchy.domain.custom_id;
+
+import java.util.UUID;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
+public abstract class MostBasicEntity {
+
+    @Id
+    @Convert(UuidStringConverter.class)
+    private UUID myId;
+
+    public UUID getMyId() {
+        return myId;
+    }
+
+    public void setMyId(UUID myId) {
+        this.myId = myId;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/RootEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/RootEntity.java
@@ -1,0 +1,34 @@
+package org.neo4j.ogm.domain.hierarchy.domain.custom_id;
+
+import java.util.UUID;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.UuidStringConverter;
+
+@NodeEntity
+public abstract class RootEntity {
+
+    @Id
+    @Convert(UuidStringConverter.class)
+    private UUID myId;
+
+    private String name;
+
+    public UUID getMyId() {
+        return myId;
+    }
+
+    public void setMyId(UUID myId) {
+        this.myId = myId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/RootEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/RootEntity.java
@@ -1,28 +1,11 @@
 package org.neo4j.ogm.domain.hierarchy.domain.custom_id;
 
-import java.util.UUID;
-
-import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
-import org.neo4j.ogm.annotation.typeconversion.Convert;
-import org.neo4j.ogm.typeconversion.UuidStringConverter;
 
 @NodeEntity
-public abstract class RootEntity {
-
-    @Id
-    @Convert(UuidStringConverter.class)
-    private UUID myId;
+public abstract class RootEntity extends MostBasicEntity {
 
     private String name;
-
-    public UUID getMyId() {
-        return myId;
-    }
-
-    public void setMyId(UUID myId) {
-        this.myId = myId;
-    }
 
     public String getName() {
         return name;

--- a/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/SubEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/SubEntity.java
@@ -1,0 +1,8 @@
+package org.neo4j.ogm.domain.hierarchy.domain.custom_id;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class SubEntity extends RootEntity {
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/SubSubEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/hierarchy/domain/custom_id/SubSubEntity.java
@@ -1,0 +1,4 @@
+package org.neo4j.ogm.domain.hierarchy.domain.custom_id;
+
+public class SubSubEntity extends SubEntity {
+}

--- a/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -19,13 +19,17 @@ import static org.neo4j.ogm.testutil.GraphTestUtils.*;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.ogm.domain.hierarchy.domain.custom_id.RootEntity;
+import org.neo4j.ogm.domain.hierarchy.domain.custom_id.SubEntity;
 import org.neo4j.ogm.domain.hierarchy.domain.annotated.*;
+import org.neo4j.ogm.domain.hierarchy.domain.custom_id.SubSubEntity;
 import org.neo4j.ogm.domain.hierarchy.domain.people.Bloke;
 import org.neo4j.ogm.domain.hierarchy.domain.people.Entity;
 import org.neo4j.ogm.domain.hierarchy.domain.people.Female;
@@ -826,4 +830,41 @@ public class ClassHierarchiesIntegrationTest extends MultiDriverTestClass {
         assertThat(m1.getName()).isEqualTo("m1");
         assertThat(m1.getChildren().iterator().next().getName()).isEqualTo("c1");
     }
+
+    /**
+     * #553
+     */
+    @Test
+    public void shouldLoadImplementationWhenParentClassIsQueriedDirectSubclass() {
+        UUID uuid = UUID.randomUUID();
+        SubEntity subEntity = new SubEntity();
+        subEntity.setMyId(uuid);
+        subEntity.setName("test");
+
+        session.save(subEntity);
+        session.clear();
+
+        RootEntity rootEntity = session.load(RootEntity.class, uuid);
+
+        assertThat(rootEntity).isNotNull();
+    }
+
+    /**
+     * #553
+     */
+    @Test
+    public void shouldLoadImplementationWhenParentClassIsQueriedDeepSubclass() {
+        UUID uuid = UUID.randomUUID();
+        SubSubEntity subsubEntity = new SubSubEntity();
+        subsubEntity.setMyId(uuid);
+        subsubEntity.setName("test");
+
+        session.save(subsubEntity);
+        session.clear();
+
+        RootEntity rootEntity = session.load(RootEntity.class, uuid);
+
+        assertThat(rootEntity).isNotNull();
+    }
+
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -26,6 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.ogm.domain.hierarchy.domain.custom_id.MostBasicEntity;
 import org.neo4j.ogm.domain.hierarchy.domain.custom_id.RootEntity;
 import org.neo4j.ogm.domain.hierarchy.domain.custom_id.SubEntity;
 import org.neo4j.ogm.domain.hierarchy.domain.annotated.*;
@@ -865,6 +866,60 @@ public class ClassHierarchiesIntegrationTest extends MultiDriverTestClass {
         RootEntity rootEntity = session.load(RootEntity.class, uuid);
 
         assertThat(rootEntity).isNotNull();
+    }
+
+    /**
+     * #553
+     */
+    @Test
+    public void shouldLoadImplementationWhenParentClassIsQueriedDeepSubclasWithsMostBasicEntity() {
+        UUID uuid = UUID.randomUUID();
+        SubSubEntity subsubEntity = new SubSubEntity();
+        subsubEntity.setMyId(uuid);
+        subsubEntity.setName("test");
+
+        session.save(subsubEntity);
+        session.clear();
+
+        MostBasicEntity rootEntity = session.load(MostBasicEntity.class, uuid);
+
+        assertThat(rootEntity).isNull();
+    }
+
+    /**
+     * #553
+     */
+    @Test
+    public void shouldLoadImplementationWhenParentClassIsQueriedLoadAll() {
+        UUID uuid = UUID.randomUUID();
+        SubSubEntity subsubEntity = new SubSubEntity();
+        subsubEntity.setMyId(uuid);
+        subsubEntity.setName("test");
+
+        session.save(subsubEntity);
+        session.clear();
+
+        Collection<RootEntity> rootEntity = session.loadAll(RootEntity.class);
+
+        assertThat(rootEntity).isNotEmpty();
+    }
+
+    /**
+     * #553
+     */
+    @Test
+    public void shouldLoadImplementationWhenParentClassIsQueriedLoadAllWithAbstractNonAnnotatedBaseClass() {
+        UUID uuid = UUID.randomUUID();
+        SubSubEntity subsubEntity = new SubSubEntity();
+        subsubEntity.setMyId(uuid);
+        subsubEntity.setName("test");
+
+        session.save(subsubEntity);
+        session.clear();
+
+        Collection<MostBasicEntity> rootEntity = session.loadAll(MostBasicEntity.class);
+
+        assertThat(rootEntity).isEmpty();
     }
 
 }


### PR DESCRIPTION
If ClassB extends ClassA, has a custom identifier and gets queried
by a session.load(ClassA.class) it won't return a result because
the current implementation does not look for possible implementations.

This fix uses a simple breadth first search to retrieve the best
matching implementation.

Solves #553