### PR TITLE
Fix tests for embedded.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
@@ -48,6 +48,8 @@ public interface TransactionManager {
      * this is successful, the transaction is detached from this thread.
      * If the specified transaction is not the correct one for this thread, throws an exception
      *
+     * <strong>Warning</strong>: This method is meant to be called from actual transactions only!!!
+     *
      * @param transaction the transaction to rollback
      */
     void rollback(Transaction transaction);
@@ -57,6 +59,8 @@ public interface TransactionManager {
      * The actual job of committing the transaction is left to the relevant driver. if
      * this is successful, the transaction is detached from this thread.
      * If the specified transaction is not the correct one for this thread, throws an exception
+     *
+     * <strong>Warning</strong>: This method is meant to be called from actual transactions only!!!
      *
      * @param transaction the transaction to commit
      */

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/BasicDriverTest.java
@@ -58,6 +58,7 @@ import org.neo4j.ogm.transaction.Transaction;
  */
 public class BasicDriverTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/QueryStatisticsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/QueryStatisticsTest.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryStatisticsTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private static final Logger logger = LoggerFactory.getLogger(QueryStatisticsTest.class);
 
     private Session session;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/EnumsNotScannedTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/EnumsNotScannedTest.java
@@ -41,6 +41,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class EnumsNotScannedTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/EnumsScannedTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/EnumsScannedTest.java
@@ -39,6 +39,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class EnumsScannedTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/LookupByPrimaryIndexTests.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/LookupByPrimaryIndexTests.java
@@ -42,6 +42,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class LookupByPrimaryIndexTests extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/EndToEndTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/EndToEndTest.java
@@ -40,6 +40,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class EndToEndTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/blog/BlogTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/blog/BlogTest.java
@@ -37,6 +37,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class BlogTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/canonical/CanonicalTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/canonical/CanonicalTest.java
@@ -37,6 +37,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class CanonicalTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsIntegrationTest.java
@@ -57,6 +57,7 @@ import org.neo4j.ogm.testutil.TestUtils;
  */
 public class CineastsIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -55,6 +55,7 @@ import org.neo4j.ogm.testutil.TestUtils;
  */
 public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/partial/RelationshipEntityPartialMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/partial/RelationshipEntityPartialMappingTest.java
@@ -40,6 +40,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class RelationshipEntityPartialMappingTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/companies/CompaniesIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/companies/CompaniesIntegrationTest.java
@@ -42,6 +42,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class CompaniesIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/convertible/ParameterizedConversionTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/convertible/ParameterizedConversionTest.java
@@ -39,6 +39,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class ParameterizedConversionTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationIntegrationTest.java
@@ -43,6 +43,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class EducationIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/election/ElectionTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/election/ElectionTest.java
@@ -43,6 +43,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class ElectionTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/friendships/FriendshipsRelationshipEntityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/friendships/FriendshipsRelationshipEntityTest.java
@@ -40,6 +40,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class FriendshipsRelationshipEntityTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/pizza/PizzaIntegrationTest.java
@@ -47,6 +47,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class PizzaIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/restaurant/RestaurantIntegrationTest.java
@@ -50,6 +50,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 public class RestaurantIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/social/SocialRelationshipsIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/social/SocialRelationshipsIntegrationTest.java
@@ -45,6 +45,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class SocialRelationshipsIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/AbstractWithGenericPropertyRelationshipTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/AbstractWithGenericPropertyRelationshipTest.java
@@ -51,6 +51,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 public class AbstractWithGenericPropertyRelationshipTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/ArraysMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/ArraysMappingTest.java
@@ -36,6 +36,8 @@ import org.neo4j.ogm.testutil.GraphTestUtils;
 import org.neo4j.ogm.testutil.MultiDriverTestClass;
 
 public class ArraysMappingTest extends MultiDriverTestClass {
+
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/DegenerateEntityModelTests.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/DegenerateEntityModelTests.java
@@ -47,6 +47,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class DegenerateEntityModelTests extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     private Folder f;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -64,6 +64,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class EntityGraphMapperTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private EntityMapper mapper;
 
     private static MetaData mappingMetadata;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityMappingTest.java
@@ -47,6 +47,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class RelationshipEntityMappingTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityPartialMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityPartialMappingTest.java
@@ -39,6 +39,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class RelationshipEntityPartialMappingTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipMappingTest.java
@@ -40,6 +40,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class RelationshipMappingTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/relationships/GenericCollectionRelationshipsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/relationships/GenericCollectionRelationshipsTest.java
@@ -38,6 +38,8 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class GenericCollectionRelationshipsTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
+
     @BeforeClass
     public static void initSesssionFactory() {
         sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.gh385");

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
@@ -75,22 +75,6 @@ public class TransactionManagerTest extends MultiDriverTestClass {
         }
     }
 
-    @Test(expected = TransactionManagerException.class)
-    public void shouldFailCommitFreeTransactionInManagedContext() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, driver);
-        try (Transaction tx = driver.newTransaction(Transaction.Type.READ_WRITE, null)) {
-            transactionManager.commit(tx);
-        }
-    }
-
-    @Test(expected = TransactionManagerException.class)
-    public void shouldFailRollbackFreeTransactionInManagedContext() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(null, driver);
-        try (Transaction tx = driver.newTransaction(Transaction.Type.READ_WRITE, null)) {
-            transactionManager.rollback(tx);
-        }
-    }
-
     @Test
     public void shouldRollbackManagedTransaction() {
         DefaultTransactionManager transactionManager = new DefaultTransactionManager(session, driver);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
@@ -49,6 +49,7 @@ import org.neo4j.ogm.transaction.Transaction;
  */
 public class TransactionManagerTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -71,6 +71,7 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
  */
 public class ClassHierarchiesIntegrationTest extends MultiDriverTestClass {
 
+    private static SessionFactory sessionFactory;
     private Session session;
 
     @BeforeClass

--- a/neo4j-ogm-tests/neo4j-ogm-native-types-tests/src/test/resources/logback-test.xml
+++ b/neo4j-ogm-tests/neo4j-ogm-native-types-tests/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright (c) 2002-2019 "Neo4j,"
+ | Neo4j Sweden AB [http://neo4j.com]
+ |
+ | This file is part of Neo4j.
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this file except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |     http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %5p %40.40c:%4L - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.neo4j.ogm" level="warn"/>
+
+    <root level="warn">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
* Changed `TransactionManagerTest` as decided together
* Make contents of `MultiDriverTestClass` immutable

So basically, have a look only at `MultiDriverTestClass`.

Everything is immutable now, `SessionFactory` is gone.
-> Every concrete test is responsible for it's session factory and doesn't mess with the other ones.

The most important change though is the removal of `createTemporaryGraphStore` in the test class. It's not needed, the embedded driver is able to do this nicely on its own.