### PR TITLE
Alternative fix for the transaction manager issues

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/driver/AbstractConfigurableDriver.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/AbstractConfigurableDriver.java
@@ -55,7 +55,6 @@ public abstract class AbstractConfigurableDriver implements Driver {
         ThreadLocal.withInitial(() -> ServiceLoader.load(CypherModificationProvider.class));
 
     protected Configuration configuration;
-    protected TransactionManager transactionManager;
 
     /**
      * Used for configuring the cypher modification providers. Defaults to {@link #getConfiguration()} and reads the
@@ -84,12 +83,6 @@ public abstract class AbstractConfigurableDriver implements Driver {
     @Override
     public void configure(Configuration config) {
         this.configuration = config;
-    }
-
-    @Override
-    public void setTransactionManager(TransactionManager transactionManager) {
-        assert (transactionManager != null);
-        this.transactionManager = transactionManager;
     }
 
     @Override

--- a/api/src/main/java/org/neo4j/ogm/driver/Driver.java
+++ b/api/src/main/java/org/neo4j/ogm/driver/Driver.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.ogm.driver;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.neo4j.ogm.config.Configuration;
@@ -28,6 +29,7 @@ import org.neo4j.ogm.transaction.TransactionManager;
 /**
  * @author Vince Bickers
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public interface Driver extends AutoCloseable {
 
@@ -36,18 +38,49 @@ public interface Driver extends AutoCloseable {
     /**
      * Begins new transaction
      *
+     * @deprecated Since 3.1.8 as it was faulty. Will be removed in 3.2
      * @param type      type of the transaction, see {@link org.neo4j.ogm.transaction.Transaction.Type}
      * @param bookmarks bookmarks to pass to the driver when transaction is started, NOTE: currently supported only
      *                  by bolt driver
      * @return new transaction
      */
-    Transaction newTransaction(Transaction.Type type, Iterable<String> bookmarks);
+    @Deprecated
+    default Transaction newTransaction(Transaction.Type type, Iterable<String> bookmarks) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return A factory method for creating suppliers of transactions for a given transaction manager
+     */
+    default Function<TransactionManager, BiFunction<Transaction.Type, Iterable<String>, Transaction>> getTransactionFactorySupplier() {
+        return transactionManager -> (type, bookmarks) -> null;
+    }
 
     void close();
 
-    Request request();
+    /**
+     * @return A new request handler
+     * @deprecated Since 3.1.8 as it was faulty. Will be removed in 3.2
+     */
+    @Deprecated
+    default Request request() {
+        throw new UnsupportedOperationException();
+    }
 
-    void setTransactionManager(TransactionManager tx);
+    /**
+     * @param transaction Current transaction, may be null, depending on the driver
+     * @return A new request handler
+     */
+    Request request(Transaction transaction);
+
+    /**
+     * @param tx new transaction manager
+     * @deprecated Since 3.1.8 as it was faulty. Will be removed in 3.2
+     */
+    @Deprecated
+    default void setTransactionManager(TransactionManager tx) {
+        throw new UnsupportedOperationException();
+    }
 
     Configuration getConfiguration();
 

--- a/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
@@ -166,9 +166,4 @@ public abstract class AbstractTransaction implements Transaction {
     public List<Object> registeredNew() {
         return registeredNew;
     }
-
-    // for testing
-    public void reOpen() {
-        status = Status.OPEN;
-    }
 }

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/BoltResponse.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/BoltResponse.java
@@ -25,7 +25,6 @@ import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.ogm.exception.CypherException;
 import org.neo4j.ogm.response.Response;
-import org.neo4j.ogm.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +34,11 @@ import org.slf4j.LoggerFactory;
 public abstract class BoltResponse<T> implements Response {
 
     final StatementResult result;
-    private final TransactionManager transactionManager;
 
     private final Logger LOGGER = LoggerFactory.getLogger(BoltResponse.class);
 
-    BoltResponse(StatementResult result, TransactionManager transactionManager) {
+    BoltResponse(StatementResult result) {
         this.result = result;
-        this.transactionManager = transactionManager;
     }
 
     @Override
@@ -58,11 +55,8 @@ public abstract class BoltResponse<T> implements Response {
 
     @Override
     public void close() {
-        // if there is no current transaction available, the response is already closed.
-        if (transactionManager.getCurrentTransaction() != null) {
-            // release the response resource
-            result.consume();
-        }
+        // Consume the rest of the result and thus closing underlying resources.
+        result.consume();
     }
 
     @Override

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/GraphModelResponse.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/GraphModelResponse.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.ogm.model.GraphModel;
 import org.neo4j.ogm.result.adapter.ResultAdapter;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * @author Luanne Misquitta
@@ -32,8 +31,8 @@ public class GraphModelResponse extends BoltResponse<GraphModel> {
 
     private final ResultAdapter<Map<String, Object>, GraphModel> adapter = new BoltGraphModelAdapter();
 
-    public GraphModelResponse(StatementResult result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public GraphModelResponse(StatementResult result) {
+        super(result);
     }
 
     @Override

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/GraphRowModelResponse.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/GraphRowModelResponse.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.ogm.model.GraphRowListModel;
 import org.neo4j.ogm.response.model.DefaultGraphRowListModel;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * @author Luanne Misquitta
@@ -32,8 +31,8 @@ public class GraphRowModelResponse extends BoltResponse<GraphRowListModel> {
 
     private BoltGraphRowModelAdapter adapter = new BoltGraphRowModelAdapter(new BoltGraphModelAdapter());
 
-    public GraphRowModelResponse(StatementResult result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public GraphRowModelResponse(StatementResult result) {
+        super(result);
         adapter.setColumns(Arrays.asList(columns()));
     }
 

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/RestModelResponse.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/RestModelResponse.java
@@ -26,7 +26,6 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.ogm.response.model.DefaultRestModel;
 import org.neo4j.ogm.response.model.QueryStatisticsModel;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * @author Luanne Misquitta
@@ -37,8 +36,8 @@ public class RestModelResponse extends BoltResponse<DefaultRestModel> {
     private final QueryStatisticsModel statisticsModel;
     private final Iterator<Record> resultProjection;
 
-    public RestModelResponse(StatementResult result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public RestModelResponse(StatementResult result) {
+        super(result);
         this.restModelAdapter = new BoltRestModelAdapter();
         resultProjection = result.list().iterator();
         statisticsModel = new StatisticsModelAdapter().adapt(result);

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/RowModelResponse.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/response/RowModelResponse.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.ogm.model.RowModel;
 import org.neo4j.ogm.result.adapter.ResultAdapter;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * @author Luanne Misquitta
@@ -33,8 +32,8 @@ public class RowModelResponse extends BoltResponse<RowModel> {
 
     private final ResultAdapter<Map<String, Object>, RowModel> adapter = new BoltRowModelAdapter();
 
-    public RowModelResponse(StatementResult result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public RowModelResponse(StatementResult result) {
+        super(result);
         ((BoltRowModelAdapter) adapter).setColumns(Arrays.asList(columns()));
     }
 

--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransaction.java
@@ -39,11 +39,25 @@ public class BoltTransaction extends AbstractTransaction {
     private final Session nativeSession;
     private final Logger LOGGER = LoggerFactory.getLogger(BoltTransaction.class);
 
-    public BoltTransaction(TransactionManager transactionManager, Transaction transaction, Session session, Type type) {
+    public BoltTransaction(TransactionManager transactionManager, Session session, Type type) {
         super(transactionManager);
-        this.nativeTransaction = transaction;
         this.nativeSession = session;
+        this.nativeTransaction = newOrExistingNativeTransaction(transactionManager.getCurrentTransaction());
         this.type = type;
+    }
+
+    private Transaction newOrExistingNativeTransaction(org.neo4j.ogm.transaction.Transaction currentOGMTransaction) {
+
+        Transaction nativeTransaction;
+        if (currentOGMTransaction != null) {
+            LOGGER.debug("Using current transaction: {}", currentOGMTransaction);
+            nativeTransaction = ((BoltTransaction) currentOGMTransaction).nativeBoltTransaction();
+        } else {
+            LOGGER.debug("No current transaction, starting a new one");
+            nativeTransaction = nativeSession.beginTransaction();
+        }
+        LOGGER.debug("Native transaction: {}", nativeTransaction);
+        return nativeTransaction;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -103,7 +103,7 @@ public class Neo4jSession implements Session {
         this.driver = driver;
 
         this.mappingContext = new MappingContext(metaData);
-        this.txManager = new DefaultTransactionManager(this, driver);
+        this.txManager = new DefaultTransactionManager(this, driver.getTransactionFactorySupplier());
         this.loadStrategy = LoadStrategy.PATH_LOAD_STRATEGY;
         this.entityInstantiator = new ReflectionEntityInstantiator(metaData);
     }
@@ -667,7 +667,7 @@ public class Neo4jSession implements Session {
     }
 
     public Request requestHandler() {
-        return driver.request();
+        return driver.request(this.txManager.getCurrentTransaction());
     }
 
     public DefaultTransactionManager transactionManager() {

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/request/EmbeddedRequest.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/request/EmbeddedRequest.java
@@ -45,12 +45,11 @@ import org.neo4j.ogm.request.RowModelRequest;
 import org.neo4j.ogm.request.Statement;
 import org.neo4j.ogm.response.EmptyResponse;
 import org.neo4j.ogm.response.Response;
-import org.neo4j.ogm.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author vince
+ * @author Vince Bickers
  * @author Luanne Misquitta
  * @author Michael J. Simons
  */
@@ -59,18 +58,14 @@ public class EmbeddedRequest implements Request {
     private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedRequest.class);
 
     private final GraphDatabaseService graphDatabaseService;
-    private final TransactionManager transactionManager;
     private final ParameterConversion parameterConversion;
 
     private final Function<String, String> cypherModification;
 
-    public EmbeddedRequest(GraphDatabaseService graphDatabaseService,
-        TransactionManager transactionManager,
-        ParameterConversion parameterConversion,
+    public EmbeddedRequest(GraphDatabaseService graphDatabaseService, ParameterConversion parameterConversion,
         Function<String, String> cypherModification
     ) {
         this.graphDatabaseService = graphDatabaseService;
-        this.transactionManager = transactionManager;
         this.parameterConversion = parameterConversion;
         this.cypherModification = cypherModification;
     }
@@ -80,7 +75,7 @@ public class EmbeddedRequest implements Request {
         if (request.getStatement().length() == 0) {
             return new EmptyResponse();
         }
-        return new GraphModelResponse(executeRequest(request), transactionManager);
+        return new GraphModelResponse(executeRequest(request));
     }
 
     @Override
@@ -88,7 +83,7 @@ public class EmbeddedRequest implements Request {
         if (request.getStatement().length() == 0) {
             return new EmptyResponse();
         }
-        return new RowModelResponse(executeRequest(request), transactionManager);
+        return new RowModelResponse(executeRequest(request));
     }
 
     @Override
@@ -101,7 +96,7 @@ public class EmbeddedRequest implements Request {
             if (columns == null) {
                 columns = result.columns().toArray(new String[result.columns().size()]);
             }
-            RowModelResponse rowModelResponse = new RowModelResponse(result, transactionManager);
+            RowModelResponse rowModelResponse = new RowModelResponse(result);
             RowModel model;
             while ((model = rowModelResponse.next()) != null) {
                 rowmodels.add(model);
@@ -123,9 +118,6 @@ public class EmbeddedRequest implements Request {
 
             @Override
             public void close() {
-                if (transactionManager.getCurrentTransaction() != null) {
-                    LOGGER.debug("Response closed: {}", this);
-                }
             }
 
             @Override
@@ -140,7 +132,7 @@ public class EmbeddedRequest implements Request {
         if (request.getStatement().length() == 0) {
             return new EmptyResponse();
         }
-        return new GraphRowModelResponse(executeRequest(request), transactionManager);
+        return new GraphRowModelResponse(executeRequest(request));
     }
 
     @Override
@@ -148,7 +140,7 @@ public class EmbeddedRequest implements Request {
         if (request.getStatement().length() == 0) {
             return new EmptyResponse();
         }
-        return new RestModelResponse(executeRequest(request), transactionManager);
+        return new RestModelResponse(executeRequest(request));
     }
 
     private Result executeRequest(Statement request) {

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/EmbeddedResponse.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/EmbeddedResponse.java
@@ -20,22 +20,19 @@ package org.neo4j.ogm.drivers.embedded.response;
 
 import org.neo4j.graphdb.Result;
 import org.neo4j.ogm.response.Response;
-import org.neo4j.ogm.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author vince
+ * @author Vince Bickers
  */
-public abstract class EmbeddedResponse<T> implements Response {
+abstract class EmbeddedResponse<T> implements Response {
 
-    protected final Result result;
     private final Logger logger = LoggerFactory.getLogger(EmbeddedResponse.class);
-    private final TransactionManager transactionManager;
+    protected final Result result;
 
-    public EmbeddedResponse(Result result, TransactionManager transactionManager) {
+    public EmbeddedResponse(Result result) {
         logger.debug("Response opened: {}", this);
-        this.transactionManager = transactionManager;
         this.result = result;
     }
 
@@ -45,14 +42,9 @@ public abstract class EmbeddedResponse<T> implements Response {
     @Override
     public void close() {
 
-        // if there is no current transaction available, the response is already closed.
-        // it is not an error to call close() multiple times, and in certain circumstances
-        // it may be unavoidable.
-        if (transactionManager.getCurrentTransaction() != null) {
-            // release the response resource
-            result.close();
-            logger.debug("Response closed: {}", this);
-        }
+        // release the response resource, this might closed implicit transaction in the GraphDatabaseService.
+        result.close();
+        logger.debug("Response closed: {}", this);
     }
 
     @Override

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/GraphModelResponse.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/GraphModelResponse.java
@@ -26,14 +26,14 @@ import org.neo4j.ogm.result.adapter.ResultAdapter;
 import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
- * @author vince
+ * @author Vince Bickers
  */
 public class GraphModelResponse extends EmbeddedResponse<GraphModel> {
 
     private final ResultAdapter<Map<String, Object>, GraphModel> adapter = new EmbeddedGraphModelAdapter();
 
-    public GraphModelResponse(Result result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public GraphModelResponse(Result result) {
+        super(result);
     }
 
     @Override

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/GraphRowModelResponse.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/GraphRowModelResponse.java
@@ -21,17 +21,16 @@ package org.neo4j.ogm.drivers.embedded.response;
 import org.neo4j.graphdb.Result;
 import org.neo4j.ogm.model.GraphRowListModel;
 import org.neo4j.ogm.response.model.DefaultGraphRowListModel;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
- * @author vince
+ * @author Vince Bickers
  */
 public class GraphRowModelResponse extends EmbeddedResponse<GraphRowListModel> {
 
     private EmbeddedGraphRowModelAdapter adapter = new EmbeddedGraphRowModelAdapter(new EmbeddedGraphModelAdapter());
 
-    public GraphRowModelResponse(Result result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public GraphRowModelResponse(Result result) {
+        super(result);
         adapter.setColumns(result.columns());
     }
 

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/RestModelResponse.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/RestModelResponse.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.neo4j.graphdb.Result;
 import org.neo4j.ogm.response.model.DefaultRestModel;
 import org.neo4j.ogm.response.model.QueryStatisticsModel;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * @author Luanne Misquitta
@@ -34,8 +33,8 @@ public class RestModelResponse extends EmbeddedResponse<DefaultRestModel> {
     private EmbeddedRestModelAdapter restModelAdapter = new EmbeddedRestModelAdapter();
     private final QueryStatisticsModel statisticsModel;
 
-    public RestModelResponse(Result result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public RestModelResponse(Result result) {
+        super(result);
         statisticsModel = new StatisticsModelAdapter().adapt(result);
     }
 

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/RowModelResponse.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/response/RowModelResponse.java
@@ -23,17 +23,16 @@ import java.util.Map;
 import org.neo4j.graphdb.Result;
 import org.neo4j.ogm.model.RowModel;
 import org.neo4j.ogm.result.adapter.ResultAdapter;
-import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
- * @author vince
+ * @author Vince Bickers
  */
 public class RowModelResponse extends EmbeddedResponse<RowModel> {
 
     private final ResultAdapter<Map<String, Object>, RowModel> adapter = new EmbeddedRowModelAdapter();
 
-    public RowModelResponse(Result result, TransactionManager transactionManager) {
-        super(result, transactionManager);
+    public RowModelResponse(Result result) {
+        super(result);
         ((EmbeddedRowModelAdapter) adapter).setColumns(result.columns());
     }
 

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/transaction/EmbeddedTransaction.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/transaction/EmbeddedTransaction.java
@@ -29,13 +29,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author vince
+ * @author Vince Bickers
  */
 public class EmbeddedTransaction extends AbstractTransaction {
 
     private final org.neo4j.graphdb.Transaction nativeTransaction;
     private final Logger LOGGER = LoggerFactory.getLogger(EmbeddedTransaction.class);
-    private boolean autoCommit;
 
     /**
      * Request a new transaction.
@@ -95,14 +94,6 @@ public class EmbeddedTransaction extends AbstractTransaction {
 
     public org.neo4j.graphdb.Transaction getNativeTransaction() {
         return nativeTransaction;
-    }
-
-    public void enableAutoCommit() {
-        this.autoCommit = true;
-    }
-
-    public boolean isAutoCommit() {
-        return autoCommit;
     }
 
     public boolean transactionIsOpen() {

--- a/http-driver/src/main/java/org/neo4j/ogm/drivers/http/transaction/HttpTransaction.java
+++ b/http-driver/src/main/java/org/neo4j/ogm/drivers/http/transaction/HttpTransaction.java
@@ -31,7 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author vince
+ * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class HttpTransaction extends AbstractTransaction {
 
@@ -54,7 +55,7 @@ public class HttpTransaction extends AbstractTransaction {
         try {
             if (transactionManager.canRollback()) {
                 HttpDelete request = new HttpDelete(url);
-                request.setHeader(new BasicHeader("X-WRITE", driver.readOnly() ? "0" : "1"));
+                request.setHeader(new BasicHeader("X-WRITE", readOnly() ? "0" : "1"));
                 driver.executeHttpRequest(request);
             }
         } catch (Exception e) {
@@ -71,7 +72,7 @@ public class HttpTransaction extends AbstractTransaction {
             if (transactionManager.canCommit()) {
                 HttpPost request = new HttpPost(url + "/commit");
                 request.setHeader(new BasicHeader(HTTP.CONTENT_TYPE, "application/json;charset=UTF-8"));
-                request.setHeader(new BasicHeader("X-WRITE", driver.readOnly() ? "0" : "1"));
+                request.setHeader(new BasicHeader("X-WRITE", readOnly() ? "0" : "1"));
                 driver.executeHttpRequest(request);
             }
         } catch (Exception e) {
@@ -79,6 +80,16 @@ public class HttpTransaction extends AbstractTransaction {
         } finally {
             super.commit(); // must always be done to keep extension depth correct
         }
+    }
+
+    private boolean readOnly() {
+        if (transactionManager != null) {
+            Transaction tx = transactionManager.getCurrentTransaction();
+            if (tx != null) {
+                return tx.isReadOnly();
+            }
+        }
+        return false; // its read-write by default
     }
 
     public String url() {

--- a/test/src/test/java/org/neo4j/ogm/CypherModificationSPITest.java
+++ b/test/src/test/java/org/neo4j/ogm/CypherModificationSPITest.java
@@ -117,19 +117,16 @@ public class CypherModificationSPITest {
     }
 
     private static class TestDriver extends AbstractConfigurableDriver {
-        // Not interested in any of those.
-        @Override
-        public Transaction newTransaction(Transaction.Type type, Iterable<String> bookmarks) {
-            return null;
-        }
 
         @Override
         public void close() {
         }
 
-        @Override public Request request() {
+        @Override
+        public Request request(Transaction transaction) {
             return null;
         }
+
     }
 
     private static class TestServiceLoaderClassLoader extends ClassLoader {

--- a/test/src/test/java/org/neo4j/ogm/drivers/StubHttpDriver.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/StubHttpDriver.java
@@ -55,12 +55,7 @@ public abstract class StubHttpDriver extends AbstractConfigurableDriver {
     }
 
     @Override
-    public Transaction newTransaction(Transaction.Type type, Iterable<String> bookmarks) {
-        throw new RuntimeException("not implemented");
-    }
-
-    @Override
-    public Request request() {
+    public Request request(Transaction transaction) {
 
         return new Request() {
 

--- a/test/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
@@ -33,8 +33,8 @@ public class BoltTransactionTest {
     @Test
     public void commitShouldCloseTransactionAndSession() {
         Transaction nativeTx = openTransactionMock();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(),  nativeSession, READ_ONLY);
 
         boltTx.commit();
 
@@ -46,8 +46,8 @@ public class BoltTransactionTest {
     @Test
     public void commitShouldCloseSessionWhenTransactionIsClosed() {
         Transaction nativeTx = closedTransactionMock();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(),  nativeSession, READ_ONLY);
 
         try {
             boltTx.commit();
@@ -63,8 +63,8 @@ public class BoltTransactionTest {
     public void commitShouldCloseSessionWhenTransactionCloseThrows() {
         Transaction nativeTx = openTransactionMock();
         doThrow(new RuntimeException("Close failed")).when(nativeTx).close();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(committingTxManager(), nativeSession, READ_ONLY);
 
         try {
             boltTx.commit();
@@ -79,8 +79,8 @@ public class BoltTransactionTest {
     @Test
     public void rollbackShouldCloseTransactionAndSession() {
         Transaction nativeTx = openTransactionMock();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeSession, READ_ONLY);
 
         boltTx.rollback();
 
@@ -92,8 +92,8 @@ public class BoltTransactionTest {
     @Test
     public void rollbackShouldCloseSessionWhenTransactionIsClosed() {
         Transaction nativeTx = closedTransactionMock();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeSession, READ_ONLY);
 
         boltTx.rollback();
 
@@ -105,8 +105,8 @@ public class BoltTransactionTest {
     public void rollbackShouldCloseSessionWhenTransactionCloseThrows() {
         Transaction nativeTx = openTransactionMock();
         doThrow(new RuntimeException("Close failed")).when(nativeTx).close();
-        Session nativeSession = openSessionMock();
-        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeTx, nativeSession, READ_ONLY);
+        Session nativeSession = openSessionMock(nativeTx);
+        BoltTransaction boltTx = new BoltTransaction(rollingBackTxManager(), nativeSession, READ_ONLY);
 
         try {
             boltTx.rollback();
@@ -118,9 +118,10 @@ public class BoltTransactionTest {
         verify(nativeSession).close();
     }
 
-    private static Session openSessionMock() {
+    private static Session openSessionMock(Transaction nativeTx) {
         Session session = mock(Session.class);
         when(session.isOpen()).thenReturn(true);
+        when(session.beginTransaction()).thenReturn(nativeTx);
         return session;
     }
 

--- a/test/src/test/java/org/neo4j/ogm/persistence/transaction/ClosedTransactionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/transaction/ClosedTransactionTest.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.ogm.persistence.transaction;
 
+import java.lang.reflect.Field;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -29,18 +31,19 @@ import org.neo4j.ogm.session.transaction.DefaultTransactionManager;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 import org.neo4j.ogm.transaction.AbstractTransaction;
 import org.neo4j.ogm.transaction.Transaction;
+import org.neo4j.ogm.transaction.TransactionManager;
 
 /**
  * This test class defines the behaviour of a transaction which is open
  * on the client, but closed on the server (for whatever reason), under
  * the different scenarios of commit, rollback and close.
  *
- * @author vince
+ * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class ClosedTransactionTest extends MultiDriverTestClass {
 
     private static SessionFactory sessionFactory;
-    private Session session;
     private DefaultTransactionManager transactionManager;
 
     private Transaction tx;
@@ -52,20 +55,24 @@ public class ClosedTransactionTest extends MultiDriverTestClass {
 
     @Before
     public void init() {
-        transactionManager = new DefaultTransactionManager(session, sessionFactory.getDriver());
-        session = sessionFactory.openSession();
+        Session session = sessionFactory.openSession();
+        // The session actually has it's own transaction manager, which is btw tied to thread locally to the driver.
+        // We could force get the sessions transaction manager or just create a new one here and tie it to the driver.
+        // Both feel broken, this here a little less painfull, though.
+        transactionManager = new DefaultTransactionManager(session, driver.getTransactionFactorySupplier());
     }
 
     @Before
     public void createTransactionAndCloseOnServerButNotOnClient() {
         tx = transactionManager.openTransaction();
         tx.close();
-        transactionManager.reinstate((AbstractTransaction) tx);
+
+        reOpen(transactionManager, tx);
     }
 
     @After
     public void clearTransactionManager() {
-        transactionManager.clear();
+        getTransactionThreadLocal(transactionManager).remove();
     }
 
     @Test
@@ -81,5 +88,28 @@ public class ClosedTransactionTest extends MultiDriverTestClass {
     @Test(expected = TransactionException.class)
     public void shouldThrowExceptionWhenCommittingAClosedTransaction() {
         tx.commit();
+    }
+
+    private static void reOpen(TransactionManager transactionManager, Transaction transaction) {
+
+        try {
+            Field statusField = AbstractTransaction.class.getDeclaredField("status");
+            statusField.setAccessible(true);
+            statusField.set(transaction, Transaction.Status.OPEN);
+
+            getTransactionThreadLocal(transactionManager).set(transaction);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ThreadLocal<Transaction> getTransactionThreadLocal(TransactionManager transactionManager) {
+        try {
+            Field transactionField = DefaultTransactionManager.class.getDeclaredField("currentThreadLocalTransaction");
+            transactionField.setAccessible(true);
+            return (ThreadLocal<Transaction>) transactionField.get(transactionManager);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
@@ -67,7 +67,7 @@ public class TransactionManagerTest extends MultiDriverTestClass {
     @Test
     public void shouldBeAbleToCreateManagedTransaction() {
         DefaultTransactionManager transactionManager = new DefaultTransactionManager(session,
-            sessionFactory.getDriver());
+            sessionFactory.getDriver().getTransactionFactorySupplier());
         assertThat(session.getLastBookmark()).isNull();
         try (Transaction tx = transactionManager.openTransaction()) {
             assertThat(tx.status()).isEqualTo(Transaction.Status.OPEN);
@@ -77,7 +77,7 @@ public class TransactionManagerTest extends MultiDriverTestClass {
     @Test(expected = TransactionManagerException.class)
     @Ignore("What's the rationale of this test ? Actually leaves tx in an inconsistent state")
     public void shouldFailCommitFreeTransactionInManagedContext() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, sessionFactory.getDriver());
+        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, sessionFactory.getDriver().getTransactionFactorySupplier());
         try (Transaction tx = sessionFactory.getDriver().newTransaction(Transaction.Type.READ_WRITE, null)) {
             transactionManager.commit(tx);
         }
@@ -86,7 +86,7 @@ public class TransactionManagerTest extends MultiDriverTestClass {
     @Test(expected = TransactionManagerException.class)
     @Ignore("What's the rationale of this test ? Actually leaves tx in an inconsistent state")
     public void shouldFailRollbackFreeTransactionInManagedContext() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, sessionFactory.getDriver());
+        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, sessionFactory.getDriver().getTransactionFactorySupplier());
         try (Transaction tx = sessionFactory.getDriver().newTransaction(Transaction.Type.READ_WRITE, null)) {
             transactionManager.rollback(tx);
         }
@@ -95,7 +95,7 @@ public class TransactionManagerTest extends MultiDriverTestClass {
     @Test
     public void shouldRollbackManagedTransaction() {
         DefaultTransactionManager transactionManager = new DefaultTransactionManager(session,
-            sessionFactory.getDriver());
+            sessionFactory.getDriver().getTransactionFactorySupplier());
         assertThat(session.getLastBookmark()).isNull();
 
         try (Transaction tx = transactionManager.openTransaction()) {

--- a/test/src/test/java/org/neo4j/ogm/session/ConcurrentSessionTest.java
+++ b/test/src/test/java/org/neo4j/ogm/session/ConcurrentSessionTest.java
@@ -48,15 +48,12 @@ public class ConcurrentSessionTest extends MultiDriverTestClass {
         sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.concurrency");
     }
 
-    @Before
-    public void init() {
-        session = sessionFactory.openSession();
-    }
 
     @Test
     public void multipleThreadsResultsGetMixedUp() throws Exception {
 
         World world1 = new World("world 1", 1);
+        Session session = sessionFactory.openSession();
         session.save(world1, 0);
 
         World world2 = new World("world 2", 2);
@@ -70,7 +67,8 @@ public class ConcurrentSessionTest extends MultiDriverTestClass {
         for (int i = 0; i < iterations; i++) {
 
             service.execute(() -> {
-                World world = session.loadAll(World.class, new Filter("name", ComparisonOperator.EQUALS, "world 1"))
+                Session session1 = sessionFactory.openSession();
+                World world = session1.loadAll(World.class, new Filter("name", ComparisonOperator.EQUALS, "world 1"))
                     .iterator().next();
 
                 if (!"world 1".equals(world.getName())) {
@@ -81,7 +79,8 @@ public class ConcurrentSessionTest extends MultiDriverTestClass {
 
             service.execute(() -> {
 
-                World world = session.loadAll(World.class, new Filter("name", ComparisonOperator.EQUALS, "world 2"))
+                Session session2 = sessionFactory.openSession();
+                World world = session2.loadAll(World.class, new Filter("name", ComparisonOperator.EQUALS, "world 2"))
                     .iterator().next();
 
                 if (!"world 2".equals(world.getName())) {


### PR DESCRIPTION
The driver is the long living thing inside OGM. In any multithreaded
environment, it is dangerous to keep a transactionmanager like ours,
tied to a session and transaction and vice versa, here.

This commit replaces it with a supplier of factories for transactions
and decouples at least driver and transactionmanager.

This fixes especially the bookmark handling.

The bug fix cannot be done without interface changes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
