### PR TITLE
GH-640 - Store visited nodes under their native graph id if possible.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -58,7 +58,7 @@ public class EntityGraphMapper implements EntityMapper {
 
     private final MetaData metaData;
     private final MappingContext mappingContext;
-    private final Compiler compiler = new MultiStatementCypherCompiler();
+    private final Compiler compiler;
     /**
      * Default supplier for write protection: Always write all the stuff.
      */
@@ -73,6 +73,7 @@ public class EntityGraphMapper implements EntityMapper {
     public EntityGraphMapper(MetaData metaData, MappingContext mappingContext) {
         this.metaData = metaData;
         this.mappingContext = mappingContext;
+        this.compiler = new MultiStatementCypherCompiler(mappingContext::nativeId);
     }
 
     public void addWriteProtection(BiFunction<WriteProtectionTarget, Class<?>, Predicate<Object>> writeProtectionSupplier) {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/MultiStatementCypherCompiler.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/MultiStatementCypherCompiler.java
@@ -50,6 +50,7 @@ import org.neo4j.ogm.response.model.RelationshipModel;
  *
  * @author Luanne Misquitta
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public class MultiStatementCypherCompiler implements Compiler {
 
@@ -62,8 +63,8 @@ public class MultiStatementCypherCompiler implements Compiler {
     private final List<RelationshipBuilder> deletedRelationshipEntityBuilders;
     private StatementFactory statementFactory;
 
-    public MultiStatementCypherCompiler() {
-        this.context = new CypherContext(this);
+    public MultiStatementCypherCompiler(Function<Object, Long> nativeIdProvider) {
+        this.context = new CypherContext(this, nativeIdProvider);
         this.newNodeBuilders = new ArrayList<>();
         this.newRelationshipBuilders = new ArrayList<>();
         this.existingNodeBuilders = new ArrayList<>();

--- a/test/src/test/java/org/neo4j/ogm/domain/gh640/MyNode.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh640/MyNode.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh640;
+
+import static org.neo4j.ogm.annotation.Relationship.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class MyNode {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @Relationship(type = "REL_ONE", direction = INCOMING)
+    private MyNode refOne;
+
+    @Relationship(type = "REL_TWO", direction = UNDIRECTED)
+    private List<MyNode> refTwo = new ArrayList<>();
+
+    public MyNode(String name) {
+        this.name = name;
+    }
+
+    public MyNode() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public MyNode getRefOne() {
+        return refOne;
+    }
+
+    public void setRefOne(MyNode refOne) {
+        this.refOne = refOne;
+    }
+
+    public List<MyNode> getRefTwo() {
+        return refTwo;
+    }
+
+    public void setRefTwo(List<MyNode> refTwo) {
+        this.refTwo = refTwo;
+    }
+
+    public MyNode copy() {
+        MyNode n = new MyNode();
+        n.id = id;
+        n.name = name;
+        n.setRefOne(refOne);
+        n.setRefTwo(refTwo);
+        return n;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MyNode myNode = (MyNode) o;
+        return Objects.equals(id, myNode.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override public String toString() {
+        return "MyNode{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/domain/gh640/MyNodeWithAssignedId.java
+++ b/test/src/test/java/org/neo4j/ogm/domain/gh640/MyNodeWithAssignedId.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh640;
+
+import static org.neo4j.ogm.annotation.Relationship.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class MyNodeWithAssignedId {
+
+    @Id
+    private String name;
+
+    @Relationship(type = "REL_ONE", direction = INCOMING)
+    private MyNodeWithAssignedId refOne;
+
+    @Relationship(type = "REL_TWO", direction = UNDIRECTED)
+    private List<MyNodeWithAssignedId> refTwo = new ArrayList<>();
+
+    public MyNodeWithAssignedId(String name) {
+        this.name = name;
+    }
+
+    public MyNodeWithAssignedId() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MyNodeWithAssignedId getRefOne() {
+        return refOne;
+    }
+
+    public void setRefOne(MyNodeWithAssignedId refOne) {
+        this.refOne = refOne;
+    }
+
+    public List<MyNodeWithAssignedId> getRefTwo() {
+        return refTwo;
+    }
+
+    public void setRefTwo(List<MyNodeWithAssignedId> refTwo) {
+        this.refTwo = refTwo;
+    }
+
+    public MyNodeWithAssignedId copy() {
+        MyNodeWithAssignedId n = new MyNodeWithAssignedId();
+        n.name = name;
+        n.setRefOne(refOne);
+        n.setRefTwo(refTwo);
+        return n;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MyNodeWithAssignedId myNode = (MyNodeWithAssignedId) o;
+        return Objects.equals(name, myNode.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override public String toString() {
+        return "MyNodeWithAssignedId{" +
+            "name='" + name + '\'' +
+            '}';
+    }
+}

--- a/test/src/test/java/org/neo4j/ogm/persistence/model/RelationshipMappingTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/model/RelationshipMappingTest.java
@@ -18,7 +18,11 @@
  */
 package org.neo4j.ogm.persistence.model;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -27,6 +31,10 @@ import org.junit.Test;
 import org.neo4j.graphdb.Result;
 import org.neo4j.ogm.domain.election.Candidate;
 import org.neo4j.ogm.domain.election.Voter;
+import org.neo4j.ogm.domain.gh640.MyNode;
+import org.neo4j.ogm.domain.gh640.MyNodeWithAssignedId;
+import org.neo4j.ogm.domain.gh641.Entity1;
+import org.neo4j.ogm.domain.gh641.MyRelationship;
 import org.neo4j.ogm.domain.policy.Person;
 import org.neo4j.ogm.domain.policy.Policy;
 import org.neo4j.ogm.session.Session;
@@ -37,14 +45,19 @@ import org.neo4j.ogm.testutil.MultiDriverTestClass;
 /**
  * @author Mark Angrish
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class RelationshipMappingTest extends MultiDriverTestClass {
 
     private Session session;
 
     @BeforeClass
-    public static void oneTimeSetup() throws IOException {
-        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.policy", "org.neo4j.ogm.domain.election");
+    public static void oneTimeSetup() {
+        sessionFactory = new SessionFactory(driver,
+            "org.neo4j.ogm.domain.policy",
+            "org.neo4j.ogm.domain.election",
+            "org.neo4j.ogm.domain.gh640",
+            "org.neo4j.ogm.domain.gh641");
     }
 
     @Before
@@ -112,10 +125,7 @@ public class RelationshipMappingTest extends MultiDriverTestClass {
             "CREATE (n:Policy:DomainObject {name:'Health'})<-[:WRITES_POLICY]-(m:Person:DomainObject {name:'Jim'})");
     }
 
-    /**
-     * @see DATAGRAPH-674
-     */
-    @Test
+    @Test // DATAGRAPH-674
     public void testAnnotatedRelationshipTypeWhenMethodsAreJsonIgnored() {
         Person jim = new Person("Jim");
         Policy policy = new Policy("Health");
@@ -159,5 +169,121 @@ public class RelationshipMappingTest extends MultiDriverTestClass {
             "CREATE (a:Voter:Candidate {name:'A'}) " +
                 "CREATE (b:Voter:Candidate {name:'B'}) " +
                 "CREATE (v:Voter {name:'V'})-[:CANDIDATE_VOTED_FOR]->(a)");
+    }
+
+    @Test // GH-640
+    public void shouldDealWithTheSameButNotEqualParentEntities() {
+
+        Session tx = sessionFactory.openSession();
+        Map<String, Object> result = tx.query("CREATE (n1:MyNode {name: 'node1'})\n"
+            + "CREATE (n2:MyNode {name: 'node2'})\n"
+            + "CREATE (n3:MyNode {name: 'node3'})\n"
+            + "CREATE (n1) - [:REL_TWO] -> (n2)\n"
+            + "CREATE (n2) - [:REL_ONE] -> (n1)\n"
+            + "RETURN id(n1) as idOfn1, id(n2) as idOfn2, id(n3) as idOfn3", Collections.emptyMap()).iterator().next();
+
+        // Lets flush the session and thus basically creating a new tx, at least as far as the cache is concerned
+        tx = sessionFactory.openSession();
+
+        // Let's go through a bunch of queries to make sure the associations are loaded as OGM would do by default…
+        MyNode node1 = tx.load(MyNode.class, (Long)result.get("idOfn1"));
+        MyNode node2 = tx.load(MyNode.class, (Long)result.get("idOfn2"));
+        MyNode node3 = tx.load(MyNode.class, (Long)result.get("idOfn3"));
+
+        // Let's check some preconditions, shall we?
+        assertThat(node1).isNotNull();
+        assertThat(node2).isNotNull();
+        assertThat(node3).isNotNull();
+
+        assertThat(node1.getRefOne()).isEqualTo(node2);
+        assertThat(node1.getRefTwo()).containsOnly(node2);
+
+        // We start a new tx, but keep working on the copy of the previously loaded node
+        tx = sessionFactory.openSession();
+        MyNode changed = tx.load(MyNode.class, node1.getId()).copy();
+        changed.setName("Dirty thing.");
+        changed.setRefOne(node3);
+        tx.save(changed);
+
+        // Again, verify in a new session.
+        tx = sessionFactory.openSession();
+        node1 = tx.load(MyNode.class, changed.getId());
+        assertThat(node1.getRefOne()).isEqualTo(node3);
+        assertThat(node1.getRefTwo()).containsOnly(node2);
+
+        // Better safe than sorry.
+        GraphTestUtils.assertSameGraph(getGraphDatabaseService(),
+            "CREATE (n1:MyNode {name: 'Dirty thing.'})\n"
+                + "CREATE (n2:MyNode {name: 'node2'})\n"
+                + "CREATE (n3:MyNode {name: 'node3'})\n"
+                + "CREATE (n1) - [:REL_TWO] -> (n2)\n"
+                + "CREATE (n3) - [:REL_ONE] -> (n1)");
+    }
+
+    @Test // GH-640
+    public void shouldDealWithTheSameButNotEqualParentEntitiesWithAssignedId() {
+        // Sames as above but this time the entity has an assigned id.
+
+        Session tx = sessionFactory.openSession();
+        tx.query("CREATE (n1:MyNodeWithAssignedId {name: 'node1'})\n"
+            + "CREATE (n2:MyNodeWithAssignedId {name: 'node2'})\n"
+            + "CREATE (n3:MyNodeWithAssignedId {name: 'node3'})\n"
+            + "CREATE (n1) - [:REL_TWO] -> (n2)\n"
+            + "CREATE (n2) - [:REL_ONE] -> (n1)\n"
+            + "RETURN id(n1) as idOfn1, id(n2) as idOfn2, id(n3) as idOfn3", Collections.emptyMap()).iterator().next();
+
+        tx = sessionFactory.openSession();
+
+        MyNodeWithAssignedId node1 = tx.load(MyNodeWithAssignedId.class, "node1");
+        MyNodeWithAssignedId node2 = tx.load(MyNodeWithAssignedId.class, "node2");
+        MyNodeWithAssignedId node3 = tx.load(MyNodeWithAssignedId.class, "node3");
+
+        assertThat(node1).isNotNull();
+        assertThat(node2).isNotNull();
+        assertThat(node3).isNotNull();
+
+        assertThat(node1.getRefOne()).isEqualTo(node2);
+        assertThat(node1.getRefTwo()).containsOnly(node2);
+
+        tx = sessionFactory.openSession();
+        MyNodeWithAssignedId changed = tx.load(MyNodeWithAssignedId.class, node1.getName()).copy();
+        changed.setRefOne(node3);
+        tx.save(changed);
+
+        tx = sessionFactory.openSession();
+        node1 = tx.load(MyNodeWithAssignedId.class, changed.getName());
+        assertThat(node1.getRefOne()).isEqualTo(node3);
+        assertThat(node1.getRefTwo()).containsOnly(node2);
+
+        GraphTestUtils.assertSameGraph(getGraphDatabaseService(),
+            "CREATE (n1:MyNodeWithAssignedId {name: 'node1'})\n"
+                + "CREATE (n2:MyNodeWithAssignedId {name: 'node2'})\n"
+                + "CREATE (n3:MyNodeWithAssignedId {name: 'node3'})\n"
+                + "CREATE (n1) - [:REL_TWO] -> (n2)\n"
+                + "CREATE (n3) - [:REL_ONE] -> (n1)");
+    }
+
+    @Test // GH-641
+    public void shouldKeepOrderOfRelatedElements() {
+        // This test doesn't fit too well into here, as it is a broader problem than relationships,
+        // it also is tackled in org.neo4j.ogm.persistence.relationships.transitive.abb.ABBTest,
+        // org.neo4j.ogm.persistence.relationships.direct.abb.ABBTest and some others, but there it fits
+        // even worse.
+
+        session.query("CREATE (e1:Entity1)\n"
+            + "CREATE (e2:Entity2)\n"
+            + "CREATE (e3:Entity2)\n"
+            + "CREATE (e4:Entity2)\n"
+            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 1}] -> (e3)\n"
+            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 2}] -> (e4)\n"
+            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 3}] -> (e2)\n"
+            + "RETURN *", Collections.emptyMap());
+        session.clear();
+
+        Entity1 entity1 = session.queryForObject(Entity1.class,
+            "MATCH (e1:Entity1)-[r:MY_RELATIONSHIP]->(e2:Entity2)\n"
+                + "RETURN e1, r, e2\n"
+                + "ORDER BY r.ordering", Collections.emptyMap());
+        assertThat(entity1.getEntries()).extracting(MyRelationship::getOrdering).containsExactly(1, 2, 3);
     }
 }

--- a/test/src/test/java/org/neo4j/ogm/persistence/relationships/RelationshipEntityTest.java
+++ b/test/src/test/java/org/neo4j/ogm/persistence/relationships/RelationshipEntityTest.java
@@ -56,10 +56,7 @@ public class RelationshipEntityTest extends MultiDriverTestClass {
 
     @BeforeClass
     public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(driver,
-            "org.neo4j.ogm.persistence.relationships",
-            "org.neo4j.ogm.domain.gh641"
-        );
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.persistence.relationships");
     }
 
     @Before
@@ -74,31 +71,6 @@ public class RelationshipEntityTest extends MultiDriverTestClass {
         m.rset.add(r1);
 
         session.purgeDatabase();
-    }
-
-
-    @Test // GH-641
-    public void shouldKeepOrderOfRelatedElements() {
-        // This test doesn't fit too well into here, as it is a broader problem than relationships,
-        // it also is tackled in org.neo4j.ogm.persistence.relationships.transitive.abb.ABBTest,
-        // org.neo4j.ogm.persistence.relationships.direct.abb.ABBTest and some others, but there it fits
-        // even worse.
-
-        session.query("CREATE (e1:Entity1)\n"
-            + "CREATE (e2:Entity2)\n"
-            + "CREATE (e3:Entity2)\n"
-            + "CREATE (e4:Entity2)\n"
-            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 1}] -> (e3)\n"
-            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 2}] -> (e4)\n"
-            + "CREATE (e1) - [:MY_RELATIONSHIP {ordering: 3}] -> (e2)\n"
-            + "RETURN *", Collections.emptyMap());
-        session.clear();
-
-        Entity1 entity1 = session.queryForObject(Entity1.class,
-            "MATCH (e1:Entity1)-[r:MY_RELATIONSHIP]->(e2:Entity2)\n"
-            + "RETURN e1, r, e2\n"
-            + "ORDER BY r.ordering", Collections.emptyMap());
-        assertThat(entity1.getEntries()).extracting(MyRelationship::getOrdering).containsExactly(1, 2, 3);
     }
 
     @Test


### PR DESCRIPTION
This change tries to store visited nodes under their native graph id in the compile context if possible. Thus, they are recognized even when a user uses a different instance of the same entity for persisting state.

This fixes #640.