### PR TITLE
Fix for #576: Change the way of how cleared relations get handled 

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
@@ -13,6 +13,8 @@
 
 package org.neo4j.ogm.context;
 
+import java.util.Objects;
+
 /**
  * Light-weight record of a relationship mapped from the database
  * <code>startNodeId - relationshipId - relationshipType - endNodeId</code>
@@ -98,17 +100,13 @@ public class MappedRelationship implements Mappable {
 
         return startNodeId == that.startNodeId
             && endNodeId == that.endNodeId
-            && relationshipType.equals(that.relationshipType)
-            && !(relationshipId != null ? !relationshipId.equals(that.relationshipId) : that.relationshipId != null);
+            && Objects.equals(relationshipType, that.relationshipType)
+            && Objects.equals(relationshipId, that.relationshipId);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (startNodeId ^ (startNodeId >>> 32));
-        result = 31 * result + relationshipType.hashCode();
-        result = 31 * result + (int) (endNodeId ^ (endNodeId >>> 32));
-        result = 31 * result + (relationshipId != null ? relationshipId.hashCode() : 0);
-        return result;
+        return Objects.hash(startNodeId, relationshipType, endNodeId, relationshipId);
     }
 
     public String toString() {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
@@ -143,18 +143,7 @@ public class CypherContext implements CompileContext {
             return true; //relationships not in the graph, okay, we can return
         }
 
-        //Check to see if the relationships were previously deleted, if so, restore them
-        iterator = cleared.iterator();
-        while (iterator.hasNext()) {
-            Mappable mappedRelationship = iterator.next();
-            if (isMappableAlreadyDeleted(mappedRelationship)) {
-                registerRelationship(mappedRelationship);
-                iterator.remove();
-            } else {
-                deletedRelationships.add(mappedRelationship);
-            }
-        }
-        return cleared.size() > 0;
+        return handleClearedRelations(cleared);
     }
 
     /**
@@ -194,19 +183,7 @@ public class CypherContext implements CompileContext {
         if (nothingToDelete) {
             return true; //relationships not in the graph, okay, we can return
         }
-
-        //Check to see if the relationships were previously deleted, if so, restore them
-        iterator = cleared.iterator();
-        while (iterator.hasNext()) {
-            Mappable mappedRelationship = iterator.next();
-            if (isMappableAlreadyDeleted(mappedRelationship)) {
-                registerRelationship(mappedRelationship);
-                iterator.remove();
-            } else {
-                deletedRelationships.add(mappedRelationship);
-            }
-        }
-        return cleared.size() > 0;
+        return handleClearedRelations(cleared);
     }
 
     public void visitRelationshipEntity(Long relationshipEntity) {
@@ -286,5 +263,21 @@ public class CypherContext implements CompileContext {
         public int getHorizon() {
             return horizon;
         }
+    }
+
+    private boolean handleClearedRelations(List<Mappable> cleared) {
+        Iterator<Mappable> iterator = cleared.iterator();
+        while (iterator.hasNext()) {
+            Mappable mappedRelationship = iterator.next();
+            // 1st check to see if the relationship was previously deleted
+            if (isMappableAlreadyDeleted(mappedRelationship)) {
+                // if so, restore it
+                registerRelationship(mappedRelationship);
+                iterator.remove();
+            }
+        }
+        // 2nd we add the relationships which are really to delete
+        deletedRelationships.addAll(cleared);
+        return cleared.size() > 0;
     }
 }

--- a/test/src/main/java/org/neo4j/ogm/testutil/TestUtils.java
+++ b/test/src/main/java/org/neo4j/ogm/testutil/TestUtils.java
@@ -48,7 +48,11 @@ public final class TestUtils {
             Thread.currentThread().getContextClassLoader().getResourceAsStream(cqlFileName))) {
             scanner.useDelimiter(System.getProperty("line.separator"));
             while (scanner.hasNext()) {
-                cypher.append(scanner.next()).append(' ');
+                String statement = scanner.next();
+                if (statement.startsWith("//")) {
+                    continue;
+                }
+                cypher.append(statement).append(' ');
             }
         }
         return cypher;

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/BaseEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/BaseEntity.java
@@ -1,0 +1,24 @@
+package org.neo4j.ogm.domain.nodes;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + id + ")";
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/DataItem.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/DataItem.java
@@ -25,4 +25,9 @@ public class DataItem extends BaseEntity {
     public void setNodeId(String nodeId) {
         this.nodeId = nodeId;
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" + nodeId + ")";
+    }
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/DataItem.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/DataItem.java
@@ -1,0 +1,28 @@
+package org.neo4j.ogm.domain.nodes;
+
+import java.util.List;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+@NodeEntity
+public class DataItem extends BaseEntity {
+
+    private String nodeId;
+
+    /*
+     * This field is here, b/c the neo4j ogm driver optimizes queries against the class given to the query.
+     * If we want the returned child entities to have its releations mapped as well, we need to tell OGM all
+     * the fields by adding them here
+     */
+    @Relationship(type = "USES")
+    protected List<Variable> variables;
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/FormulaItem.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/FormulaItem.java
@@ -1,0 +1,17 @@
+package org.neo4j.ogm.domain.nodes;
+
+import java.util.List;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class FormulaItem extends DataItem {
+
+    public List<Variable> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(List<Variable> variables) {
+        this.variables = variables;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/Variable.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/Variable.java
@@ -1,0 +1,44 @@
+package org.neo4j.ogm.domain.nodes;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+
+@RelationshipEntity(type = "USES")
+public class Variable extends BaseEntity {
+
+	@StartNode
+	private FormulaItem formulaItem;
+
+	@EndNode
+	private DataItem dataItem;
+
+	private String variable;
+
+	public FormulaItem getFormulaItem() {
+		return formulaItem;
+	}
+
+	public Variable setFormulaItem(FormulaItem formulaItem) {
+		this.formulaItem = formulaItem;
+		return this;
+	}
+
+	public DataItem getDataItem() {
+		return dataItem;
+	}
+
+	public Variable setDataItem(DataItem dataItem) {
+		this.dataItem = dataItem;
+		return this;
+	}
+
+	public String getVariable() {
+		return variable;
+	}
+
+	public Variable setVariable(String variable) {
+		this.variable = variable;
+		return this;
+	}
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/nodes/Variable.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/nodes/Variable.java
@@ -7,38 +7,44 @@ import org.neo4j.ogm.annotation.StartNode;
 @RelationshipEntity(type = "USES")
 public class Variable extends BaseEntity {
 
-	@StartNode
-	private FormulaItem formulaItem;
+    @StartNode
+    private FormulaItem formulaItem;
 
-	@EndNode
-	private DataItem dataItem;
+    @EndNode
+    private DataItem dataItem;
 
-	private String variable;
+    private String variable;
 
-	public FormulaItem getFormulaItem() {
-		return formulaItem;
-	}
+    public FormulaItem getFormulaItem() {
+        return formulaItem;
+    }
 
-	public Variable setFormulaItem(FormulaItem formulaItem) {
-		this.formulaItem = formulaItem;
-		return this;
-	}
+    public Variable setFormulaItem(FormulaItem formulaItem) {
+        this.formulaItem = formulaItem;
+        return this;
+    }
 
-	public DataItem getDataItem() {
-		return dataItem;
-	}
+    public DataItem getDataItem() {
+        return dataItem;
+    }
 
-	public Variable setDataItem(DataItem dataItem) {
-		this.dataItem = dataItem;
-		return this;
-	}
+    public Variable setDataItem(DataItem dataItem) {
+        this.dataItem = dataItem;
+        return this;
+    }
 
-	public String getVariable() {
-		return variable;
-	}
+    public String getVariable() {
+        return variable;
+    }
 
-	public Variable setVariable(String variable) {
-		this.variable = variable;
-		return this;
-	}
+    public Variable setVariable(String variable) {
+        this.variable = variable;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + formulaItem.getNodeId() + ")-[:USES{variable: '" + variable + "'}]->(" + dataItem.getNodeId()
+            + ")";
+    }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/nodes/NodeTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/nodes/NodeTest.java
@@ -1,0 +1,96 @@
+package org.neo4j.ogm.persistence.examples.nodes;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.domain.nodes.DataItem;
+import org.neo4j.ogm.domain.nodes.FormulaItem;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.neo4j.ogm.testutil.TestUtils;
+
+/**
+ * Test class reproducing issue #576
+ *
+ * @author Andreas Berger
+ */
+@RunWith(Parameterized.class)
+public class NodeTest extends MultiDriverTestClass {
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+    private Integer additionalObjects;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.nodes");
+    }
+
+    @Parameterized.Parameters
+    public static List<Integer> data() {
+        return IntStream
+            .range(0, 10) // change the number of pre stored objects here
+            .boxed()
+            .collect(Collectors.toList());
+    }
+
+    public NodeTest(Integer additionalObjects) {
+        this.additionalObjects = additionalObjects;
+    }
+
+    @Before
+    public void init() throws IOException {
+        session = sessionFactory.openSession();
+        session.purgeDatabase();
+        session.clear();
+        IntStream
+            .range(0, additionalObjects)
+            .forEach(i -> session.query("CREATE(:Foo)", Collections.emptyMap()));
+        session.query(TestUtils.readCQLFile("org/neo4j/ogm/cql/nodes.cql").toString(), Collections.emptyMap());
+    }
+
+    @After
+    public void tearDown() {
+        session.purgeDatabase();
+    }
+
+    @Test
+    public void test() {
+        Collection<DataItem> dataItems;
+        FormulaItem formulaItem;
+
+        Filter filter = new Filter("nodeId", ComparisonOperator.EQUALS, "m1");
+
+        dataItems = session.loadAll(DataItem.class, filter);
+        assertThat(dataItems.size()).isEqualTo(1);
+        formulaItem = (FormulaItem) dataItems.iterator().next();
+        assertThat(formulaItem.getVariables().size()).isEqualTo(3);
+
+        formulaItem.getVariables()
+            .removeIf(
+                variable -> variable.getVariable().equals("A") && variable.getDataItem().getNodeId().equals("m2"));
+        session.save(formulaItem);
+
+        dataItems = session.loadAll(DataItem.class, filter);
+        assertThat(dataItems.size()).isEqualTo(1);
+        formulaItem = (FormulaItem) dataItems.iterator().next();
+        assertThat(formulaItem.getVariables().size()).isEqualTo(2);
+    }
+
+}

--- a/test/src/test/resources/org/neo4j/ogm/cql/nodes.cql
+++ b/test/src/test/resources/org/neo4j/ogm/cql/nodes.cql
@@ -1,0 +1,7 @@
+CREATE (m1:FormulaItem:DataItem {nodeId: 'm1'})
+CREATE (m2:DataItem {nodeId: 'm2'})
+CREATE (m3:DataItem {nodeId: 'm3'})
+
+CREATE (m1)-[:USES {variable: 'A'}]->(m2)
+CREATE (m1)-[:USES {variable: 'B'}]->(m2)
+CREATE (m1)-[:USES {variable: 'A'}]->(m3)


### PR DESCRIPTION
## Description

Previously, within a loop, it was checked whether [a mapping had already been deleted](https://github.com/neo4j/neo4j-ogm/compare/master...kiwigrid:bugfix/issue-576?expand=1#diff-bc01d57c8046cf702a69422d2376bb40L202) and if so this mapping was [added directly to the list of deleted relationships](https://github.com/neo4j/neo4j-ogm/compare/master...kiwigrid:bugfix/issue-576?expand=1#diff-bc01d57c8046cf702a69422d2376bb40L206). This resulted in different results depending on the order of the mappings to be deleted.
[By dividing this logic into two parts](https://github.com/neo4j/neo4j-ogm/compare/master...kiwigrid:bugfix/issue-576?expand=1#diff-bc01d57c8046cf702a69422d2376bb40R280), the problem could be solved.

## Related Issue

This PR solves #576. 

## How Has This Been Tested?

[Test is provided with this PR](https://github.com/neo4j/neo4j-ogm/compare/master...kiwigrid:bugfix/issue-576?expand=1#diff-7db200458c0a6798c1512ef48a317de8) and described in #576.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
