### PR TITLE
Replace classpath scanner with the successor Class Graph.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,8 +49,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.lukehutch</groupId>
-            <artifactId>fast-classpath-scanner</artifactId>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -97,33 +97,12 @@ public class DomainInfo {
     }
 
     private static ScanResult findClasses(String[] packagesOrClasses) {
-        List<String> packages = new ArrayList<>(packagesOrClasses.length);
-        Set<String> classes = new HashSet<>(packagesOrClasses.length);
 
-        for (String packageOrClass : packagesOrClasses) {
-            if (isClass(packageOrClass)) {
-                classes.add(packageOrClass);
-            } else {
-                packages.add(packageOrClass);
-            }
-        }
-
-        ScanResult scanResult = new ClassGraph()
+        return new ClassGraph()
             .enableAllInfo()
-            .whitelistPackages(packages.toArray(new String[] {}))
-            .whitelistClasses(classes.toArray(new String[] {}))
+            .whitelistPackages(packagesOrClasses)
+            .whitelistClasses(packagesOrClasses)
             .scan();
-
-        return scanResult;
-    }
-
-    private static boolean isClass(String className) {
-        try {
-            Class.forName(className, false, Thread.currentThread().getContextClassLoader());
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -20,8 +20,8 @@ package org.neo4j.ogm.metadata;
 
 import static java.util.Comparator.*;
 
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.scanner.ScanResult;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 
 import java.util.*;
 import java.util.function.Function;
@@ -68,17 +68,19 @@ public class DomainInfo {
 
     public static DomainInfo create(TypeSystem typeSystem, String... packages) {
 
-        ScanResult scanResult = new FastClasspathScanner(packages)
-            .strictWhitelist()
-            .scan();
+        ScanResult scanResult = findClasses(packages);
+
+        List<String> allClasses = scanResult.getAllClasses().stream()
+            .map(io.github.classgraph.ClassInfo::getName)
+            .collect(Collectors.toList());
 
         DomainInfo domainInfo = new DomainInfo(typeSystem);
 
-        Predicate<Class<?>> classCouldBeLoaded = clazz -> clazz != null;
+        Predicate<Class<?>> classCouldBeLoaded = Objects::nonNull;
         Predicate<Class<?>> classIsMappable = clazz -> !(clazz.isAnnotation() || clazz.isAnonymousClass() || clazz
             .equals(Object.class));
 
-        Map<String, Class<?>> mappableClasses = scanResult.getNamesOfAllClasses()
+        Map<String, Class<?>> mappableClasses = allClasses
             .stream()
             .map(DomainInfo::loadClass)
             .filter(classCouldBeLoaded)
@@ -89,8 +91,39 @@ public class DomainInfo {
             .forEach(clazz -> prepareClass(domainInfo, mappableClasses, typeSystem, clazz));
 
         domainInfo.finish();
+        scanResult.close();
 
         return domainInfo;
+    }
+
+    private static ScanResult findClasses(String[] packagesOrClasses) {
+        List<String> packages = new ArrayList<>(packagesOrClasses.length);
+        Set<String> classes = new HashSet<>(packagesOrClasses.length);
+
+        for (String packageOrClass : packagesOrClasses) {
+            if (isClass(packageOrClass)) {
+                classes.add(packageOrClass);
+            } else {
+                packages.add(packageOrClass);
+            }
+        }
+
+        ScanResult scanResult = new ClassGraph()
+            .enableAllInfo()
+            .whitelistPackages(packages.toArray(new String[] {}))
+            .whitelistClasses(classes.toArray(new String[] {}))
+            .scan();
+
+        return scanResult;
+    }
+
+    private static boolean isClass(String className) {
+        try {
+            Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <dropwizard-metrics.version>4.0.2</dropwizard-metrics.version>
-        <fast.classpath.scanner>2.18.1</fast.classpath.scanner>
+        <classgraph.version>4.8.41</classgraph.version>
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.10</httpcore.version>
         <jackson.version>2.9.9</jackson.version>
@@ -364,10 +364,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.github.lukehutch</groupId>
-                <artifactId>fast-classpath-scanner</artifactId>
-                <version>${fast.classpath.scanner}</version>
-                <scope>compile</scope>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${classgraph.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
As planned in #513 and #637 it would make sense to "just" upgrade to Class Graph to have the latest features of classpath scanning in place.
This PR does not target any changes to the business logic of analysing the classes but only alters the dependency and makes some adjustment to the code base to use the new API.