### PR TITLE
Fix for #613 - Edge get deleted even though it is still mapped

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -23,7 +23,15 @@ import static org.neo4j.ogm.metadata.reflect.EntityAccessManager.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.ogm.annotation.EndNode;
 import org.neo4j.ogm.annotation.StartNode;
@@ -308,9 +316,9 @@ public class GraphEntityMapper implements ResponseMapper<GraphModel> {
                     Class<?> paramType = writer.type();
                     Class elementType = underlyingElementType(classInfo, property.getKey().toString());
                     if (paramType.isArray()) {
-                        value = EntityAccessManager.merge(paramType, value, new Object[] {}, elementType);
+                        value = EntityAccessManager.merge(paramType, value, (Object[]) null, elementType);
                     } else {
-                        value = EntityAccessManager.merge(paramType, value, Collections.emptyList(), elementType);
+                        value = EntityAccessManager.merge(paramType, value, (Collection<?>) null, elementType);
                     }
                 }
             }

--- a/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
@@ -34,11 +34,11 @@ public class MappedRelationship implements Mappable {
     private final String relationshipType;
     private final long endNodeId;
     private Long relationshipId;
-    private Class startNodeType;
-    private Class endNodeType;
+    private Class<?> startNodeType;
+    private Class<?> endNodeType;
 
-    public MappedRelationship(long startNodeId, String relationshipType, long endNodeId, Class startNodeType,
-        Class endNodeType) {
+    public MappedRelationship(long startNodeId, String relationshipType, long endNodeId, Class<?> startNodeType,
+        Class<?> endNodeType) {
         this.startNodeId = startNodeId;
         this.relationshipType = relationshipType;
         this.endNodeId = endNodeId;
@@ -47,7 +47,7 @@ public class MappedRelationship implements Mappable {
     }
 
     public MappedRelationship(long startNodeId, String relationshipType, long endNodeId, Long relationshipId,
-        Class startNodeType, Class endNodeType) {
+        Class<?> startNodeType, Class<?> endNodeType) {
         this.startNodeId = startNodeId;
         this.relationshipType = relationshipType;
         this.endNodeId = endNodeId;
@@ -84,11 +84,11 @@ public class MappedRelationship implements Mappable {
     public void activate() {
     }
 
-    public Class getEndNodeType() {
+    public Class<?> getEndNodeType() {
         return endNodeType;
     }
 
-    public Class getStartNodeType() {
+    public Class<?> getStartNodeType() {
         return startNodeType;
     }
 

--- a/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
@@ -19,7 +19,7 @@
 package org.neo4j.ogm.context;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -64,8 +64,8 @@ public class SingleUseEntityMapper {
     /**
      * Constructs a new {@link SingleUseEntityMapper} based on the given mapping {@link MetaData}.
      *
-     * @param mappingMetaData The {@link MetaData} to use for performing mappings
-     * @param entityInstantiator   The entity factory to use.
+     * @param mappingMetaData    The {@link MetaData} to use for performing mappings
+     * @param entityInstantiator The entity factory to use.
      */
     public SingleUseEntityMapper(MetaData mappingMetaData, EntityInstantiator entityInstantiator) {
         this.metadata = mappingMetaData;
@@ -142,8 +142,8 @@ public class SingleUseEntityMapper {
             if (writer.type().isArray() || Iterable.class.isAssignableFrom(writer.type())) {
                 Class elementType = underlyingElementType(classInfo, property.getKey());
                 value = writer.type().isArray()
-                    ? EntityAccessManager.merge(writer.type(), value, new Object[] {}, elementType)
-                    : EntityAccessManager.merge(writer.type(), value, Collections.EMPTY_LIST, elementType);
+                    ? EntityAccessManager.merge(writer.type(), value, (Object[]) null, elementType)
+                    : EntityAccessManager.merge(writer.type(), value, (Collection<?>) null, elementType);
             }
             writer.write(instance, value);
         } else {

--- a/core/src/main/java/org/neo4j/ogm/context/TransientRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/TransientRelationship.java
@@ -45,10 +45,10 @@ public class TransientRelationship {
     private final Long tgt;
     private final Long ref;
     private final String rel;
-    private final Class srcClass;
-    private final Class tgtClass;
+    private final Class<?> srcClass;
+    private final Class<?> tgtClass;
 
-    public TransientRelationship(Long src, Long ref, String rel, Long tgt, Class srcClass, Class tgtClass) {
+    public TransientRelationship(Long src, Long ref, String rel, Long tgt, Class<?> srcClass, Class<?> tgtClass) {
         this.src = src;
         this.tgt = tgt;
         this.ref = ref;
@@ -58,29 +58,23 @@ public class TransientRelationship {
     }
 
     public boolean equals(Long src, RelationshipBuilder builder, Long tgt) {
-        Boolean singleton = builder.isSingleton();
-        if (this.rel.equals(builder.type())) {
-            if (singleton) {
-                if (builder.hasDirection(Relationship.OUTGOING)) {
-                    if (this.src.equals(src) && this.tgt.equals(tgt)) {
-                        return true;
-                    }
-                } else if (builder.hasDirection(Relationship.INCOMING)) {
-                    if (this.src.equals(tgt) && this.tgt.equals(src)) {
-                        return true;
-                    }
-                } else {
-                    // Implies outgoing so the direction is ignored
-                    if (this.src.equals(src) && this.tgt.equals(tgt)) {
-                        return true;
-                    }
-                    if (this.src.equals(tgt) && this.tgt.equals(src)) {
-                        return true;
-                    }
-                }
-            }
+        if (!this.rel.equals(builder.type())) {
+            return false;
         }
-        return false;
+        if (!builder.isSingleton()) {
+            return false;
+        }
+        if (builder.hasDirection(Relationship.OUTGOING)) {
+            return this.src.equals(src) && this.tgt.equals(tgt);
+        } else if (builder.hasDirection(Relationship.INCOMING)) {
+            return this.src.equals(tgt) && this.tgt.equals(src);
+        } else {
+            // Implies outgoing so the direction is ignored
+            if (this.src.equals(src) && this.tgt.equals(tgt)) {
+                return true;
+            }
+            return this.src.equals(tgt) && this.tgt.equals(src);
+        }
     }
 
     public Long getSrc() {
@@ -99,11 +93,11 @@ public class TransientRelationship {
         return rel;
     }
 
-    public Class getSrcClass() {
+    public Class<?> getSrcClass() {
         return srcClass;
     }
 
-    public Class getTgtClass() {
+    public Class<?> getTgtClass() {
         return tgtClass;
     }
 

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
@@ -74,7 +74,7 @@ public interface CompileContext {
 
     Collection<Mappable> getDeletedRelationships();
 
-    Object getVisitedObject(Long reference);
+    Collection<Object> visitedObjects();
 
     Collection<Object> getTransientRelationships(SrcTargetKey key);
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 import org.neo4j.ogm.compiler.SrcTargetKey;
 import org.neo4j.ogm.context.Mappable;
+import org.neo4j.ogm.context.TransientRelationship;
 
 /**
  * Maintains contextual information throughout the process of compiling Cypher statements to persist a graph of objects.
@@ -41,7 +42,7 @@ public interface CompileContext {
 
     void register(Object entity);
 
-    void registerTransientRelationship(SrcTargetKey key, Object object);
+    void registerTransientRelationship(SrcTargetKey key, TransientRelationship object);
 
     void registerNewObject(Long reference, Object relationshipEntity);
 
@@ -76,5 +77,5 @@ public interface CompileContext {
 
     Collection<Object> visitedObjects();
 
-    Collection<Object> getTransientRelationships(SrcTargetKey key);
+    Collection<TransientRelationship> getTransientRelationships(SrcTargetKey key);
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 
 import org.neo4j.ogm.compiler.SrcTargetKey;
 import org.neo4j.ogm.context.Mappable;
+import org.neo4j.ogm.context.TransientRelationship;
 
 /**
  * Maintains contextual information throughout the process of compiling Cypher statements to persist a graph of objects.
@@ -48,7 +49,7 @@ public class CypherContext implements CompileContext {
     private final Set<Mappable> deletedRelationships = new HashSet<>();
 
     private final Set<Object> registry = new HashSet<>();
-    private final Map<SrcTargetKey, Set<Object>> transientRelsIndex = new HashMap<>();
+    private final Map<SrcTargetKey, Set<TransientRelationship>> transientRelsIndex = new HashMap<>();
 
     private final Compiler compiler;
 
@@ -96,11 +97,11 @@ public class CypherContext implements CompileContext {
     }
 
     @Override
-    public void registerTransientRelationship(SrcTargetKey key, Object object) {
-        if (!registry.contains(object)) {
-            registry.add(object);
-            Set<Object> collection = transientRelsIndex.computeIfAbsent(key, k -> new HashSet<>());
-            collection.add(object);
+    public void registerTransientRelationship(SrcTargetKey key, TransientRelationship object) {
+        if (registry.add(object)) {
+            transientRelsIndex
+                .computeIfAbsent(key, k -> new HashSet<>())
+                .add(object);
         }
     }
 
@@ -245,8 +246,8 @@ public class CypherContext implements CompileContext {
     }
 
     @Override
-    public Collection<Object> getTransientRelationships(SrcTargetKey srcTargetKey) {
-        Collection<Object> objects = transientRelsIndex.get(srcTargetKey);
+    public Collection<TransientRelationship> getTransientRelationships(SrcTargetKey srcTargetKey) {
+        Collection<TransientRelationship> objects = transientRelsIndex.get(srcTargetKey);
         if (objects != null) {
             return objects;
         } else {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
@@ -92,9 +92,7 @@ public class CypherContext implements CompileContext {
     }
 
     public void register(Object object) {
-        if (!registry.contains(object)) {
-            registry.add(object);
-        }
+        registry.add(object);
     }
 
     @Override
@@ -242,8 +240,8 @@ public class CypherContext implements CompileContext {
     }
 
     @Override
-    public Object getVisitedObject(Long reference) {
-        return visitedObjects.get(reference);
+    public Collection<Object> visitedObjects() {
+        return Collections.unmodifiableSet(visitedObjects.keySet());
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
@@ -51,8 +51,6 @@ public interface RelationshipBuilder extends PropertyContainerBuilder<Relationsh
 
     void setRelationshipEntity(boolean relationshipEntity);
 
-    boolean isNew();
-
     Edge edge();
 
     void setPrimaryIdName(String primaryIdName);

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
@@ -87,11 +87,6 @@ public class DefaultRelationshipBuilder extends AbstractPropertyContainerBuilder
     }
 
     @Override
-    public boolean isNew() {
-        return true;
-    }
-
-    @Override
     public void setSingleton(boolean b) {
         this.singleton = b;
     }

--- a/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -52,6 +52,7 @@ public class SessionFactory {
 
     private LoadStrategy loadStrategy = LoadStrategy.SCHEMA_LOAD_STRATEGY;
     private EntityInstantiator entityInstantiator;
+    private boolean updateOtherSideOfRelationships;
 
     /**
      * Constructs a new {@link SessionFactory} by initialising the object-graph mapping meta-data from the given list of domain
@@ -137,7 +138,10 @@ public class SessionFactory {
      * @return A new {@link Session}
      */
     public Session openSession() {
-        return new Neo4jSession(metaData, driver, eventListeners, loadStrategy, entityInstantiator);
+        Neo4jSession neo4jSession = new Neo4jSession(metaData, driver, eventListeners, loadStrategy,
+            entityInstantiator);
+        neo4jSession.setUpdateOtherSideOfRelationships(updateOtherSideOfRelationships);
+        return neo4jSession;
     }
 
     /**
@@ -192,6 +196,20 @@ public class SessionFactory {
      */
     public Driver getDriver() {
         return driver;
+    }
+
+    /**
+     * @return true, if changing one side of the relationship should also update the opposite side
+     */
+    public boolean isUpdateOtherSideOfRelationships() {
+        return updateOtherSideOfRelationships;
+    }
+
+    /**
+     * @param updateOtherSideOfRelationships true if changing one side of the relationship should also update the opposite side
+     */
+    public void setUpdateOtherSideOfRelationships(boolean updateOtherSideOfRelationships) {
+        this.updateOtherSideOfRelationships = updateOtherSideOfRelationships;
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
@@ -55,7 +55,10 @@ public class SaveDelegate extends SessionDelegate {
 
         SaveEventDelegate eventsDelegate = new SaveEventDelegate(session);
 
-        EntityGraphMapper entityGraphMapper = new EntityGraphMapper(session.metaData(), session.context());
+        EntityGraphMapper entityGraphMapper = new EntityGraphMapper(
+            session.metaData(),
+            session.context(),
+            session.isUpdateOtherSideOfRelationships());
         if (this.writeProtectionStrategy != null) {
             entityGraphMapper.addWriteProtection(this.writeProtectionStrategy.get());
         }

--- a/test/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
@@ -60,7 +60,7 @@ public class DirectRelationshipsTest {
 
     @Before
     public void setUpMapper() {
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
     }
 
     @After
@@ -518,7 +518,7 @@ public class DirectRelationshipsTest {
         assertThat(statements.get(0).getStatement()).isEqualTo(
             "UNWIND {rows} as row MATCH (startNode) WHERE ID(startNode) = row.startNodeId WITH row,startNode MATCH (endNode) WHERE ID(endNode) = row.endNodeId MATCH (startNode)-[rel:`CONTAINS`]->(endNode) DELETE rel");
 
-        mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         //There are no more changes to the graph
         compiler = mapper.map(doc1).getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
@@ -901,7 +901,7 @@ public class CompilerTest {
     }
 
     private Compiler mapAndCompile(Object object) {
-        EntityMapper mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        EntityMapper mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         CompileContext context = mapper.map(object);
         Compiler compiler = context.getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
@@ -77,6 +77,25 @@ public class SavingTest extends MultiDriverTestClass {
         assertThat(loc2.getChildNodes()).hasSize(2);
     }
 
+    @Test
+    public void testClearRelationship() {
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+
+        Node loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getLabels()).hasSize(1);
+
+        loc1_1.setLabels(null);
+        session.save(loc1_1);
+
+        Node root = queryNode("root");
+        assertThat(root.getChildNodes()).hasSize(2);
+        session.save(root);
+
+        loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+    }
+
     private Node queryNode(String nodeId) {
         Collection<Node> nodeTypes = session
             .loadAll(Node.class, new Filters(new Filter("nodeId", ComparisonOperator.EQUALS, nodeId)));

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
@@ -1,0 +1,77 @@
+package org.neo4j.ogm.cypher.compiler;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.domain.gh613.Label;
+import org.neo4j.ogm.domain.gh613.Node;
+import org.neo4j.ogm.domain.gh613.NodeType;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+
+/**
+ * @author Andreas Berger
+ */
+public class SavingTest extends MultiDriverTestClass {
+
+    private Session session;
+
+    @BeforeClass
+    public static void initSesssionFactory() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.gh613");
+    }
+
+    @Before
+    public void init() {
+        session = sessionFactory.openSession();
+
+        NodeType nodeType = new NodeType("nt");
+        Node l1 = new Node("l1").setNodeType(nodeType);
+        Node l2 = new Node("l2")
+            .setNodeType(nodeType)
+            .setLabels(Collections.singleton(new Label().setKey("label1")))
+            .setChildOf(l1);
+
+        l1.setChildNodes(Collections.singleton(l2));
+
+        session.save(l1);
+        session.save(l2);
+        session.clear();
+    }
+
+    /**
+     * GH-613
+     */
+    @Test
+    public void testSaveParentAfterChild() {
+
+        Node l2 = queryNode("l2");
+        assertThat(l2.getNodeType()).isNotNull();
+        l2.setLabels(null);
+        session.save(l2);
+
+        Node l1 = queryNode("l1");
+        assertThat(l1.getChildNodes()).hasSize(1);
+        assertThat(l1.getNodeType()).isNotNull();
+        session.save(l1);
+
+        l2 = queryNode("l2");
+        assertThat(l2.getNodeType()).isNotNull();
+    }
+
+    private Node queryNode(String nodeId) {
+        Collection<Node> nodeTypes = session
+            .loadAll(Node.class, new Filters(new Filter("nodeId", ComparisonOperator.EQUALS, nodeId)));
+        assertThat(nodeTypes).hasSize(1);
+        return nodeTypes.iterator().next();
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
+++ b/test/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
@@ -27,6 +27,7 @@ public class SavingTest extends MultiDriverTestClass {
     @BeforeClass
     public static void initSesssionFactory() {
         sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.gh613");
+        sessionFactory.setUpdateOtherSideOfRelationships(true);
     }
 
     @Before

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
@@ -1,0 +1,22 @@
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+/**
+ * @author Andreas Berger
+ */
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
@@ -1,5 +1,7 @@
 package org.neo4j.ogm.domain.gh613;
 
+import java.util.Objects;
+
 import org.neo4j.ogm.annotation.Index;
 import org.neo4j.ogm.annotation.NodeEntity;
 
@@ -21,7 +23,25 @@ public class Label extends BaseEntity {
         return this;
     }
 
-    @Override public String toString() {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Label label = (Label) o;
+        return Objects.equals(key, label.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public String toString() {
         return "Label{" +
             "key='" + key + '\'' +
             '}';

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
@@ -1,0 +1,23 @@
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Label extends BaseEntity {
+
+    @Index
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public Label setKey(String key) {
+        this.key = key;
+        return this;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
@@ -20,4 +20,10 @@ public class Label extends BaseEntity {
         this.key = key;
         return this;
     }
+
+    @Override public String toString() {
+        return "Label{" +
+            "key='" + key + '\'' +
+            '}';
+    }
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
@@ -1,0 +1,81 @@
+package org.neo4j.ogm.domain.gh613;
+
+import java.util.Set;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Node extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeId;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.OUTGOING)
+    private Node childOf;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.INCOMING)
+    protected Set<Node> childNodes;
+
+    @Relationship(type = "HAS_TYPE", direction = Relationship.OUTGOING)
+    private NodeType nodeType;
+
+    @Relationship(type = "LABELED", direction = Relationship.OUTGOING)
+    private Set<Label> labels;
+
+    public Node() {
+    }
+
+    public Node(String nodeId) {
+        setNodeId(nodeId);
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public Node setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+        return this;
+    }
+
+    public Node getChildOf() {
+        return childOf;
+    }
+
+    public Node setChildOf(Node childOf) {
+        this.childOf = childOf;
+        return this;
+    }
+
+    public Set<Node> getChildNodes() {
+        return childNodes;
+    }
+
+    public Node setChildNodes(Set<Node> childNodes) {
+        this.childNodes = childNodes;
+        return this;
+    }
+
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    public Node setNodeType(NodeType nodeType) {
+        this.nodeType = nodeType;
+        return this;
+    }
+
+    public Set<Label> getLabels() {
+        return labels;
+    }
+
+    public Node setLabels(Set<Label> labels) {
+        this.labels = labels;
+        return this;
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
@@ -1,5 +1,7 @@
 package org.neo4j.ogm.domain.gh613;
 
+import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.neo4j.ogm.annotation.Index;
@@ -52,6 +54,28 @@ public class Node extends BaseEntity {
         return this;
     }
 
+    public Node setChildOfBidirectional(Node newParent) {
+        Node currentParent = this.getChildOf();
+        if (newParent == currentParent) {
+            return this;
+        }
+        if (currentParent != null
+            && currentParent.getChildNodes() != null
+            && !currentParent.getChildNodes().isEmpty()) {
+            // updating both sides of the bidirectional mapping
+            // this is to workaround this issue https://github.com/neo4j/neo4j-ogm/issues/591
+            currentParent.getChildNodes().remove(this);
+        }
+        if (newParent != null) {
+            if (newParent.getChildNodes() == null) {
+                newParent.setChildNodes(new HashSet<>());
+            }
+            newParent.getChildNodes().add(this);
+        }
+        this.childOf = newParent;
+        return this;
+    }
+
     public Set<Node> getChildNodes() {
         return childNodes;
     }
@@ -79,7 +103,25 @@ public class Node extends BaseEntity {
         return this;
     }
 
-    @Override public String toString() {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Node)) {
+            return false;
+        }
+        Node that = (Node) o;
+        return Objects.equals(nodeId, that.nodeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeId);
+    }
+
+    @Override
+    public String toString() {
         return "Node{" +
             "nodeId='" + nodeId + '\'' +
             '}';

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
@@ -78,4 +78,10 @@ public class Node extends BaseEntity {
         this.labels = labels;
         return this;
     }
+
+    @Override public String toString() {
+        return "Node{" +
+            "nodeId='" + nodeId + '\'' +
+            '}';
+    }
 }

--- a/test/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
@@ -1,0 +1,36 @@
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class NodeType extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeTypeId;
+
+    public NodeType() {
+    }
+
+    public NodeType(String nodeTypeId) {
+        this.nodeTypeId = nodeTypeId;
+    }
+
+    public String getNodeTypeId() {
+        return nodeTypeId;
+    }
+
+    public NodeType setNodeTypeId(String nodeTypeId) {
+        this.nodeTypeId = nodeTypeId;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeType: " + nodeTypeId;
+    }
+
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/social/SocialUser.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/social/SocialUser.java
@@ -81,31 +81,4 @@ public class SocialUser {
     public void setName(String name) {
         this.name = name;
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
-        SocialUser that = (SocialUser) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null)
-            return false;
-        if (friends != null ? !friends.equals(that.friends) : that.friends != null)
-            return false;
-        if (following != null ? !following.equals(that.following) : that.following != null)
-            return false;
-        return !(followers != null ? !followers.equals(that.followers) : that.followers != null);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 31 + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (friends != null ? friends.hashCode() : 0);
-        result = 31 * result + (following != null ? following.hashCode() : 0);
-        result = 31 * result + (followers != null ? followers.hashCode() : 0);
-        return result;
-    }
 }

--- a/test/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
+++ b/test/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
@@ -53,7 +53,7 @@ public class MergeWithPrimaryIndexTests {
     @Before
     public void setUpMapper() {
         mappingContext = new MappingContext(mappingMetadata);
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
     }
 
     @After

--- a/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -410,7 +410,7 @@ public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
         movies = session.loadAll(Movie.class,
             new Filter("title", ComparisonOperator.EQUALS, "Harry Potter and the Order of the Phoenix"));
         phoenix = movies.iterator().next();
-        assertThat(phoenix.getRatings()).isNull();
+        assertThat(phoenix.getRatings()).isNullOrEmpty();
 
         movies = session.loadAll(Movie.class,
             new Filter("title", ComparisonOperator.EQUALS, "Harry Potter and the Goblet of Fire"));

--- a/test/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -88,7 +88,7 @@ public class EntityGraphMapperTest extends MultiDriverTestClass {
             "org.neo4j.ogm.domain.election", "org.neo4j.ogm.domain.forum",
             "org.neo4j.ogm.domain.education", "org.neo4j.ogm.domain.types");
         mappingContext.clear();
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         session = sessionFactory.openSession();
         session.purgeDatabase();
     }

--- a/test/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
@@ -144,28 +144,28 @@ public class SaveCapabilityTest extends MultiDriverTestClass {
         lost.setArtist(bonJovi);
         lost.setGuestArtist(leann);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(lost, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(lost, depth);
         assertThat(context.registry()).as("Should save 3 nodes and 2 relations (5 items)").hasSize(5);
 
         session.save(lost);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(lost, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(lost, depth);
         assertThat(context.registry()).as("Should have nothing to save").isEmpty();
 
         session.clear();
 
         Artist loadedLeann = session.load(Artist.class, leann.getId(), depth);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have nothing to save").isEmpty();
 
         loadedLeann.setName("New name");
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have one node to save").hasSize(1);
 
         loadedLeann.getGuestAlbums().iterator().next().setName("New Album Name");
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have two node to save").hasSize(2);
     }
 

--- a/test/src/test/java/org/neo4j/ogm/persistence/session/lifecycle/StaleObjectTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/session/lifecycle/StaleObjectTest.java
@@ -106,11 +106,11 @@ public class StaleObjectTest extends MultiDriverTestClass {
         // directly after a save all objects in the save tree are guaranteed to not be dirty
         // directly after a load, all objects in the load tree are guaranteed to not be dirty
 
-        assertThat(p.getDocuments().iterator().next() == b).isFalse();
+        assertThat(p.getDocuments().iterator().next()).isNotSameAs(b);
 
         assertThat(a.toString()).isEqualTo("Document{folder=null, name='a'}");
         assertThat(b.toString()).isEqualTo(
-            "Document{folder=Folder{name='f', documents=2, archived=0}, name='b'}");   // b is attached to f, which hasn't been saved or reloaded, so is unchanged
+            "Document{folder=Folder{name='f', documents=2, archived=0}, name='b'}"); // b is attached to f, which hasn't been saved or reloaded, so is unchanged
 
         assertThat(p.getDocuments().iterator().next().toString())
             .isEqualTo("Document{folder=Folder{name='f', documents=1, archived=0}, name='b'}");

--- a/test/src/test/java/org/neo4j/ogm/persistence/session/mappingContext/SessionAndMappingContextTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/session/mappingContext/SessionAndMappingContextTest.java
@@ -129,13 +129,13 @@ public class SessionAndMappingContextTest extends MultiDriverTestClass {
         // check that objects with references to the deleted object have been cleared
         // check for TransientRelationship, where the object connected to the deleted object holds ref in a Set
         Album retrievedAlbum1 = (Album) mappingContext.getNodeEntity(album1.getId());
-        assertThat(retrievedAlbum1.getArtist() == null).isTrue();
+        assertThat(retrievedAlbum1.getArtist()).isNull();
 
         Album retrievedAlbum2 = (Album) mappingContext.getNodeEntity(album2.getId());
-        assertThat(retrievedAlbum2.getArtist() == null).isTrue();
+        assertThat(retrievedAlbum2.getArtist()).isNull();
 
         Album retrievedAlbum3 = (Album) mappingContext.getNodeEntity(album3.getId());
-        assertThat(retrievedAlbum3.getArtist() == null).isTrue();
+        assertThat(retrievedAlbum3.getArtist()).isNull();
     }
 
     @Test

--- a/test/src/test/resources/org/neo4j/ogm/cql/gh613.cql
+++ b/test/src/test/resources/org/neo4j/ogm/cql/gh613.cql
@@ -1,0 +1,17 @@
+CREATE
+  (location:NodeType {nodeTypeId: 'location'})
+CREATE
+  (l1:Label {key: 'l1'})
+CREATE
+  (loc1:Node:BaseNodeEntity {nodeId: 'loc1'})-[:HAS_TYPE]->(location),
+  (loc2:Node:BaseNodeEntity {nodeId: 'loc2'})-[:HAS_TYPE]->(location),
+  (loc1_1:Node:BaseNodeEntity {nodeId: 'loc1_1'})-[:HAS_TYPE]->(location),
+  (loc1_2:Node:BaseNodeEntity {nodeId: 'loc1_2'})-[:HAS_TYPE]->(location),
+  (loc1_3:Node:BaseNodeEntity {nodeId: 'loc1_3'})-[:HAS_TYPE]->(location),
+  (c1)<-[:CHILD_OF]-(loc1),
+  (c1)<-[:CHILD_OF]-(loc2),
+  (loc1)<-[:CHILD_OF]-(loc1_1),
+  (loc1)<-[:CHILD_OF]-(loc1_2),
+  (loc1)<-[:CHILD_OF]-(loc1_3),
+  (loc1_1)-[:LABELED]->(l1),
+  (loc1_2)-[:LABELED]->(l1);

--- a/test/src/test/resources/org/neo4j/ogm/cql/gh613.cql
+++ b/test/src/test/resources/org/neo4j/ogm/cql/gh613.cql
@@ -3,13 +3,14 @@ CREATE
 CREATE
   (l1:Label {key: 'l1'})
 CREATE
-  (loc1:Node:BaseNodeEntity {nodeId: 'loc1'})-[:HAS_TYPE]->(location),
-  (loc2:Node:BaseNodeEntity {nodeId: 'loc2'})-[:HAS_TYPE]->(location),
-  (loc1_1:Node:BaseNodeEntity {nodeId: 'loc1_1'})-[:HAS_TYPE]->(location),
-  (loc1_2:Node:BaseNodeEntity {nodeId: 'loc1_2'})-[:HAS_TYPE]->(location),
-  (loc1_3:Node:BaseNodeEntity {nodeId: 'loc1_3'})-[:HAS_TYPE]->(location),
-  (c1)<-[:CHILD_OF]-(loc1),
-  (c1)<-[:CHILD_OF]-(loc2),
+  (root:Node {nodeId: 'root'})-[:HAS_TYPE]->(location),
+  (loc1:Node {nodeId: 'loc1'})-[:HAS_TYPE]->(location),
+  (loc2:Node {nodeId: 'loc2'})-[:HAS_TYPE]->(location),
+  (loc1_1:Node {nodeId: 'loc1_1'})-[:HAS_TYPE]->(location),
+  (loc1_2:Node {nodeId: 'loc1_2'})-[:HAS_TYPE]->(location),
+  (loc1_3:Node {nodeId: 'loc1_3'})-[:HAS_TYPE]->(location),
+  (root)<-[:CHILD_OF]-(loc1),
+  (root)<-[:CHILD_OF]-(loc2),
   (loc1)<-[:CHILD_OF]-(loc1_1),
   (loc1)<-[:CHILD_OF]-(loc1_2),
   (loc1)<-[:CHILD_OF]-(loc1_3),


### PR DESCRIPTION

## Description

When invoking `session.save` the `EntityGraphMapper` clears potentially entities registered in the `mappingContext` in Line:

https://github.com/neo4j/neo4j-ogm/blob/9a9d458afce0bf44fbbc5d3783100329fac52336/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java#L199-L200

But the `mappingContext` still contains relationships related to the cleared entities. This fix removes the stale relationships in the `mappingContext`.

## Related Issue

#613 

## How Has This Been Tested?

see attached test case

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
