### PR TITLE
Add functionality to generate sitemap

### DIFF
--- a/neo4j-ogm-docs/build.gradle
+++ b/neo4j-ogm-docs/build.gradle
@@ -1,6 +1,8 @@
 import org.asciidoctor.Asciidoctor
 import org.asciidoctor.OptionsBuilder
 import org.asciidoctor.SafeMode
+import org.neo4j.doc.build.xslt.XsltTask
+import org.neo4j.doc.build.docbook.DocBookPlugin
 
 //
 // Object-Graph Mapping (OGM) Manual
@@ -22,6 +24,8 @@ buildscript {
         classpath 'net.sf.docbook:docbook-xsl:1.79.1:ns-resources@zip'
         classpath fileTree(dir: "${rootProject.projectDir}/lib", include: '*.jar')
         classpath files("src/main/resources/docbook/catalog/")
+        classpath "org.dom4j:dom4j:2.1.1"
+        classpath "jaxen:jaxen:1.1.6"
     }
 }
 
@@ -258,6 +262,63 @@ html {
     finalizedBy { copyHtmlResources }
 }
 
+task makeToc(type: XsltTask, dependsOn: {toDocbook}) {
+    description 'Create a table of contents.'
+
+    doFirst {
+        def sourceFile = "${buildDir}/docbook/${ogmDocVersion}/index.xml"
+        def outputFile = "${buildDir}/docbook/${ogmDocVersion}/toc.xml"
+        def outputDir = "${buildDir}/docbook/${ogmDocVersion}/_trash"
+        def toolsDir = "${rootProject.projectDir}/docbook"
+
+        def url = DocBookPlugin.getClassLoader().getResource("xsl/create-toc/xhtml/maketoc.xsl")
+        stylesheet url
+        input sourceFile
+        outFile outputFile
+
+        sourceSaxParser "org.apache.xml.resolver.tools.ResolvingXMLReader"
+        stylesheetSaxParser "org.apache.xml.resolver.tools.ResolvingXMLReader"
+        uriResolver "org.apache.xml.resolver.tools.CatalogResolver"
+
+        usingUrls true
+        usingClasspathUrls true
+        if (hasProperty('traceDocbook')) { verbose true }
+
+        parameters([
+            "base.dir": "${outputDir}",
+            "chunk.section.depth": "1",
+            "chunk.first.sections": "1",
+            "use.id.as.dirname": "1",
+        ])
+    }
+}
+
+
+task sitemap() {
+    ext.contentMapXml = file("${projectDir}/docbook/content-map.xml")
+    def siteMapDir = "$buildDir/sitemap/$ogmDocVersion"
+    outputs.dir siteMapDir
+
+    doLast {
+        def siteMap = org.dom4j.DocumentHelper.createDocument()
+        def urlset = siteMap.addElement("urlset", "http://www.sitemaps.org/schemas/sitemap/0.9")
+        def contentMap = new org.dom4j.io.SAXReader().read(contentMapXml)
+        contentMap.selectNodes('//processing-instruction("dbhtml")')
+            .collect { pi ->
+              pi.getText()                    // filename="installation/index.html"
+              .replaceAll("filename=|\"", "") // installation/index.html
+        }.each { filename ->
+               def url = "${docsBaseUri}/ogm-manual/current" + "/" + filename
+               urlset.addElement("url").addElement("loc").addText(url)
+        }
+        mkdir(siteMapDir)
+        new org.dom4j.io.XMLWriter(
+            new FileOutputStream(file("$siteMapDir/sitemap.xml")),
+            org.dom4j.io.OutputFormat.createPrettyPrint()
+        ).write(siteMap)
+    }
+}
+
 task copyHtmlResources(type: Copy) {
     description 'Copy resources for the multi-page Neo4j Object-Graph Mapping (OGM) Manual'
     inputs.dir "${projectDir}/css"
@@ -287,7 +348,7 @@ task copyHtmlResources(type: Copy) {
     into "${buildDir}/html/${ogmDocVersion}"
 }
 
-task packageHtml(type: Tar, dependsOn: html) {
+task packageHtml(type: Tar, dependsOn: [html, sitemap]) {
     baseName "ogm-manual"
     version ogmDocVersion
     extension 'tar.gz'
@@ -295,6 +356,7 @@ task packageHtml(type: Tar, dependsOn: html) {
     from {
         "${buildDir}/html/${ogmDocVersion}"
     }
+    from { sitemap }
     into {
         "${baseName}/${ogmDocVersion}"
     }

--- a/neo4j-ogm-docs/docbook/content-map.xml
+++ b/neo4j-ogm-docs/docbook/content-map.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<d:toc xmlns:d="http://docbook.org/ns/docbook" xmlns="http://www.w3.org/1999/xhtml" role="chunk-toc">
+  <d:tocentry linkend="ogm-manual"><?dbhtml filename="index.html"?>
+    <d:tocentry linkend="introduction"><?dbhtml filename="introduction/index.html"?>
+    </d:tocentry>
+    <d:tocentry linkend="tutorial"><?dbhtml filename="tutorial/index.html"?>
+    </d:tocentry>
+    <d:tocentry linkend="reference"><?dbhtml filename="reference/index.html"?>
+    </d:tocentry>
+    <d:tocentry linkend="migration"><?dbhtml filename="migration/index.html"?>
+    </d:tocentry>
+    <d:tocentry linkend="design-considerations"><?dbhtml filename="design-considerations/index.html"?>
+    </d:tocentry>
+    <d:tocentry linkend="faq"><?dbhtml filename="faq/index.html"?>
+    </d:tocentry>
+  </d:tocentry>
+</d:toc>


### PR DESCRIPTION
To allow for this urgently, the content map is only halfway implemented.
It would be advantageous to complete this in order to make the
docs builds more similar across various docs artifacts.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
