### PR TITLE
Fix nested class mapping and type collisions during mapping.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -94,11 +94,12 @@ public class ClassInfo {
     /**
      * This class was referenced as a superclass of the given subclass.
      *
-     * @param name     the name of the class
+     * @param cls     superclass of {@code subclass}
      * @param subclass {@link ClassInfo} of the subclass
      */
-    ClassInfo(String name, ClassInfo subclass) {
-        this.className = name;
+    ClassInfo(Class<?> cls, ClassInfo subclass) {
+        this.cls = cls;
+        this.className = cls.getName();
         this.hydrated = false;
         this.fieldsInfo = new FieldsInfo();
         this.methodsInfo = new MethodsInfo();
@@ -152,7 +153,6 @@ public class ClassInfo {
             this.isInterface = classInfoDetails.isInterface;
             this.isEnum = classInfoDetails.isEnum;
             this.directSuperclassName = classInfoDetails.directSuperclassName;
-            this.cls = classInfoDetails.cls;
 
             this.interfacesInfo.append(classInfoDetails.interfacesInfo());
 
@@ -192,6 +192,12 @@ public class ClassInfo {
     }
 
     String simpleName() {
+        return deriveSimpleName(this.cls);
+    }
+
+    public static String deriveSimpleName(Class<?> clazz) {
+
+        String className = clazz.getName();
         return className.substring(className.lastIndexOf('.') + 1);
     }
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -30,6 +30,7 @@ import org.neo4j.ogm.cypher.query.CypherQuery;
 import org.neo4j.ogm.cypher.query.DefaultGraphModelRequest;
 import org.neo4j.ogm.cypher.query.DefaultRestModelRequest;
 import org.neo4j.ogm.cypher.query.DefaultRowModelRequest;
+import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.model.GraphModel;
@@ -51,6 +52,7 @@ import org.neo4j.ogm.utils.ClassUtils;
  * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Jasper Blues
+ * @author Gerrit Meier
  */
 public class ExecuteQueriesDelegate extends SessionDelegate {
 
@@ -73,7 +75,21 @@ public class ExecuteQueriesDelegate extends SessionDelegate {
             throw new RuntimeException("Result not of expected size. Expected 1 row but found " + resultSize);
         }
 
-        return results.iterator().next();
+        T next = results.iterator().next();
+
+        if (!next.getClass().isAssignableFrom(type)) {
+
+            String typeOfResult = next.getClass().getName();
+            String wantedType = type.getName();
+            String message = String.format(
+                "Cannot map %s to %s. This can be caused by missing registration of %s.",
+                typeOfResult, wantedType, wantedType
+            );
+
+            throw new MappingException(message);
+        }
+
+        return next;
     }
 
     public Result query(String cypher, Map<String, ?> parameters) {

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -12,6 +12,8 @@
  */
 package org.neo4j.ogm.session.delegates;
 
+import static org.neo4j.ogm.metadata.ClassInfo.*;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -132,7 +134,7 @@ public class ExecuteQueriesDelegate extends SessionDelegate {
         ResponseMapper mapper) {
 
         return session.<Iterable<T>>doInTransaction( () -> {
-            if (type != null && session.metaData().classInfo(type.getSimpleName()) != null) {
+            if (type != null && session.metaData().classInfo(deriveSimpleName(type)) != null) {
                 GraphModelRequest request = new DefaultGraphModelRequest(cypher, parameters);
                 try (Response<GraphModel> response = session.requestHandler().execute(request)) {
                     return new GraphEntityMapper(session.metaData(), session.context(), session.getEntityInstantiator()).map(type, response);

--- a/test/src/test/java/org/neo4j/ogm/domain/nested/NestingClass.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nested/NestingClass.java
@@ -1,0 +1,19 @@
+package org.neo4j.ogm.domain.nested;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class NestingClass {
+
+    @NodeEntity
+    public static class Something {
+        @Id
+        @GeneratedValue
+        private Long id;
+
+        private String name;
+
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
@@ -13,6 +13,7 @@
 
 package org.neo4j.ogm.persistence.session.capability;
 
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
@@ -30,6 +31,8 @@ import org.neo4j.ogm.domain.cineasts.annotated.Actor;
 import org.neo4j.ogm.domain.cineasts.annotated.Movie;
 import org.neo4j.ogm.domain.cineasts.annotated.Rating;
 import org.neo4j.ogm.domain.cineasts.annotated.User;
+import org.neo4j.ogm.domain.restaurant.Restaurant;
+import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.model.Result;
 import org.neo4j.ogm.response.model.NodeModel;
 import org.neo4j.ogm.session.Session;
@@ -40,6 +43,7 @@ import org.neo4j.ogm.testutil.TestUtils;
 
 /**
  * @author Luanne Misquitta
+ * @author Gerrit Meier
  */
 public class QueryCapabilityTest extends MultiDriverTestClass {
 
@@ -708,6 +712,11 @@ public class QueryCapabilityTest extends MultiDriverTestClass {
         row = iterator.next();
         assertThat(row.get("names").getClass().isArray()).isTrue();
         assertThat(((Object[]) row.get("names")).length).isEqualTo(0);
+    }
+
+    @Test(expected = MappingException.class)
+    public void shouldThrowExceptionIfTypeMismatchesInQueryForObject() {
+        session.queryForObject(Restaurant.class, "MATCH (n:User) return count(n)", emptyMap());
     }
 
     private boolean checkForMichal(Map<String, Object> result, boolean foundMichal) {


### PR DESCRIPTION
This PR addresses two related issues that appeared in one test case:
- static nested classes cannot get loaded back from the graph
- wrong types returned in a `Session#queryForObject` get mapped and result in a class cast exception when accessing the object