### PR TITLE
Add some usefull Kotlin extensions to Session.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <java-module-name>org.neo4j.ogm.core</java-module-name>
+        <mockk.version>1.9.3</mockk.version>
     </properties>
 
     <dependencies>
@@ -68,5 +69,83 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <version>${mockk.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <jvmTarget>${maven.compiler.source}</jvmTarget>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-kotlin-source</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/kotlin</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/core/src/main/kotlin/org/neo4j/ogm/session/SessionExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/session/SessionExtensions.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session
+
+import org.neo4j.ogm.cypher.Filter
+import org.neo4j.ogm.cypher.Filters
+import org.neo4j.ogm.cypher.query.Pagination
+import org.neo4j.ogm.cypher.query.SortOrder
+import java.io.Serializable
+
+/**
+ * Extension for [Session.loadAll] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.loadAll(
+        ids: Collection<out Serializable>,
+        sortOrder: SortOrder = SortOrder(),
+        pagination: Pagination? = null,
+        depth: Int = 1
+): Collection<T> = loadAll(T::class.java, ids, sortOrder, pagination, depth)
+
+/**
+ * Extension for [Session.loadAll] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.loadAll(
+        sortOrder: SortOrder = SortOrder(),
+        pagination: Pagination? = null,
+        depth: Int = 1
+): Collection<T> = loadAll(T::class.java, sortOrder, pagination, depth)
+
+/**
+ * Extension for [Session.loadAll] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.loadAll(
+        filter: Filter,
+        sortOrder: SortOrder = SortOrder(),
+        pagination: Pagination? = null,
+        depth: Int = 1
+): Collection<T> = loadAll(T::class.java, filter, sortOrder, pagination, depth)
+
+/**
+ * Extension for [Session.loadAll] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.loadAll(
+        filters: Filters,
+        sortOrder: SortOrder = SortOrder(),
+        pagination: Pagination? = null,
+        depth: Int = 1
+): Collection<T> = loadAll(T::class.java, filters, sortOrder, pagination, depth)
+
+/**
+ * Extension for [Session.load] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.load(id: Serializable, depth: Int = 1): T =
+        load(T::class.java, id)
+
+/**
+ * Extension for [Session.deleteAll] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.deleteAll(): Unit =
+        deleteAll(T::class.java)
+
+/**
+ * Extension for [Session.delete] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.delete(filters : Iterable<Filter>, listResults: Boolean): Any =
+        delete(T::class.java, filters, listResults)
+
+/**
+ * Extension for [Session.queryForObject] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.queryForObject(
+        cypher: String,
+        parameters: Map<String, Any> = emptyMap()
+): T = queryForObject(T::class.java, cypher, parameters)
+
+/**
+ * Extension for [Session.query] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.query(
+        cypher: String,
+        parameters: Map<String, Any> = emptyMap()
+): Iterable<T> = query(T::class.java, cypher, parameters)
+
+/**
+ * Extension for [Session.countEntitiesOfType] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.countEntitiesOfType(): Long = countEntitiesOfType(T::class.java)
+
+/**
+ * Extension for [Session.countEntitiesOfType] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> Session.count(filters: Iterable<Filter>): Long
+        = count(T::class.java, filters)

--- a/core/src/main/kotlin/org/neo4j/ogm/session/SessionFactoryExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/session/SessionFactoryExtensions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session
+
+/**
+ * Extension for [SessionFactory.unwrap] leveraging reified type parameters.
+ */
+inline fun <reified T : Any> SessionFactory.unwrap(): T = unwrap(T::class.java)

--- a/core/src/test/kotlin/org/neo4j/ogm/session/SessionExtensionsTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/session/SessionExtensionsTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.neo4j.ogm.cypher.Filter
+import org.neo4j.ogm.cypher.Filters
+import org.neo4j.ogm.cypher.query.SortOrder
+
+/**
+ * @author Michael J. Simons
+ */
+class SessionExtensionsTest {
+
+    val session = mockk<Session>(relaxed = true)
+    val ids = listOf(1L)
+
+    class SomeEntity
+
+    @Test
+    fun `loadAll(ids) extension should call its Java counterpart`() {
+
+        session.loadAll<SomeEntity>(listOf(1L))
+
+        verify(exactly = 1) { session.loadAll(SomeEntity::class.java, eq(ids), ofType(SortOrder::class), isNull(), 1) }
+    }
+
+    @Test
+    fun `loadAll extension should call its Java counterpart`() {
+
+        session.loadAll<SomeEntity>()
+
+        verify(exactly = 1) { session.loadAll(SomeEntity::class.java, ofType(SortOrder::class), isNull(), 1) }
+    }
+
+    @Test
+    fun `loadAll(filter) extension should call its Java counterpart`() {
+
+        val filter = mockk<Filter>()
+        session.loadAll<SomeEntity>(filter)
+
+        verify(exactly = 1) { session.loadAll(SomeEntity::class.java, filter, ofType(SortOrder::class), isNull(), 1) }
+    }
+
+    @Test
+    fun `loadAll(filters) extension should call its Java counterpart`() {
+
+        val filters = Filters()
+        session.loadAll<SomeEntity>(filters)
+
+        verify(exactly = 1) { session.loadAll(SomeEntity::class.java, filters, ofType(SortOrder::class), isNull(), 1) }
+    }
+
+    @Test
+    fun `load(id) extension should call its Java counterpart`() {
+
+        session.load<SomeEntity>(23L)
+
+        verify(exactly = 1) { session.load(SomeEntity::class.java, 23L) }
+    }
+
+    @Test
+    fun `deleteAll extension should call its Java counterpart`() {
+
+        session.deleteAll<SomeEntity>()
+
+        verify(exactly = 1) { session.deleteAll(SomeEntity::class.java) }
+    }
+
+    @Test
+    fun `delete(filters, boolean) extension should call its Java counterpart`() {
+
+        val filters = emptyList<Filter>()
+        session.delete<SomeEntity>(filters, true)
+
+        verify(exactly = 1) { session.delete(SomeEntity::class.java, filters, true) }
+    }
+
+    @Test
+    fun `queryForObject extension should call its Java counterpart`() {
+
+        val cypher = "MATCH (n:SomeEntity) RETURN n LIMIT 1"
+        session.queryForObject<SomeEntity>(cypher)
+
+        verify(exactly = 1) { session.queryForObject(SomeEntity::class.java, cypher, emptyMap<String, Any>()) }
+    }
+
+    @Test
+    fun `query extension should call its Java counterpart`() {
+
+        val cypher = "MATCH (n:SomeEntity) RETURN n"
+        session.query<SomeEntity>(cypher)
+
+        verify(exactly = 1) { session.query(SomeEntity::class.java, cypher, emptyMap<String, Any>()) }
+    }
+
+    @Test
+    fun `countEntitiesOfType extension should call its Java counterpart`() {
+
+        session.countEntitiesOfType<SomeEntity>()
+
+        verify(exactly = 1) { session.countEntitiesOfType(SomeEntity::class.java) }
+    }
+
+    @Test
+    fun `count extension should call its Java counterpart`() {
+
+        session.count<SomeEntity>(emptyList())
+
+        verify(exactly = 1) { session.count(SomeEntity::class.java, emptyList()) }
+    }
+}

--- a/core/src/test/kotlin/org/neo4j/ogm/session/SessionFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/session/SessionFactoryExtensionsTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.neo4j.ogm.driver.Driver
+
+/**
+ * @author Michael J. Simons
+ */
+class SessionFactoryExtensionsTest {
+
+    val sessionFactory = mockk<SessionFactory>(relaxed = true)
+
+    @Test
+    fun `unwrap extension should call its Java counterpart`() {
+
+        sessionFactory.unwrap<Driver>()
+
+        verify(exactly = 1) { sessionFactory.unwrap(Driver::class.java) }
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
@@ -31,22 +31,6 @@
     <name>Neo4j-OGM Integration tests</name>
     <description>Integration tests of Neo4j-OGM Core and API across different transports.</description>
 
-    <properties>
-        <kotlin.version>1.3.41</kotlin.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <jline.version>2.14.3</jline.version>
         <junit.version>4.12</junit.version>
+        <kotlin.version>1.3.50</kotlin.version>
         <logback.version>1.2.3</logback.version>
         <lucene.version>5.5.5</lucene.version>
         <neo4j.version>3.4.15</neo4j.version>
@@ -237,6 +238,14 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This adds extensions for the `Session` and `SessionFactory` to make the work with Neo4j-OGM in Kotlin more enjoyable.

@jexp I tagged you to see if you have more suggestions in general or to use more idiomatic Kotlin in the `KotlinInteropTest`.