### PR TITLE
Support single uri in uris properties.

### DIFF
--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
@@ -158,8 +158,17 @@ public class BoltDriver extends AbstractConfigurableDriver {
         }
     }
 
+    /**
+     * It is a routing config if at least two URIs are defined.
+     * Either URI and at least one value in URIS or two URIS.
+     *
+     * @return true, if more than one URI are defined in all URI related properties. Otherwise false.
+     */
     private boolean isRoutingConfig() {
-        return configuration.getURIS() != null && (configuration.getURIS().length > 1 || configuration.getURI() != null);
+        String[] uris = configuration.getURIS();
+        String uri = configuration.getURI();
+
+        return uris != null && (uri == null && uris.length > 1 || uri != null && uris.length >= 1);
     }
 
     private List<URI> getMergedURIs() {

--- a/neo4j-ogm-docs/src/main/asciidoc/reference/ha.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/ha.adoc
@@ -37,6 +37,11 @@ To use clustering, simply configure your Bolt URI to use the bolt routing protoc
 ----
 URI=bolt+routing://instance0 <1>
 ----
+or
+[source, configs]
+----
+URIS=bolt+routing://instance0 <1>
+----
 <1> `instance0` must be one of your core cluster group (that accepts reads and writes).
 
 
@@ -50,20 +55,14 @@ In this section we go through important points to be aware of when using causal 
 * Use bookmarks to read your own writes
 * Plan for failure
 
-=== Hardware and cluster configuration
+=== Cluster configuration
 
-Hardware, and particularly network, can have a great impact on cluster stability.
-The deployment scenario also plays a critical role.
-It has to be carefully chosen, each configuration having it strengths and weaknesses.
+Please read the https://neo4j.com/docs/operations-manual/current/clustering/causal-clustering/[causal cluster reference] to plan the best topology according to your needs.
 
-Please read carefully the https://neo4j.com/docs/operations-manual/current/clustering/causal-clustering/[causal cluster reference] to plan the best topology according to your needs.
-
-// ideally we should link to clustering recommandations on the Neo4j website for network sizing
-
-You can also provide additional core instances in `URIS` property, separated by a comma.
-The `URI` property still needs to be set and will be tried first, followed by entries from `URIS` property.
+You can provide additional core instances in `URIS` property, separated by a comma.
+The `URI` property is optional as long as all URIs are provided in the `URIS` property.
 Same credentials are used for all instances.
-All listed instances must be core servers.
+Please keep in mind that all listed instances must be core servers.
 
 [source, configs]
 ----

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
@@ -127,6 +127,15 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/ConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/ConfigurationTest.java
@@ -169,6 +169,19 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void shouldSetUsernameAndPasswordCredentialsForBoltProtocol() {
+        String username = "neo4j";
+        String password = "password";
+        Configuration dbConfig = new Configuration.Builder().uri("bolt://" + username + ":" + password + "@localhost")
+            .build();
+        Credentials credentials = dbConfig.getCredentials();
+        UsernamePasswordCredentials basic = (UsernamePasswordCredentials) credentials;
+        assertThat(basic).isNotNull();
+        assertThat(basic.getUsername()).isEqualTo(username);
+        assertThat(basic.getPassword()).isEqualTo(password);
+    }
+
+    @Test
     public void shouldConfigureFromSpringBootPropertiesFile() {
 
         Configuration configuration = new Configuration.Builder(

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/DriverConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/DriverConfigurationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.ogm.drivers.bolt.driver.BoltDriver;
+import org.neo4j.ogm.session.SessionFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Gerrit Meier
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GraphDatabase.class)
+public class DriverConfigurationTest {
+
+    @Before
+    public void setup() {
+        PowerMockito.mockStatic(GraphDatabase.class);
+        Driver driverMock = Mockito.mock(Driver.class);
+        Mockito.when(GraphDatabase.routingDriver(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(driverMock);
+    }
+
+    @Test
+    public void shouldSupportAdditionalRoutingUris() {
+
+        String uri = "bolt+routing://somewhere1";
+        String[] uris = { "bolt+routing://somewhere2", "bolt+routing://somewhere3" };
+        List<URI> routingUris = Arrays.asList(
+            URI.create("bolt+routing://somewhere1"),
+            URI.create("bolt+routing://somewhere2"),
+            URI.create("bolt+routing://somewhere3"));
+
+        Configuration configuration = new Configuration.Builder()
+            .uri(uri)
+            .uris(uris)
+            .verifyConnection(true)
+            .build();
+
+        // trigger bolt driver creation
+        new SessionFactory(configuration, "non.existing.package");
+
+        assertThat(configuration.getURI()).isEqualTo(uri);
+        assertThat(configuration.getURIS()).isEqualTo(uris);
+
+        PowerMockito.verifyStatic(GraphDatabase.class);
+        GraphDatabase.routingDriver(Mockito.eq(routingUris), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldSupportAdditionalRoutingUrisWithoutDefiningUri() {
+
+        String[] uris = { "bolt+routing://somewhere1", "bolt+routing://somewhere2", "bolt+routing://somewhere3" };
+        List<URI> routingUris = Arrays.asList(
+            URI.create("bolt+routing://somewhere1"),
+            URI.create("bolt+routing://somewhere2"),
+            URI.create("bolt+routing://somewhere3"));
+
+        Configuration configuration = new Configuration.Builder()
+            .uris(uris)
+            .verifyConnection(true)
+            .build();
+
+        // trigger bolt driver creation
+        new SessionFactory(configuration, "non.existing.package");
+
+        assertThat(configuration.getURIS()).isEqualTo(uris);
+
+        PowerMockito.verifyStatic(GraphDatabase.class);
+        GraphDatabase.routingDriver(Mockito.eq(routingUris), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void shouldCallDefaultGraphDatabaseInstantiationWithJustOneUriInUris() {
+
+        String[] uris = { "bolt+routing://somewhere1" };
+        URI uri = URI.create("bolt+routing://somewhere1");
+
+        Configuration configuration = new Configuration.Builder()
+            .uris(uris)
+            .verifyConnection(true)
+            .build();
+
+        // trigger bolt driver creation
+        new SessionFactory(configuration, "non.existing.package");
+
+        assertThat(configuration.getURIS()).isEqualTo(uris);
+
+        PowerMockito.verifyStatic(GraphDatabase.class);
+        GraphDatabase.driver(Mockito.eq(uri), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void boltDriverJavaDriverInitializationShouldFailIfNoUriOrUrisAreSupplied() {
+
+        assertThatThrownBy(() -> new BoltDriver().configure(new Configuration.Builder().verifyConnection(true).build()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("You must provide either an URI or at least one URI in the URIS parameter.");
+    }
+
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/DriverPropertiesFileConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/DriverPropertiesFileConfigurationTest.java
@@ -30,7 +30,7 @@ import org.neo4j.ogm.config.UsernamePasswordCredentials;
  * @author vince
  * @author Michael J. Simons
  */
-public class DriverConfigurationTest {
+public class DriverPropertiesFileConfigurationTest {
 
     @Test
     public void shouldLoadHttpDriverConfigFromPropertiesFile() {
@@ -57,16 +57,4 @@ public class DriverConfigurationTest {
         assertThat(driverConfig.getTrustCertFile()).isEqualTo("/tmp/cert");
     }
 
-    @Test
-    public void shouldSetUsernameAndPasswordCredentialsForBoltProtocol() {
-        String username = "neo4j";
-        String password = "password";
-        Configuration dbConfig = new Configuration.Builder().uri("bolt://" + username + ":" + password + "@localhost")
-            .build();
-        Credentials credentials = dbConfig.getCredentials();
-        UsernamePasswordCredentials basic = (UsernamePasswordCredentials) credentials;
-        assertThat(basic).isNotNull();
-        assertThat(basic.getUsername()).isEqualTo(username);
-        assertThat(basic.getPassword()).isEqualTo(password);
-    }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/MultipleURIsBoltDriverTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/MultipleURIsBoltDriverTest.java
@@ -20,10 +20,8 @@ package org.neo4j.ogm.drivers.bolt;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
-import org.neo4j.ogm.config.ClasspathConfigurationSource;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.session.SessionFactory;
 
@@ -33,7 +31,7 @@ import org.neo4j.ogm.session.SessionFactory;
 public class MultipleURIsBoltDriverTest {
 
     @Test
-    public void throwCorrectExceptionOnUnavailableCluster() throws Exception {
+    public void throwCorrectExceptionOnUnavailableCluster() {
 
         Configuration configuration = new Configuration.Builder()
             .uri("bolt+routing://localhost:1022")
@@ -48,29 +46,5 @@ public class MultipleURIsBoltDriverTest {
             assertThat(cause).isInstanceOf(ServiceUnavailableException.class);
             assertThat(cause).hasMessage("Failed to discover an available server");
         }
-    }
-
-    @Test
-    @Ignore("this needs local causal cluster running")
-    public void connectToCCUsingConfiguration() throws Exception {
-        Configuration configuration = new Configuration.Builder()
-            .uri("bolt+routing://localhost:1023")
-            .uris(new String[] { "bolt+routing://localhost:7688",
-                "bolt+routing://localhost:7687",
-                "bolt+routing://localhost:7689" })
-            .verifyConnection(true)
-            .build();
-
-        new SessionFactory(configuration, "org.neo4j.ogm.domain.social");
-    }
-
-    @Test
-    @Ignore("this needs local causal cluster running")
-    public void connectToCCUsingProperties() throws Exception {
-        Configuration configuration = new Configuration.Builder(
-            new ClasspathConfigurationSource("ogm-bolt-uris.properties"))
-            .build();
-
-        new SessionFactory(configuration, "org.neo4j.ogm.domain.social");
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.Mockito;
-import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.session.SessionFactory;
@@ -46,8 +46,9 @@ public class BoltDriverConfigurationTest {
     @Before
     public void setup() {
         PowerMockito.mockStatic(GraphDatabase.class);
-        Driver driverMock = Mockito.mock(Driver.class);
-        Mockito.when(GraphDatabase.routingDriver(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(driverMock);
+        Mockito
+            .when(GraphDatabase.routingDriver(Mockito.any(), Mockito.any(), Mockito.any()))
+            .thenAnswer(Answers.RETURNS_MOCKS);
     }
 
     @Test

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
@@ -120,6 +120,26 @@ public class BoltDriverConfigurationTest {
     }
 
     @Test
+    public void shouldCallDefaultGraphDatabaseInstantiationWithOneUri() {
+
+        String uriValue ="bolt+routing://somewhere1";
+        URI uri = URI.create(uriValue);
+
+        Configuration configuration = new Configuration.Builder()
+            .uri(uriValue)
+            .verifyConnection(true)
+            .build();
+
+        // trigger bolt driver creation
+        new SessionFactory(configuration, "non.existing.package");
+
+        assertThat(configuration.getURI()).isEqualTo(uriValue);
+
+        PowerMockito.verifyStatic(GraphDatabase.class);
+        GraphDatabase.driver(Mockito.eq(uri), Mockito.any(), Mockito.any());
+    }
+
+    @Test
     public void boltDriverJavaDriverInitializationShouldFailIfNoUriOrUrisAreSupplied() {
 
         assertThatThrownBy(() -> new BoltDriver().configure(new Configuration.Builder().verifyConnection(true).build()))

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverConfigurationTest.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.ogm.config;
+package org.neo4j.ogm.drivers.bolt.driver;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.ogm.drivers.bolt.driver.BoltDriver;
+import org.neo4j.ogm.config.Configuration;
 import org.neo4j.ogm.session.SessionFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -41,7 +41,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(GraphDatabase.class)
-public class DriverConfigurationTest {
+public class BoltDriverConfigurationTest {
 
     @Before
     public void setup() {

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M2</maven-surefire-plugin.version>
         <mockito.version>2.23.4</mockito.version>
+        <objenesis.version>3.0.1</objenesis.version>
         <powermock.version>2.0.0</powermock.version>
         <scala.version>2.11.12</scala.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -311,12 +312,13 @@
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.objenesis</groupId>
-                        <artifactId>objenesis</artifactId>
-                    </exclusion>
-                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.objenesis</groupId>
+                <artifactId>objenesis</artifactId>
+                <version>${objenesis.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.10</httpcore.version>
         <jackson.version>2.9.8</jackson.version>
+        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <jline.version>2.14.3</jline.version>
         <junit.version>4.12</junit.version>
         <logback.version>1.2.3</logback.version>
@@ -212,11 +213,11 @@
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M2</maven-surefire-plugin.version>
         <mockito.version>2.23.4</mockito.version>
+        <powermock.version>2.0.0</powermock.version>
         <scala.version>2.11.12</scala.version>
         <slf4j.version>1.7.25</slf4j.version>
         <spotbugs.plugin.version>3.1.3</spotbugs.plugin.version>
@@ -309,6 +310,26 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.objenesis</groupId>
+                        <artifactId>objenesis</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
This is done because it confuses people that `uris` are only
meaningful if they have already provided an `uri` parameter.
This commit does not change the old behaviour but enables an `uris`
property only approach.

I see no problem in applying this PR also to the 3.1.x line.