### PR TITLE
GH-632 - Use name() for enum keys in both writing and reading of dynamic properties.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
@@ -91,13 +91,14 @@ public class MapCompositeConverter implements CompositeAttributeConverter<Map<?,
     private void addMapToProperties(Map<?, ?> fieldValue, Map<String, Object> graphProperties, String entryPrefix) {
         for (Map.Entry<?, ?> entry : fieldValue.entrySet()) {
             Object entryValue = entry.getValue();
+            String entryKey = entryPrefix + keyInstanceToString(entry.getKey());
             if (entryValue instanceof Map) {
-                addMapToProperties((Map<?, ?>) entryValue, graphProperties, entryPrefix + entry.getKey() + delimiter);
+                addMapToProperties((Map<?, ?>) entryValue, graphProperties, entryKey + delimiter);
             } else {
                 if (isCypherType(entryValue) ||
                     (allowCast && canCastType(entryValue))) {
 
-                    graphProperties.put(entryPrefix + entry.getKey(), entryValue);
+                    graphProperties.put(entryKey, entryValue);
                 } else {
                     throw new MappingException("Could not map key=" + entryPrefix + entry.getKey() + ", " +
                         "value=" + entryValue + " (type = " + entryValue.getClass() + ") " +
@@ -171,6 +172,22 @@ public class MapCompositeConverter implements CompositeAttributeConverter<Map<?,
         }
     }
 
+    private String keyInstanceToString(Object propertyKey) {
+        if (propertyKey == null) {
+            throw new UnsupportedOperationException("Null is not a supported property key!");
+        }
+
+        if (propertyKey instanceof String) {
+            return (String) propertyKey;
+        } else if (propertyKey.getClass().isEnum()) {
+            return ((Enum) propertyKey).name();
+        }
+
+        throw new UnsupportedOperationException(
+            "Only String and Enum allowed to be keys, got " + propertyKey.getClass());
+
+    }
+
     private Object keyInstanceFromString(String propertyKey, Class<?> keyType) {
         if (keyType == null) {
             return propertyKey;
@@ -182,8 +199,8 @@ public class MapCompositeConverter implements CompositeAttributeConverter<Map<?,
             } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                 throw new RuntimeException("Should not happen", e);
             }
-        } else {
-            throw new UnsupportedOperationException("Only String and Enum allowed to be keys, got " + keyType);
         }
+
+        throw new UnsupportedOperationException("Only String and Enum allowed to be keys, got " + keyType);
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/properties/User.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/properties/User.java
@@ -29,9 +29,21 @@ import org.neo4j.ogm.annotation.Relationship;
 
 /**
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
 @NodeEntity
 public class User {
+
+    public enum EnumA {VALUE_AA}
+
+    public enum EnumB {
+        VALUE_BA;
+
+        @Override
+        public String toString() {
+            return super.name() + " deliberately screw the enum combo toString/name.";
+        }
+    }
 
     private Long id;
 
@@ -51,6 +63,12 @@ public class User {
 
     @Properties(allowCast = true)
     private Map<String, Object> allowCastProperties;
+
+    @Properties
+    private Map<EnumA, Object> enumAProperties;
+
+    @Properties
+    private Map<EnumB, Object> enumBProperties;
 
     @Relationship(type = "VISITED")
     private Set<Visit> visits;
@@ -168,4 +186,19 @@ public class User {
         visits.add(visit);
     }
 
+    public Map<EnumA, Object> getEnumAProperties() {
+        return enumAProperties;
+    }
+
+    public void setEnumAProperties(Map<EnumA, Object> enumAProperties) {
+        this.enumAProperties = enumAProperties;
+    }
+
+    public Map<EnumB, Object> getEnumBProperties() {
+        return enumBProperties;
+    }
+
+    public void setEnumBProperties(Map<EnumB, Object> enumBProperties) {
+        this.enumBProperties = enumBProperties;
+    }
 }


### PR DESCRIPTION
This closes #632.