### PR TITLE
Fix ClassCastExceptions due to wrong type detection in certain hierarchies.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
@@ -13,6 +13,8 @@
 
 package org.neo4j.ogm.metadata;
 
+import static org.neo4j.ogm.metadata.reflect.GenericUtils.*;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -98,8 +100,8 @@ public class FieldInfo {
     public FieldInfo(ClassInfo classInfo, Field field, String typeParameterDescriptor, ObjectAnnotations annotations, boolean isSupportedNativeType) {
         this.containingClassInfo = classInfo;
         this.field = field;
-        this.fieldType = field.getType();
-        this.isArray = field.getType().isArray();
+        this.fieldType = isGenericField(field) ? findFieldType(field, classInfo.getUnderlyingClass()) : field.getType();
+        this.isArray = fieldType.isArray();
         this.name = field.getName();
         this.descriptor = field.getType().getTypeName();
         this.typeParameterDescriptor = typeParameterDescriptor;

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
@@ -84,7 +84,7 @@ public class EntityAccessManager {
 
             Object array = Array.newInstance(type, objects.size());
             for (int i = 0; i < objects.size(); i++) {
-                Array.set(array, i, objects.get(i));
+                Array.set(array, i, Utils.coerceTypes(type, objects.get(i)));
             }
             return array;
         }

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/GenericUtils.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/GenericUtils.java
@@ -1,27 +1,49 @@
 /*
- * Copyright (c) 2002-2018 "Neo Technology,"
- * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ * Copyright 2002-2019 the original author or authors.
  *
- * This product is licensed to you under the Apache License, Version 2.0 (the "License").
- * You may not use this product except in compliance with the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This product may include a number of subcomponents with
- * separate copyright notices and license terms. Your use of the source
- * code for these subcomponents is subject to the terms and
- * conditions of the subcomponent's license, as noted in the LICENSE file.
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.neo4j.ogm.metadata.reflect;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
+ * Contains a stripped down version of <a href="https://github.com/jhalterman">Jonathan Halterman's</a>
+ * <a href="https://github.com/jhalterman/typetools/blob/master/src/main/java/net/jodah/typetools/TypeResolver.java">TypeResolver</a>
+ * from <a href="https://github.com/jhalterman/typetools">Typetools</a>.
+ *
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
-public class GenericUtils {
+public final class GenericUtils {
+
+    /**
+     * Helper to check whether a given field is a generic field (A field described by a type variable).
+     *
+     * @param field The field to check for a type variable
+     * @return True, if {@code field} is a generic field.
+     */
+    public static boolean isGenericField(Field field) {
+        return field.getGenericType() instanceof TypeVariable;
+    }
 
     /**
      * Tries to discover type of given field
@@ -35,47 +57,193 @@ public class GenericUtils {
      */
     public static Class findFieldType(Field field, Class concreteClass) {
 
-        if (field.getGenericType() instanceof Class) {
+        Class<?>[] arguments = resolveRawArguments(field.getGenericType(), concreteClass);
+        if (arguments == null || arguments.length == 0 || arguments[0] == Unknown.class) {
             return field.getType();
         }
 
-        TypeVariable[] typeParameters = field.getDeclaringClass().getTypeParameters();
-        for (int i = 0; i < typeParameters.length; i++) {
-            if (typeParameters[i].getName().equals(field.getGenericType().getTypeName())) {
-
-                ParameterizedType genericSuperclass = findMatchingSuperclass(concreteClass, field);
-                if (genericSuperclass != null) {
-                    return (Class) genericSuperclass.getActualTypeArguments()[i];
-                }
-            }
-        }
-
-        return field.getType();
+        return arguments[0];
     }
 
     /**
-     * Find a generic superclass of given class that matches declaring class of given field
+     * Returns an array of raw classes representing arguments for the {@code genericType} using type variable information
+     * from the {@code subType}. Arguments for {@code genericType} that cannot be resolved are returned as
+     * {@code Unknown.class}. If no arguments can be resolved then {@code null} is returned.
      *
-     * @param clazz concrete class
-     * @param field field
-     * @return superclass as ParameterizedType
+     * @param genericType to resolve arguments for
+     * @param subType     to extract type variable information from
+     * @return array of raw classes representing arguments for the {@code genericType} else {@code null} if no type
+     * arguments are declared
      */
-    private static ParameterizedType findMatchingSuperclass(Class clazz, Field field) {
-        Type superclass = clazz.getGenericSuperclass();
-        if (superclass == null) {
-            return null;
+    private static Class<?>[] resolveRawArguments(Type genericType, Class<?> subType) {
+        Class<?>[] result = null;
+        Class<?> functionalInterface = null;
+
+        // Handle lambdas
+        if (subType.isSynthetic()) {
+            Class<?> fi = genericType instanceof ParameterizedType
+                && ((ParameterizedType) genericType).getRawType() instanceof Class
+                ? (Class<?>) ((ParameterizedType) genericType).getRawType()
+                : genericType instanceof Class ? (Class<?>) genericType : null;
+            if (fi != null && fi.isInterface())
+                functionalInterface = fi;
         }
 
-        if (superclass instanceof ParameterizedType) {
-            ParameterizedType paramType = (ParameterizedType) superclass;
-            if (paramType.getRawType().equals(field.getDeclaringClass())) {
-                return paramType;
-            } else {
-                return findMatchingSuperclass(clazz.getSuperclass(), field);
+        if (genericType instanceof ParameterizedType) {
+            ParameterizedType paramType = (ParameterizedType) genericType;
+            Type[] arguments = paramType.getActualTypeArguments();
+            result = new Class[arguments.length];
+            for (int i = 0; i < arguments.length; i++)
+                result[i] = resolveRawClass(arguments[i], subType, functionalInterface);
+        } else if (genericType instanceof TypeVariable) {
+            result = new Class[1];
+            result[0] = resolveRawClass(genericType, subType, functionalInterface);
+        } else if (genericType instanceof Class) {
+            TypeVariable<?>[] typeParams = ((Class<?>) genericType).getTypeParameters();
+            result = new Class[typeParams.length];
+            for (int i = 0; i < typeParams.length; i++)
+                result[i] = resolveRawClass(typeParams[i], subType, functionalInterface);
+        }
+
+        return result;
+    }
+
+    private static Class<?> resolveRawClass(Type genericType, Class<?> subType, Class<?> functionalInterface) {
+        if (genericType instanceof Class) {
+            return (Class<?>) genericType;
+        } else if (genericType instanceof ParameterizedType) {
+            return resolveRawClass(((ParameterizedType) genericType).getRawType(), subType, functionalInterface);
+        } else if (genericType instanceof GenericArrayType) {
+            GenericArrayType arrayType = (GenericArrayType) genericType;
+            Class<?> component = resolveRawClass(arrayType.getGenericComponentType(), subType, functionalInterface);
+            return Array.newInstance(component, 0).getClass();
+        } else if (genericType instanceof TypeVariable) {
+            TypeVariable<?> variable = (TypeVariable<?>) genericType;
+            genericType = getTypeVariableMap(subType, functionalInterface).get(variable);
+            genericType = genericType == null ? resolveBound(variable)
+                : resolveRawClass(genericType, subType, functionalInterface);
+        }
+
+        return genericType instanceof Class ? (Class<?>) genericType : Unknown.class;
+    }
+
+    private static Map<TypeVariable<?>, Type> getTypeVariableMap(final Class<?> targetType,
+        Class<?> functionalInterface) {
+        Map<TypeVariable<?>, Type> map = new HashMap<TypeVariable<?>, Type>();
+
+        // Populate interfaces
+        populateSuperTypeArgs(targetType.getGenericInterfaces(), map, functionalInterface != null);
+
+        // Populate super classes and interfaces
+        Type genericType = targetType.getGenericSuperclass();
+        Class<?> type = targetType.getSuperclass();
+        while (type != null && !Object.class.equals(type)) {
+            if (genericType instanceof ParameterizedType)
+                populateTypeArgs((ParameterizedType) genericType, map, false);
+            populateSuperTypeArgs(type.getGenericInterfaces(), map, false);
+
+            genericType = type.getGenericSuperclass();
+            type = type.getSuperclass();
+        }
+
+        // Populate enclosing classes
+        type = targetType;
+        while (type.isMemberClass()) {
+            genericType = type.getGenericSuperclass();
+            if (genericType instanceof ParameterizedType)
+                populateTypeArgs((ParameterizedType) genericType, map, functionalInterface != null);
+
+            type = type.getEnclosingClass();
+        }
+
+        return map;
+    }
+
+    /**
+     * Populates the {@code map} with with variable/argument pairs for the given {@code types}.
+     */
+    private static void populateSuperTypeArgs(final Type[] types, final Map<TypeVariable<?>, Type> map,
+        boolean depthFirst) {
+        for (Type type : types) {
+            if (type instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) type;
+                if (!depthFirst)
+                    populateTypeArgs(parameterizedType, map, depthFirst);
+                Type rawType = parameterizedType.getRawType();
+                if (rawType instanceof Class)
+                    populateSuperTypeArgs(((Class<?>) rawType).getGenericInterfaces(), map, depthFirst);
+                if (depthFirst)
+                    populateTypeArgs(parameterizedType, map, depthFirst);
+            } else if (type instanceof Class) {
+                populateSuperTypeArgs(((Class<?>) type).getGenericInterfaces(), map, depthFirst);
             }
-        } else {
-            return findMatchingSuperclass(clazz.getSuperclass(), field);
         }
+    }
 
+    /**
+     * Populates the {@code map} with variable/argument pairs for the given {@code type}.
+     */
+    private static void populateTypeArgs(ParameterizedType type, Map<TypeVariable<?>, Type> map, boolean depthFirst) {
+        if (type.getRawType() instanceof Class) {
+            TypeVariable<?>[] typeVariables = ((Class<?>) type.getRawType()).getTypeParameters();
+            Type[] typeArguments = type.getActualTypeArguments();
+
+            if (type.getOwnerType() != null) {
+                Type owner = type.getOwnerType();
+                if (owner instanceof ParameterizedType)
+                    populateTypeArgs((ParameterizedType) owner, map, depthFirst);
+            }
+
+            for (int i = 0; i < typeArguments.length; i++) {
+                TypeVariable<?> variable = typeVariables[i];
+                Type typeArgument = typeArguments[i];
+
+                if (typeArgument instanceof Class) {
+                    map.put(variable, typeArgument);
+                } else if (typeArgument instanceof GenericArrayType) {
+                    map.put(variable, typeArgument);
+                } else if (typeArgument instanceof ParameterizedType) {
+                    map.put(variable, typeArgument);
+                } else if (typeArgument instanceof TypeVariable) {
+                    TypeVariable<?> typeVariableArgument = (TypeVariable<?>) typeArgument;
+                    if (depthFirst) {
+                        Type existingType = map.get(variable);
+                        if (existingType != null) {
+                            map.put(typeVariableArgument, existingType);
+                            continue;
+                        }
+                    }
+
+                    Type resolvedType = map.get(typeVariableArgument);
+                    if (resolvedType == null)
+                        resolvedType = resolveBound(typeVariableArgument);
+                    map.put(variable, resolvedType);
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolves the first bound for the {@code typeVariable}, returning {@code Unknown.class} if none can be resolved.
+     */
+    private static Type resolveBound(TypeVariable<?> typeVariable) {
+        Type[] bounds = typeVariable.getBounds();
+        if (bounds.length == 0)
+            return Unknown.class;
+
+        Type bound = bounds[0];
+        if (bound instanceof TypeVariable)
+            bound = resolveBound((TypeVariable<?>) bound);
+
+        return bound == Object.class ? Unknown.class : bound;
+    }
+
+    /**
+     * An unknown type.
+     */
+    private static final class Unknown {
+    }
+
+    private GenericUtils() {
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/gh492/BaseUser.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh492/BaseUser.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.domain.gh492;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ *
+ * @param <T> Type of the generic value
+ * @author Michael J. Simons
+ */
+public abstract class BaseUser<T> {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String loginName;
+
+    private T genericValue;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getLoginName() {
+        return loginName;
+    }
+
+    public void setLoginName(final String loginName) {
+        this.loginName = loginName;
+    }
+
+    public T getGenericValue() {
+        return genericValue;
+    }
+
+    public void setGenericValue(final T genericValue) {
+        this.genericValue = genericValue;
+    }
+
+    @NodeEntity
+    public static class StringUser extends BaseUser<String[]> {
+    }
+
+    @NodeEntity
+    public static class ByteUser extends BaseUser<byte[]> {
+
+        private byte[] notGenericValue;
+
+        public byte[] getNotGenericValue() {
+            return notGenericValue;
+        }
+
+        public void setNotGenericValue(final byte[] notGenericValue) {
+            this.notGenericValue = notGenericValue;
+        }
+    }
+
+    @NodeEntity
+    public static class IntUser extends BaseUser<int[]> {
+    }
+
+    @NodeEntity
+    public static class IntegerUser extends BaseUser<Integer[]> {
+    }
+
+    @NodeEntity
+    public static class LongUser extends BaseUser<long[]> {
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/metadata/GenericsFieldsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/GenericsFieldsTest.java
@@ -13,13 +13,17 @@
 
 package org.neo4j.ogm.metadata;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.Serializable;
 import java.util.Map;
 
 import org.junit.Test;
+import org.neo4j.ogm.domain.gh492.BaseUser;
 
 /**
- * @author vince
+ * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class GenericsFieldsTest extends TestMetaDataTypeResolution {
 
@@ -91,5 +95,25 @@ public class GenericsFieldsTest extends TestMetaDataTypeResolution {
     @Test    // Iterable<Map<Class<S>, POJO<S, T, U>>> iterable;
     public void testIterableOfMapOfParameterizedClasses() {
         checkField("iterable", "java.util.Map", Map.class);
+    }
+
+    @Test // GH-492
+    public void shouldDetectPrimitiveArraysInGenericFields() {
+        MetaData metaData = new MetaData("org.neo4j.ogm.domain.gh492");
+
+        ClassInfo classInfo = metaData.classInfo(BaseUser.IntUser.class);
+        FieldInfo fieldInfo = classInfo.getFieldInfo("genericValue");
+        assertThat(fieldInfo.isArray()).isTrue();
+        assertThat(fieldInfo.type()).isEqualTo(int[].class);
+    }
+
+    @Test // GH-492
+    public void shouldDetectWrapperArraysInGenericFields() {
+        MetaData metaData = new MetaData("org.neo4j.ogm.domain.gh492");
+
+        ClassInfo classInfo = metaData.classInfo(BaseUser.IntegerUser.class);
+        FieldInfo fieldInfo = classInfo.getFieldInfo("genericValue");
+        assertThat(fieldInfo.isArray()).isTrue();
+        assertThat(fieldInfo.type()).isEqualTo(Integer[].class);
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/typeconversion/GenericArrayConversionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/typeconversion/GenericArrayConversionTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ * You may not use this product except in compliance with the License.
+ *
+ * This product may include a number of subcomponents with
+ * separate copyright notices and license terms. Your use of the source
+ * code for these subcomponents is subject to the terms and
+ *  conditions of the subcomponent's license, as noted in the LICENSE file.
+ */
+package org.neo4j.ogm.typeconversion;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.Config;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.harness.ServerControls;
+import org.neo4j.harness.TestServerBuilders;
+import org.neo4j.ogm.domain.gh492.BaseUser.ByteUser;
+import org.neo4j.ogm.domain.gh492.BaseUser.IntUser;
+import org.neo4j.ogm.domain.gh492.BaseUser.IntegerUser;
+import org.neo4j.ogm.domain.gh492.BaseUser.LongUser;
+import org.neo4j.ogm.domain.gh492.BaseUser.StringUser;
+import org.neo4j.ogm.driver.Driver;
+import org.neo4j.ogm.drivers.bolt.driver.BoltDriver;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+
+/**
+ * @author Michael J. Simons
+ */
+public class GenericArrayConversionTest {
+    protected static final String DOMAIN_PACKAGE = "org.neo4j.ogm.domain.gh492";
+
+    protected static ServerControls serverControls;
+
+    protected static SessionFactory sessionFactory;
+
+    @BeforeClass
+    public static void startServer() {
+        serverControls = TestServerBuilders.newInProcessBuilder().newServer();
+        Driver driver = new BoltDriver(
+            GraphDatabase.driver(serverControls.boltURI(), Config.build().withoutEncryption().toConfig()));
+        sessionFactory = new SessionFactory(driver, DOMAIN_PACKAGE);
+    }
+
+    @Test // GH-492
+    public void byteSampleTest() {
+        ByteUser byteUser = new ByteUser();
+        byteUser.setLoginName("test-byteUser");
+        byteUser.setGenericValue(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+        byteUser.setNotGenericValue(new byte[] { 7, 6, 5, 4, 3, 2, 1, 0 });
+
+        Session session = sessionFactory.openSession();
+        session.save(byteUser);
+        session.clear();
+
+        byteUser = session.load(ByteUser.class, byteUser.getId());
+
+        assertThat(byteUser.getNotGenericValue()).isInstanceOf(byte[].class);
+        assertThat(byteUser.getGenericValue()).isInstanceOf(byte[].class);
+    }
+
+    @Test // GH-492
+    public void intSampleTest() {
+        IntUser intUser = new IntUser();
+        intUser.setLoginName("test-intUser");
+        intUser.setGenericValue(new int[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+
+        Session session = sessionFactory.openSession();
+        session.save(intUser);
+        session.clear();
+
+        intUser = session.load(IntUser.class, intUser.getId());
+        assertThat(intUser.getGenericValue()).isInstanceOf(int[].class);
+    }
+
+    @Test // GH-492
+    public void integerSampleTest() {
+        IntegerUser integerUser = new IntegerUser();
+        integerUser.setLoginName("test-intUser");
+        integerUser.setGenericValue(new Integer[] { Integer.MIN_VALUE, Integer.MAX_VALUE });
+
+        Session session = sessionFactory.openSession();
+        session.save(integerUser);
+        session.clear();
+
+        integerUser = session.load(IntegerUser.class, integerUser.getId());
+        assertThat(integerUser.getGenericValue()).isInstanceOf(Integer[].class)
+            .containsExactly(Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    @Test // GH-492
+    public void longSampleTest() {
+        LongUser longUser = new LongUser();
+        longUser.setLoginName("test-intUser");
+        longUser.setGenericValue(new long[] { Long.MIN_VALUE, Long.MAX_VALUE });
+
+        Session session = sessionFactory.openSession();
+        session.save(longUser);
+        session.clear();
+
+        longUser = session.load(LongUser.class, longUser.getId());
+        assertThat(longUser.getGenericValue()).isInstanceOf(long[].class)
+            .containsExactly(Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    @Test // GH-492
+    public void stringSampleTest() {
+        StringUser stringUser = new StringUser();
+        stringUser.setLoginName("test-stringUser");
+        stringUser.setGenericValue(new String[] { "1", "2", "3", "4", "5", "6", "7" });
+
+        Session session = sessionFactory.openSession();
+        session.save(stringUser);
+        session.clear();
+
+        stringUser = session.load(StringUser.class, stringUser.getId());
+        assertThat(stringUser.getGenericValue()).isInstanceOf(String[].class);
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        sessionFactory.close();
+        serverControls.close();
+    }
+}


### PR DESCRIPTION
This PR fixes #492. 

Please see the individual commit messages.
In short:
* Allow for a better detection of field types
* Use this during computation of `FieldInfo`: `FieldInfo` now checks the class hierarchy of a the current class in question and adds the declared fields of the hierarchy when the fields are generically types fields. Thus, the `FieldsInfo` of the concrete class takes precedence over the base class. *this was the root cause, the generic fields would resolve as Object and than the mapper writes collection "as is"*
* Fixes a bug that was probably unrelated, but the elements of arrays needs to be coerced during "our" types as well.

Again, I can take of merging into master _and_ 3.1 if I see green lights. The changes in `FieldsInfo` and `FieldInfo` are actual very non-invasive.