### PR TITLE
GH-613 - Fix incomplete removal of stale relationships and nodes from context (master)

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -18,7 +18,10 @@
  */
 package org.neo4j.ogm.context;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -37,9 +40,10 @@ import org.neo4j.ogm.cypher.compiler.RelationshipBuilder;
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.metadata.AnnotationInfo;
 import org.neo4j.ogm.metadata.ClassInfo;
+import org.neo4j.ogm.metadata.DescriptorMappings;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.metadata.MetaData;
-import org.neo4j.ogm.metadata.DescriptorMappings;
+import org.neo4j.ogm.metadata.reflect.EntityAccessManager;
 import org.neo4j.ogm.utils.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +55,7 @@ import org.slf4j.LoggerFactory;
  * @author Luanne Misquitta
  * @author Mark Angrish
  * @author Michael J. Simons
+ * @author Andreas Berger
  */
 public class EntityGraphMapper implements EntityMapper {
 
@@ -59,6 +64,7 @@ public class EntityGraphMapper implements EntityMapper {
     private final MetaData metaData;
     private final MappingContext mappingContext;
     private final Compiler compiler = new MultiStatementCypherCompiler();
+    private boolean updateOtherSideOfRelationships;
     /**
      * Default supplier for write protection: Always write all the stuff.
      */
@@ -71,9 +77,10 @@ public class EntityGraphMapper implements EntityMapper {
      * @param metaData       The {@link MetaData} containing the mapping information
      * @param mappingContext The {@link MappingContext} for the current session
      */
-    public EntityGraphMapper(MetaData metaData, MappingContext mappingContext) {
+    public EntityGraphMapper(MetaData metaData, MappingContext mappingContext, boolean updateOtherSideOfRelationships) {
         this.metaData = metaData;
         this.mappingContext = mappingContext;
+        this.updateOtherSideOfRelationships = updateOtherSideOfRelationships;
     }
 
     public void addWriteProtection(
@@ -194,13 +201,17 @@ public class EntityGraphMapper implements EntityMapper {
                     }
                 }
 
-                // remove all nodes that are referenced by this relationship in the mapping context
-                // this will ensure that stale versions of these objects don't exist
-                clearRelatedObjects(mappedRelationship.getStartNodeId());
-                clearRelatedObjects(mappedRelationship.getEndNodeId());
+                if (updateOtherSideOfRelationships) {
+                    // update all entities related by this change
+                    removeOtherSideOfRelationship(mappedRelationship);
+                } else {
+                    // remove all nodes that are referenced by this relationship in the mapping context
+                    // this will ensure that stale versions of these objects don't exist
+                    clearRelatedObjects(mappedRelationship.getStartNodeId());
+                    clearRelatedObjects(mappedRelationship.getEndNodeId());
+                }
 
                 // finally remove the relationship from the mapping context
-                //mappingContext.removeRelationship(mappedRelationship);
                 mappedRelationshipIterator.remove();
             }
         }
@@ -824,13 +835,11 @@ public class EntityGraphMapper implements EntityMapper {
         RelationshipBuilder relationshipBuilder, RelationshipNodes relNodes) {
 
         if (relNodes.targetId == null || relNodes.sourceId == null) {
-            maybeCreateRelationship(context, srcNodeBuilder.reference(), relationshipBuilder,
-                tgtNodeBuilder.reference(), relNodes.sourceType, relNodes.targetType);
+            maybeCreateRelationship(context, srcNodeBuilder, tgtNodeBuilder, relationshipBuilder, relNodes);
         } else {
             MappedRelationship mappedRelationship = createMappedRelationship(relationshipBuilder, relNodes);
             if (!mappingContext.containsRelationship(mappedRelationship)) {
-                maybeCreateRelationship(context, srcNodeBuilder.reference(), relationshipBuilder,
-                    tgtNodeBuilder.reference(), relNodes.sourceType, relNodes.targetType);
+                maybeCreateRelationship(context, srcNodeBuilder, tgtNodeBuilder, relationshipBuilder, relNodes);
             } else {
                 LOGGER.debug("context-add: ({})-[{}:{}]->({})", mappedRelationship.getStartNodeId(),
                     relationshipBuilder.reference(), mappedRelationship.getRelationshipType(),
@@ -853,12 +862,18 @@ public class EntityGraphMapper implements EntityMapper {
      * once from one of the participating nodes (rather than from both ends).
      *
      * @param context             the current compiler {@link CompileContext}
-     * @param src                 the compiler's reference to the domain object representing the start node
+     * @param srcNodeBuilder      a {@link NodeBuilder} that knows how to create cypher phrases about nodes
+     * @param tgtNodeBuilder      a {@link NodeBuilder} that knows how to create cypher phrases about nodes
      * @param relationshipBuilder a {@link RelationshipBuilder} that knows how to create cypher phrases about relationships
-     * @param tgt                 the compiler's reference to the domain object representing the end node
+     * @param relNodes            {@link EntityGraphMapper.RelationshipNodes} representing the nodes at the ends of this relationship
      */
-    private void maybeCreateRelationship(CompileContext context, Long src, RelationshipBuilder relationshipBuilder,
-        Long tgt, Class srcClass, Class tgtClass) {
+    private void maybeCreateRelationship(CompileContext context, NodeBuilder srcNodeBuilder, NodeBuilder tgtNodeBuilder,
+        RelationshipBuilder relationshipBuilder, RelationshipNodes relNodes) {
+
+        Long src = srcNodeBuilder.reference();
+        Long tgt = tgtNodeBuilder.reference();
+        Class<?> srcClass = relNodes.sourceType;
+        Class<?> tgtClass = relNodes.targetType;
 
         //if (hasTransientRelationship(context, src, relationshipBuilder.type(), tgt)) {
         if (hasTransientRelationship(context, src, relationshipBuilder, tgt)) {
@@ -885,6 +900,10 @@ public class EntityGraphMapper implements EntityMapper {
         } else {
             reallyCreateRelationship(context, src, relationshipBuilder, tgt, srcClass, tgtClass);
         }
+
+        if (updateOtherSideOfRelationships) {
+            updateSidesOfRelationship(relationshipBuilder, relNodes);
+        }
     }
 
     /**
@@ -900,11 +919,9 @@ public class EntityGraphMapper implements EntityMapper {
      */
     private boolean hasTransientRelationship(CompileContext ctx, Long src, RelationshipBuilder relationshipBuilder,
         Long tgt) {
-        for (Object object : ctx.getTransientRelationships(new SrcTargetKey(src, tgt))) {
-            if (object instanceof TransientRelationship) {
-                if (((TransientRelationship) object).equals(src, relationshipBuilder, tgt)) {
-                    return true;
-                }
+        for (TransientRelationship relationship : ctx.getTransientRelationships(new SrcTargetKey(src, tgt))) {
+            if (relationship.equals(src, relationshipBuilder, tgt)) {
+                return true;
             }
         }
         return false;
@@ -925,11 +942,11 @@ public class EntityGraphMapper implements EntityMapper {
         relBuilder.relate(src, tgt);
         LOGGER.debug("context-new: ({})-[{}:{}]->({})", src, relBuilder.reference(), relBuilder.type(), tgt);
 
-        if (relBuilder.isNew()) {  //We only want to create or log new relationships
-            ctx.registerTransientRelationship(new SrcTargetKey(src, tgt),
-                new TransientRelationship(src, relBuilder.reference(), relBuilder.type(), tgt, srcClass,
-                    tgtClass)); // we log the new relationship as part of the transaction context.
-        }
+        // we log the new relationship as part of the transaction context.
+        ctx.registerTransientRelationship(
+            new SrcTargetKey(src, tgt),
+            new TransientRelationship(src, relBuilder.reference(), relBuilder.type(), tgt, srcClass, tgtClass)
+        );
     }
 
     /**
@@ -1017,6 +1034,165 @@ public class EntityGraphMapper implements EntityMapper {
         }
 
         return target.equals(srcObject);
+    }
+
+    private Object getEntity(long id) {
+        if (id < 0) {
+            return compileContext().getNewObject(id);
+        }
+        return Optional.ofNullable(mappingContext.getNodeEntity(id))
+            .orElseGet(() -> mappingContext.getRelationshipEntity(id));
+    }
+
+    private FieldInfo getFieldInfoForRelationship(Object entity, String relationshipType, Class<?> nodeType,
+        String direction) {
+        if (entity == null) {
+            return null;
+        }
+        ClassInfo classInfo = metaData.classInfo(entity);
+        if (classInfo == null) {
+            throw new IllegalStateException("cannot find classInfo for entity " + entity);
+        }
+        FieldInfo relatedField = EntityAccessManager
+            .getRelationalWriter(classInfo, relationshipType, direction, nodeType);
+        if (relatedField == null) {
+            return null;
+        }
+        return relatedField;
+    }
+
+    private void updateSidesOfRelationship(RelationshipBuilder relationshipBuilder, RelationshipNodes relNodes) {
+        Class<?> startCls;
+        Class<?> endCls;
+        Object startEntity;
+        Object endEntity;
+        String relationshipType = relationshipBuilder.type();
+
+        if (relationshipBuilder.hasDirection(Relationship.INCOMING)) {
+            startCls = relNodes.targetType;
+            endCls = relNodes.sourceType;
+            startEntity = relNodes.target == null ? getEntity(relNodes.targetId) : relNodes.target;
+            endEntity = relNodes.source == null ? getEntity(relNodes.sourceId) : relNodes.source;
+        } else {
+            startCls = relNodes.sourceType;
+            endCls = relNodes.targetType;
+            startEntity = relNodes.source == null ? getEntity(relNodes.sourceId) : relNodes.source;
+            endEntity = relNodes.target == null ? getEntity(relNodes.targetId) : relNodes.target;
+        }
+        if (startEntity == null || endEntity == null) {
+            return;
+        }
+        if (relationshipBuilder.isRelationshipEntity()) {
+            Object relationshipEntity = getEntity(relationshipBuilder.reference());
+            Class<?> relationshipCls;
+            if (relationshipEntity != null) {
+                relationshipCls = relationshipEntity.getClass();
+                updateSideOfRelationship(startEntity, relationshipEntity, relationshipType, relationshipCls,
+                    Relationship.OUTGOING);
+                updateSideOfRelationship(endEntity, relationshipEntity, relationshipType, relationshipCls,
+                    Relationship.INCOMING);
+            } else {
+                ClassInfo relationshipClassInfo = metaData.classInfo(relationshipType);
+                relationshipCls = relationshipClassInfo.getUnderlyingClass();
+            }
+            if (startCls.isAssignableFrom(relationshipCls)) {
+                startCls = endEntity.getClass();
+            } else if (endCls.isAssignableFrom(relationshipCls)) {
+                endCls = endEntity.getClass();
+            }
+        }
+
+        updateSideOfRelationship(startEntity, endEntity, relationshipType, endCls, Relationship.OUTGOING);
+        updateSideOfRelationship(endEntity, startEntity, relationshipType, startCls, Relationship.INCOMING);
+    }
+
+    private void updateSideOfRelationship(Object entity, Object otherSideEntity, String relationshipType,
+        Class<?> nodeType,
+        String direction) {
+        FieldInfo relatedField = getFieldInfoForRelationship(entity, relationshipType, nodeType, direction);
+        if (relatedField == null) {
+            return;
+        }
+        Object val = relatedField.read(entity);
+        if (Iterable.class.isAssignableFrom(relatedField.type())) {
+            val = EntityAccessManager.merge(
+                relatedField.type(),
+                new ArrayList<>(Collections.singleton(otherSideEntity)),
+                (Collection<?>) val,
+                DescriptorMappings.getType(relatedField.typeParameterDescriptor()));
+        } else if (relatedField.type().isArray()) {
+            val = EntityAccessManager.merge(
+                relatedField.type(),
+                Collections.singleton(otherSideEntity),
+                (Object[]) val,
+                DescriptorMappings.getType(relatedField.typeParameterDescriptor()));
+        } else {
+            if (val == otherSideEntity) {
+                return;
+            }
+            val = otherSideEntity;
+        }
+        relatedField.write(entity, val);
+    }
+
+    private void removeOtherSideOfRelationship(MappedRelationship mappedRelationship) {
+
+        Class<?> startCls = mappedRelationship.getStartNodeType();
+        Class<?> endCls = mappedRelationship.getEndNodeType();
+        String relationshipType = mappedRelationship.getRelationshipType();
+
+        Object startEntity = mappingContext.getNodeEntity(mappedRelationship.getStartNodeId());
+        Object endEntity = mappingContext.getNodeEntity(mappedRelationship.getEndNodeId());
+        Object relationshipEntity = mappingContext.getRelationshipEntity(mappedRelationship.getRelationshipId());
+
+        if (startEntity != null && endEntity != null) {
+            removeOtherSideFromEntity(startEntity, endEntity, relationshipType, endCls, Relationship.OUTGOING);
+            removeOtherSideFromEntity(endEntity, startEntity, relationshipType, startCls, Relationship.INCOMING);
+        }
+
+        if (relationshipEntity != null) {
+            if (startCls.isAssignableFrom(relationshipEntity.getClass())) {
+                removeOtherSideFromEntity(startEntity, relationshipEntity, relationshipType, startCls,
+                    Relationship.OUTGOING);
+            } else if (endCls.isAssignableFrom(relationshipEntity.getClass())) {
+                removeOtherSideFromEntity(endEntity, relationshipEntity, relationshipType, endCls,
+                    Relationship.INCOMING);
+            }
+        }
+    }
+
+    private void removeOtherSideFromEntity(Object entity, Object otherSideEntity, String relationshipType,
+        Class<?> nodeType,
+        String direction) {
+        FieldInfo relatedField = getFieldInfoForRelationship(entity, relationshipType, nodeType, direction);
+        if (relatedField == null) {
+            return;
+        }
+        Object currentValue = relatedField.read(entity);
+        if (currentValue == null) {
+            return;
+        }
+        if (currentValue instanceof Collection) {
+            ((Collection<?>) currentValue).remove(otherSideEntity);
+        } else if (currentValue.getClass().isArray()) {
+            int i = 0;
+            Object[] array = (Object[]) currentValue;
+            for (int j = 0; j < array.length; ++j) {
+                if (array[j] != otherSideEntity) {
+                    array[i++] = array[j];
+                }
+            }
+            array = Arrays.copyOf(array, i);
+            relatedField.write(entity, array);
+        } else {
+            Long currentSetId = mappingContext.nativeId(currentValue);
+            Long otherSideId = mappingContext.nativeId(otherSideEntity);
+            if (!currentSetId.equals(otherSideId)) {
+                // ok the field was already changed by the user
+                return;
+            }
+            relatedField.write(entity, null);
+        }
     }
 
     static class RelationshipNodes {

--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -285,9 +285,9 @@ public class GraphEntityMapper {
                     Class<?> paramType = writer.type();
                     Class elementType = underlyingElementType(classInfo, property.getKey().toString());
                     if (paramType.isArray()) {
-                        value = EntityAccessManager.merge(paramType, value, new Object[] {}, elementType);
+                        value = EntityAccessManager.merge(paramType, value, (Object[]) null, elementType);
                     } else {
-                        value = EntityAccessManager.merge(paramType, value, Collections.emptyList(), elementType);
+                        value = EntityAccessManager.merge(paramType, value, (Collection<?>) null, elementType);
                     }
                 }
             }

--- a/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
@@ -19,7 +19,7 @@
 package org.neo4j.ogm.context;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -142,8 +142,8 @@ public class SingleUseEntityMapper {
             if (writer.type().isArray() || Iterable.class.isAssignableFrom(writer.type())) {
                 Class elementType = underlyingElementType(classInfo, property.getKey());
                 value = writer.type().isArray()
-                    ? EntityAccessManager.merge(writer.type(), value, new Object[] {}, elementType)
-                    : EntityAccessManager.merge(writer.type(), value, Collections.EMPTY_LIST, elementType);
+                    ? EntityAccessManager.merge(writer.type(), value, (Object[]) null, elementType)
+                    : EntityAccessManager.merge(writer.type(), value, (Collection<?>) null, elementType);
             }
             writer.write(instance, value);
         } else {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CompileContext.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 import org.neo4j.ogm.compiler.SrcTargetKey;
 import org.neo4j.ogm.context.Mappable;
+import org.neo4j.ogm.context.TransientRelationship;
 
 /**
  * Maintains contextual information throughout the process of compiling Cypher statements to persist a graph of objects.
@@ -41,7 +42,7 @@ public interface CompileContext {
 
     void register(Object entity);
 
-    void registerTransientRelationship(SrcTargetKey key, Object object);
+    void registerTransientRelationship(SrcTargetKey key, TransientRelationship object);
 
     void registerNewObject(Long reference, Object relationshipEntity);
 
@@ -76,5 +77,5 @@ public interface CompileContext {
 
     Object getVisitedObject(Long reference);
 
-    Collection<Object> getTransientRelationships(SrcTargetKey key);
+    Collection<TransientRelationship> getTransientRelationships(SrcTargetKey key);
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 
 import org.neo4j.ogm.compiler.SrcTargetKey;
 import org.neo4j.ogm.context.Mappable;
+import org.neo4j.ogm.context.TransientRelationship;
 
 /**
  * Maintains contextual information throughout the process of compiling Cypher statements to persist a graph of objects.
@@ -48,7 +49,7 @@ public class CypherContext implements CompileContext {
     private final Set<Mappable> deletedRelationships = new HashSet<>();
 
     private final Set<Object> registry = new HashSet<>();
-    private final Map<SrcTargetKey, Set<Object>> transientRelsIndex = new HashMap<>();
+    private final Map<SrcTargetKey, Set<TransientRelationship>> transientRelsIndex = new HashMap<>();
 
     private final Compiler compiler;
 
@@ -98,11 +99,11 @@ public class CypherContext implements CompileContext {
     }
 
     @Override
-    public void registerTransientRelationship(SrcTargetKey key, Object object) {
-        if (!registry.contains(object)) {
-            registry.add(object);
-            Set<Object> collection = transientRelsIndex.computeIfAbsent(key, k -> new HashSet<>());
-            collection.add(object);
+    public void registerTransientRelationship(SrcTargetKey key, TransientRelationship object) {
+        if (registry.add(object)) {
+            transientRelsIndex
+                .computeIfAbsent(key, k -> new HashSet<>())
+                .add(object);
         }
     }
 
@@ -247,8 +248,8 @@ public class CypherContext implements CompileContext {
     }
 
     @Override
-    public Collection<Object> getTransientRelationships(SrcTargetKey srcTargetKey) {
-        Collection<Object> objects = transientRelsIndex.get(srcTargetKey);
+    public Collection<TransientRelationship> getTransientRelationships(SrcTargetKey srcTargetKey) {
+        Collection<TransientRelationship> objects = transientRelsIndex.get(srcTargetKey);
         if (objects != null) {
             return objects;
         } else {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
@@ -51,8 +51,6 @@ public interface RelationshipBuilder extends PropertyContainerBuilder<Relationsh
 
     void setRelationshipEntity(boolean relationshipEntity);
 
-    boolean isNew();
-
     Edge edge();
 
     void setPrimaryIdName(String primaryIdName);

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
@@ -87,11 +87,6 @@ public class DefaultRelationshipBuilder extends AbstractPropertyContainerBuilder
     }
 
     @Override
-    public boolean isNew() {
-        return true;
-    }
-
-    @Override
     public void setSingleton(boolean b) {
         this.singleton = b;
     }

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
@@ -82,11 +82,14 @@ public class EntityAccessManager {
 
             //2. A char[] may come in as a String or an array of String[]
             newValues = stringToCharacterIterable(newValues, parameterType, elementType);
+        } else {
+            return currentValues;
         }
+        Collection<?> newValuesCollection = (Collection<?>) newValues;
 
         if (parameterType.isArray()) {
-            Class type = parameterType.getComponentType();
-            List<Object> objects = new ArrayList<>(union((Collection) newValues, currentValues, elementType));
+            Class<?> type = parameterType.getComponentType();
+            List<Object> objects = new ArrayList<>(union(newValuesCollection, currentValues, elementType));
 
             Object array = Array.newInstance(type, objects.size());
             for (int i = 0; i < objects.size(); i++) {
@@ -94,9 +97,12 @@ public class EntityAccessManager {
             }
             return array;
         }
+        if (currentValues != null && currentValues.containsAll(newValuesCollection)) {
+            return currentValues;
+        }
 
         // create the desired type of collection and use it for the merge
-        Collection newCollection = createCollection(parameterType, (Collection) newValues, currentValues, elementType);
+        Collection<?> newCollection = createCollection(parameterType, newValuesCollection, currentValues, elementType);
         if (newCollection != null) {
             return newCollection;
         }

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -95,6 +95,7 @@ public class Neo4jSession implements Session {
 
     private Driver driver;
     private String bookmark;
+    private boolean updateOtherSideOfRelationships;
 
     private List<EventListener> registeredEventListeners = new LinkedList<>();
 
@@ -691,6 +692,20 @@ public class Neo4jSession implements Session {
     @Override
     public void setLoadStrategy(LoadStrategy loadStrategy) {
         this.loadStrategy = loadStrategy;
+    }
+
+    /**
+     * @return true, if changing one side of the relationship should also update the opposite side
+     */
+    public boolean isUpdateOtherSideOfRelationships() {
+        return updateOtherSideOfRelationships;
+    }
+
+    /**
+     * @param updateOtherSideOfRelationships true if changing one side of the relationship should also update the opposite side
+     */
+    public void setUpdateOtherSideOfRelationships(boolean updateOtherSideOfRelationships) {
+        this.updateOtherSideOfRelationships = updateOtherSideOfRelationships;
     }
 
     private LoadClauseBuilder loadNodeClauseBuilder(int depth) {

--- a/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
+++ b/core/src/main/java/org/neo4j/ogm/session/SessionFactory.java
@@ -52,6 +52,7 @@ public class SessionFactory {
 
     private LoadStrategy loadStrategy = LoadStrategy.SCHEMA_LOAD_STRATEGY;
     private EntityInstantiator entityInstantiator;
+    private boolean updateOtherSideOfRelationships;
 
     /**
      * Constructs a new {@link SessionFactory} by initialising the object-graph mapping meta-data from the given list of domain
@@ -137,7 +138,9 @@ public class SessionFactory {
      * @return A new {@link Session}
      */
     public Session openSession() {
-        return new Neo4jSession(metaData, driver, eventListeners, loadStrategy, entityInstantiator);
+        Neo4jSession session = new Neo4jSession(metaData, driver, eventListeners, loadStrategy, entityInstantiator);
+        session.setUpdateOtherSideOfRelationships(updateOtherSideOfRelationships);
+        return session;
     }
 
     /**
@@ -183,6 +186,20 @@ public class SessionFactory {
 
     public void setEntityInstantiator(EntityInstantiator entityInstantiator) {
         this.entityInstantiator = entityInstantiator;
+    }
+
+    /**
+     * @return true, if changing one side of the relationship should also update the opposite side
+     */
+    public boolean isUpdateOtherSideOfRelationships() {
+        return updateOtherSideOfRelationships;
+    }
+
+    /**
+     * @param updateOtherSideOfRelationships true if changing one side of the relationship should also update the opposite side
+     */
+    public void setUpdateOtherSideOfRelationships(boolean updateOtherSideOfRelationships) {
+        this.updateOtherSideOfRelationships = updateOtherSideOfRelationships;
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SaveDelegate.java
@@ -55,7 +55,10 @@ public class SaveDelegate extends SessionDelegate {
 
         SaveEventDelegate eventsDelegate = new SaveEventDelegate(session);
 
-        EntityGraphMapper entityGraphMapper = new EntityGraphMapper(session.metaData(), session.context());
+        EntityGraphMapper entityGraphMapper = new EntityGraphMapper(
+            session.metaData(),
+            session.context(),
+            session.isUpdateOtherSideOfRelationships());
         if (this.writeProtectionStrategy != null) {
             entityGraphMapper.addWriteProtection(this.writeProtectionStrategy.get());
         }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/DirectRelationshipsTest.java
@@ -60,7 +60,7 @@ public class DirectRelationshipsTest {
 
     @Before
     public void setUpMapper() {
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
     }
 
     @After
@@ -519,7 +519,7 @@ public class DirectRelationshipsTest {
         assertThat(statements.get(0).getStatement()).isEqualTo(
             "UNWIND {rows} as row MATCH (startNode) WHERE ID(startNode) = row.startNodeId WITH row,startNode MATCH (endNode) WHERE ID(endNode) = row.endNodeId MATCH (startNode)-[rel:`CONTAINS`]->(endNode) DELETE rel");
 
-        mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         //There are no more changes to the graph
         compiler = mapper.map(doc1).getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
@@ -91,7 +91,7 @@ public class CompilerTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionOnAttemptToMapNullObjectToCypherQuery() {
-        new EntityGraphMapper(mappingMetadata, mappingContext).map(null);
+        new EntityGraphMapper(mappingMetadata, mappingContext, false).map(null);
     }
 
     @Test
@@ -900,7 +900,7 @@ public class CompilerTest {
     }
 
     private Compiler mapAndCompile(Object object) {
-        EntityMapper mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        EntityMapper mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         CompileContext context = mapper.map(object);
         Compiler compiler = context.getCompiler();
         compiler.useStatementFactory(new RowStatementFactory());

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
@@ -1,0 +1,132 @@
+package org.neo4j.ogm.cypher.compiler;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.domain.gh613.Node;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.MultiDriverTestClass;
+import org.neo4j.ogm.testutil.TestUtils;
+
+/**
+ * @author Andreas Berger
+ */
+public class SavingTest extends MultiDriverTestClass {
+    private static SessionFactory sessionFactory;
+    private Session session;
+
+    @BeforeClass
+    public static void initSesssionFactory() {
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.gh613");
+        sessionFactory.setUpdateOtherSideOfRelationships(true);
+    }
+
+    @Before
+    public void init() {
+        session = sessionFactory.openSession();
+        session.purgeDatabase();
+        session.clear();
+
+        session.query(TestUtils.readCQLFile("org/neo4j/ogm/cql/gh613.cql").toString(), Collections.emptyMap());
+    }
+
+    /**
+     * GH-613
+     */
+    @Test
+    public void testSaveParentAfterChild() {
+
+        Node loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getNodeType()).isNotNull();
+        loc1_1.setLabels(null);
+        session.save(loc1_1);
+
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getChildNodes()).hasSize(3);
+        assertThat(loc1.getNodeType()).isNotNull();
+        session.save(loc1);
+
+        loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getNodeType()).isNotNull();
+    }
+
+    @Test
+    public void testChangeParent() {
+
+        Node loc2 = queryNode("loc2");
+        Node loc1_1 = queryNode("loc1_1");
+        Node loc1_2 = queryNode("loc1_2");
+
+        loc1_1.setChildOf(loc2);
+        session.save(loc1_1);
+        loc1_2.setChildOf(loc2);
+        session.save(loc1_2);
+
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getChildNodes()).hasSize(1);
+
+        loc2 = queryNode("loc2");
+        assertThat(loc2.getChildNodes()).hasSize(2);
+    }
+
+    @Test
+    public void testClearRelationship() {
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+
+        Node loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getLabels()).hasSize(1);
+
+        loc1_1.setLabels(null);
+        session.save(loc1_1);
+
+        Node root = queryNode("root");
+        assertThat(root.getChildNodes()).hasSize(2);
+        session.save(root);
+
+        loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+    }
+
+
+    @Test
+    public void moveNode() {
+        Node m1 = queryNode("m1");
+        Node company2 = queryNode("company2");
+        Node loc2 = queryNode("loc2");
+
+        m1.setChildOf(loc2);
+        session.save(m1);
+        m1.setBelongsTo(company2);
+        session.save(m1);
+
+        Iterable<Node> belongsTo;
+        belongsTo = getNodesBelongingToOtherNode("company2");
+        assertThat(belongsTo).hasSize(1);
+
+        belongsTo = getNodesBelongingToOtherNode("company1");
+        assertThat(belongsTo).hasSize(0);
+    }
+
+    private Iterable<Node> getNodesBelongingToOtherNode(String otherNodeId) {
+        return session
+            .query(Node.class, "MATCH (c:Node)<-[:BELONGS_TO]-(m:Node) WHERE c.nodeId = {c} RETURN m",
+                Collections.singletonMap("c", otherNodeId));
+    }
+
+    private Node queryNode(String nodeId) {
+        Collection<Node> nodeTypes = session
+            .loadAll(Node.class, new Filters(new Filter("nodeId", ComparisonOperator.EQUALS, nodeId)));
+        assertThat(nodeTypes).hasSize(1);
+        return nodeTypes.iterator().next();
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
@@ -1,0 +1,22 @@
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+/**
+ * @author Andreas Berger
+ */
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
@@ -1,0 +1,49 @@
+package org.neo4j.ogm.domain.gh613;
+
+import java.util.Objects;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Label extends BaseEntity {
+
+    @Index
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public Label setKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Label label = (Label) o;
+        return Objects.equals(key, label.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public String toString() {
+        return "Label{" +
+            "key='" + key + '\'' +
+            '}';
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
@@ -1,0 +1,119 @@
+package org.neo4j.ogm.domain.gh613;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Node extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeId;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.OUTGOING)
+    private Node childOf;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.INCOMING)
+    protected Set<Node> childNodes;
+
+    @Relationship(type = "HAS_TYPE", direction = Relationship.OUTGOING)
+    private NodeType nodeType;
+
+    @Relationship(type = "LABELED", direction = Relationship.OUTGOING)
+    private Set<Label> labels;
+
+    @Relationship(type = "BELONGS_TO")
+    protected Node belongsTo;
+
+    public Node() {
+    }
+
+    public Node(String nodeId) {
+        setNodeId(nodeId);
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public Node setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+        return this;
+    }
+
+    public Node getChildOf() {
+        return childOf;
+    }
+
+    public Node setChildOf(Node childOf) {
+        this.childOf = childOf;
+        return this;
+    }
+
+    public Set<Node> getChildNodes() {
+        return childNodes;
+    }
+
+    public Node setChildNodes(Set<Node> childNodes) {
+        this.childNodes = childNodes;
+        return this;
+    }
+
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    public Node setNodeType(NodeType nodeType) {
+        this.nodeType = nodeType;
+        return this;
+    }
+
+    public Node getBelongsTo() {
+        return belongsTo;
+    }
+
+    public Node setBelongsTo(Node belongsTo) {
+        this.belongsTo = belongsTo;
+        return this;
+    }
+
+    public Set<Label> getLabels() {
+        return labels;
+    }
+
+    public Node setLabels(Set<Label> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Node)) {
+            return false;
+        }
+        Node that = (Node) o;
+        return Objects.equals(nodeId, that.nodeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeId);
+    }
+
+    @Override
+    public String toString() {
+        return "Node{" +
+            "nodeId='" + nodeId + '\'' +
+            '}';
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
@@ -1,0 +1,36 @@
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class NodeType extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeTypeId;
+
+    public NodeType() {
+    }
+
+    public NodeType(String nodeTypeId) {
+        this.nodeTypeId = nodeTypeId;
+    }
+
+    public String getNodeTypeId() {
+        return nodeTypeId;
+    }
+
+    public NodeType setNodeTypeId(String nodeTypeId) {
+        this.nodeTypeId = nodeTypeId;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeType: " + nodeTypeId;
+    }
+
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/social/SocialUser.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/social/SocialUser.java
@@ -81,36 +81,4 @@ public class SocialUser {
     public void setName(String name) {
         this.name = name;
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        SocialUser that = (SocialUser) o;
-
-        if (name != null ? !name.equals(that.name) : that.name != null) {
-            return false;
-        }
-        if (friends != null ? !friends.equals(that.friends) : that.friends != null) {
-            return false;
-        }
-        if (following != null ? !following.equals(that.following) : that.following != null) {
-            return false;
-        }
-        return !(followers != null ? !followers.equals(that.followers) : that.followers != null);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = 31 + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (friends != null ? friends.hashCode() : 0);
-        result = 31 * result + (following != null ? following.hashCode() : 0);
-        result = 31 * result + (followers != null ? followers.hashCode() : 0);
-        return result;
-    }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
@@ -53,7 +53,7 @@ public class MergeWithPrimaryIndexTests {
     @Before
     public void setUpMapper() {
         mappingContext = new MappingContext(mappingMetadata);
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
     }
 
     @After

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsRelationshipEntityTest.java
@@ -411,7 +411,7 @@ public class CineastsRelationshipEntityTest extends MultiDriverTestClass {
         movies = session.loadAll(Movie.class,
             new Filter("title", ComparisonOperator.EQUALS, "Harry Potter and the Order of the Phoenix"));
         phoenix = movies.iterator().next();
-        assertThat(phoenix.getRatings()).isNull();
+        assertThat(phoenix.getRatings()).isNullOrEmpty();
 
         movies = session.loadAll(Movie.class,
             new Filter("title", ComparisonOperator.EQUALS, "Harry Potter and the Goblet of Fire"));

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -89,7 +89,7 @@ public class EntityGraphMapperTest extends MultiDriverTestClass {
             "org.neo4j.ogm.domain.election", "org.neo4j.ogm.domain.forum",
             "org.neo4j.ogm.domain.education", "org.neo4j.ogm.domain.types");
         mappingContext.clear();
-        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext);
+        this.mapper = new EntityGraphMapper(mappingMetadata, mappingContext, false);
         session = sessionFactory.openSession();
         session.purgeDatabase();
     }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
@@ -144,28 +144,28 @@ public class SaveCapabilityTest extends MultiDriverTestClass {
         lost.setArtist(bonJovi);
         lost.setGuestArtist(leann);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(lost, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(lost, depth);
         assertThat(context.registry()).as("Should save 3 nodes and 2 relations (5 items)").hasSize(5);
 
         session.save(lost);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(lost, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(lost, depth);
         assertThat(context.registry()).as("Should have nothing to save").isEmpty();
 
         session.clear();
 
         Artist loadedLeann = session.load(Artist.class, leann.getId(), depth);
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have nothing to save").isEmpty();
 
         loadedLeann.setName("New name");
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have one node to save").hasSize(1);
 
         loadedLeann.getGuestAlbums().iterator().next().setName("New Album Name");
 
-        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context()).map(loadedLeann, depth);
+        context = new EntityGraphMapper(neo4jSession.metaData(), neo4jSession.context(), false).map(loadedLeann, depth);
         assertThat(context.registry()).as("Should have two node to save").hasSize(2);
     }
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/resources/org/neo4j/ogm/cql/gh613.cql
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/resources/org/neo4j/ogm/cql/gh613.cql
@@ -1,0 +1,25 @@
+CREATE
+  (location:NodeType {nodeTypeId: 'location'})
+CREATE
+  (l1:Label {key: 'l1'})
+CREATE
+  (root:Node {nodeId: 'root'})-[:HAS_TYPE]->(location),
+  (company1:Node {nodeId: 'company1'}),
+  (company2:Node {nodeId: 'company2'}),
+  (loc1:Node {nodeId: 'loc1'})-[:HAS_TYPE]->(location),
+  (loc2:Node {nodeId: 'loc2'})-[:HAS_TYPE]->(location),
+  (loc1_1:Node {nodeId: 'loc1_1'})-[:HAS_TYPE]->(location),
+  (m1:Node {nodeId: 'm1'}),
+  (loc1_2:Node {nodeId: 'loc1_2'})-[:HAS_TYPE]->(location),
+  (loc1_3:Node {nodeId: 'loc1_3'})-[:HAS_TYPE]->(location),
+  (root)<-[:CHILD_OF]-(company1),
+  (root)<-[:CHILD_OF]-(company2),
+  (company1)<-[:CHILD_OF]-(loc1),
+  (company2)<-[:CHILD_OF]-(loc2),
+  (loc1)<-[:CHILD_OF]-(loc1_1),
+  (loc1)<-[:CHILD_OF]-(loc1_2),
+  (loc1)<-[:CHILD_OF]-(loc1_3),
+  (loc1_1)<-[:CHILD_OF]-(m1),
+  (company1)<-[:BELONGS_TO]-(m1),
+  (loc1_1)-[:LABELED]->(l1),
+  (loc1_2)-[:LABELED]->(l1);


### PR DESCRIPTION
This closes #613. With #621 a new function was introduced to synchronize bidirectional mappings through OGM. Since it is not only a bugfix and therefore will not be merged into 3.1.x anymore, this PR is meant to provide the changes as a new feature in the master.

## Description
The solution in this PR ensures that bidirectional relations are also synchronized on both sides during the saving process. This way, the data in the session is always consistent with the database.
The changes can be activated via Session or SessionFactory

## Related Issue
#613
#615
#617
#621 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
