### PR TITLE
Optimize cpu performance in CypherContext::isAlreadyDeleted

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/CypherContext.java
@@ -22,7 +22,6 @@ import static java.util.Collections.*;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import org.neo4j.ogm.compiler.SrcTargetKey;
 import org.neo4j.ogm.context.Mappable;
@@ -277,8 +276,7 @@ public class CypherContext implements CompileContext {
      */
     private boolean isAlreadyDeleted(Mappable mappedRelationship) {
 
-        Predicate<Mappable> describesSameRelationship = mappedRelationship::equals;
-        return deletedRelationships.stream().anyMatch(describesSameRelationship);
+        return deletedRelationships.contains(mappedRelationship);
     }
 
     private static class NodeBuilderHorizonPair {


### PR DESCRIPTION
## Description

In method CypherContext::isAlreadyDeleted, there is a control implemented using stream programming, however this control can be replaced with a simple "contains" in the hashset.

Based on my tests, the performances has increased significantly.

### Before:
903ms to save 7000 unmodified relations, total time is about 8 seconds
![before](https://user-images.githubusercontent.com/538137/66438033-b43e8400-ea2b-11e9-93f7-6ff9d1c64f88.png)

### After:
Here isAlreadyDeleted is not even mentioned
![after](https://user-images.githubusercontent.com/538137/66438036-b7397480-ea2b-11e9-9de4-547b02f859f5.png)

## How Has This Been Tested?
I executed maven test (with the intellij plugin) before and after modifications

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
