### PR TITLE
GH-671 - Fix check if result type is assignable to provided generic type

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -85,7 +85,7 @@ public class ExecuteQueriesDelegate extends SessionDelegate {
 
         T next = results.iterator().next();
 
-        if (!next.getClass().isAssignableFrom(type)) {
+        if (!type.isAssignableFrom(next.getClass())) {
 
             String typeOfResult = next.getClass().getName();
             String wantedType = type.getName();

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
@@ -696,6 +696,12 @@ public class QueryCapabilityTest extends MultiDriverTestClass {
                 Restaurant.class.getName());
     }
 
+    @Test // GH-671
+    public void shouldNotThrowExceptionIfTypeIsSuperTypeOfResultObject() {
+    	session.queryForObject(Long.class, "MATCH (n:User) return count(n)", emptyMap());
+    	session.queryForObject(Number.class, "MATCH (n:User) return count(n)", emptyMap());
+    }
+
     @Test
     public void queryForObjectFindsNestedClasses() {
 


### PR DESCRIPTION
This pull request fixes issue #671.

## Description
The check if the type of the query result object in ExecuteQueriesDelegate#queryForObject has been adjusted from
`if (!next.getClass().isAssignableFrom(type)) {`
to
`if (!type.isAssignableFrom(next.getClass())) {`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
