### PR TITLE
GH-665 - Backport nested type conversion from 3.2 for embedded.

### DIFF
--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/JavaDriverBasedParameterConversion.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/JavaDriverBasedParameterConversion.java
@@ -18,8 +18,14 @@
  */
 package org.neo4j.ogm.drivers.bolt.driver;
 
+import static java.util.stream.Collectors.*;
+
+import java.lang.reflect.Array;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.Values;


### PR DESCRIPTION
The backport is not needed for the Driver based version, as the driver takes care of dealing with list and map values.