### PR TITLE
GH-678 - Optimize scanning and storage of Node- and RelationshipEntities.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -145,16 +145,14 @@ public class DomainInfo {
 
             AnnotationInfo nodeEntityAnnotation = classInfo.annotationsInfo().get(NodeEntity.class);
             if (nodeEntityAnnotation != null) {
-                String label = nodeEntityAnnotation.get(NodeEntity.LABEL, classInfo.neo4jName());
-                List<ClassInfo> classInfos = temporaryNodeEntitiesByLabel.computeIfAbsent(label, k -> new ArrayList());
+                List<ClassInfo> classInfos = temporaryNodeEntitiesByLabel.computeIfAbsent(classInfo.neo4jName(), k -> new ArrayList());
                 classInfos.add(classInfo);
             }
 
             AnnotationInfo relationshipEntityAnnotation = classInfo.annotationsInfo().get(RelationshipEntity.class);
             if (relationshipEntityAnnotation != null) {
-                String type = relationshipEntityAnnotation.get(RelationshipEntity.TYPE, classInfo.neo4jName());
                 List<ClassInfo> classInfos = temporaryRelationshipEntitiesByType
-                    .computeIfAbsent(type, k -> new ArrayList());
+                    .computeIfAbsent(classInfo.neo4jName(), k -> new ArrayList());
                 classInfos.add(classInfo);
             }
         }

--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -27,8 +27,9 @@ import io.github.classgraph.ScanResult;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.annotation.typeconversion.Convert;
 import org.neo4j.ogm.driver.TypeSystem;
 import org.neo4j.ogm.driver.TypeSystem.NoNativeTypes;
@@ -54,8 +55,9 @@ public class DomainInfo {
     private final TypeSystem typeSystem;
 
     private final Map<String, ClassInfo> classNameToClassInfo = new HashMap<>();
-    private final Map<String, ArrayList<ClassInfo>> annotationNameToClassInfo = new HashMap<>();
-    private final Map<String, ArrayList<ClassInfo>> interfaceNameToClassInfo = new HashMap<>();
+    private Map<String, List<ClassInfo>> nodeEntitiesByLabel;
+    private Map<String, List<ClassInfo>> relationshipEntitiesByType;
+    private final Map<String, List<ClassInfo>> interfaceNameToClassInfo = new HashMap<>();
     private final Set<Class> enumTypes = new HashSet<>();
     private final ConversionCallbackRegistry conversionCallbackRegistry = new ConversionCallbackRegistry();
 
@@ -69,36 +71,24 @@ public class DomainInfo {
 
     public static DomainInfo create(TypeSystem typeSystem, String... packages) {
 
-        ScanResult scanResult = findClasses(packages);
-
-        List<String> allClasses = scanResult.getAllClasses().stream()
-            .map(io.github.classgraph.ClassInfo::getName)
-            .collect(Collectors.toList());
-
         DomainInfo domainInfo = new DomainInfo(typeSystem);
-
-        Predicate<Class<?>> classCouldBeLoaded = Objects::nonNull;
         Predicate<Class<?>> classIsMappable = clazz -> !(clazz.isAnnotation() || clazz.isAnonymousClass() || clazz
             .equals(Object.class));
 
-        Map<String, Class<?>> mappableClasses = allClasses
+        ScanResult scanResult = findClasses(packages);
+        scanResult.getAllClasses().loadClasses(true)
             .stream()
-            .map(DomainInfo::loadClass)
-            .filter(classCouldBeLoaded)
             .filter(classIsMappable)
-            .collect(Collectors.toMap(Class::getName, Function.identity()));
-
-        mappableClasses.values()
-            .forEach(clazz -> prepareClass(domainInfo, mappableClasses, typeSystem, clazz));
-
-        domainInfo.finish();
+            .forEach(clazz -> prepareClass(domainInfo, typeSystem, clazz));
         scanResult.close();
+        domainInfo.finish();
 
         return domainInfo;
     }
 
     private static ScanResult findClasses(String[] packagesOrClasses) {
 
+        // .enableExternalClasses() is not needed, as the super classes are loaded anywhere when the class is loaded.
         return new ClassGraph()
             .enableAllInfo()
             .whitelistPackages(packagesOrClasses)
@@ -111,12 +101,11 @@ public class DomainInfo {
      * and prepares the super classes recursively and adds it to {@link DomainInfo#classNameToClassInfo}.
      *
      * @param domainInfo
-     * @param mappableClasses
      * @param typeSystem
      * @param clazz
      */
     static void prepareClass(
-        DomainInfo domainInfo, Map<String, Class<?>> mappableClasses, TypeSystem typeSystem, Class clazz) {
+        DomainInfo domainInfo, TypeSystem typeSystem, Class clazz) {
         ClassInfo newClassInfo = new ClassInfo(clazz, typeSystem);
         String className = newClassInfo.name();
         String superclassName = newClassInfo.superclassName();
@@ -133,15 +122,9 @@ public class DomainInfo {
             if (superclassInfo != null) {
                 superclassInfo.addSubclass(classInfo);
             } else if (!"java.lang.Object".equals(superclassName) && !"java.lang.Enum".equals(superclassName)) {
-
-                Class<?> superClazz = Optional.ofNullable(mappableClasses.get(superclassName))
-                    // This is the case when a class outside the scanned packages is referred to
-                    .orElseGet(() -> (Class) loadClass(superclassName));
-
-                superclassInfo = new ClassInfo(superClazz, classInfo);
-                domainInfo.classNameToClassInfo.put(superclassName, superclassInfo);
-
-                prepareClass(domainInfo, mappableClasses, typeSystem, superClazz);
+                Class<?> superClazz = clazz.getSuperclass();
+                domainInfo.classNameToClassInfo.put(superclassName, new ClassInfo(superClazz, classInfo));
+                prepareClass(domainInfo, typeSystem, superClazz);
             }
         }
 
@@ -151,46 +134,45 @@ public class DomainInfo {
         }
     }
 
-    static Class<?> loadClass(String className) {
+    private void buildByLabelLookupMaps() {
 
-        Class<?> loadedButNotInitalizedClass = null;
-        try {
-            loadedButNotInitalizedClass = Class
-                .forName(className, false, Thread.currentThread().getContextClassLoader());
-        } catch (ClassNotFoundException e) {
-            LOGGER.warn("Could not load class {}", className);
+        LOGGER.info("Building byLabel lookup maps");
 
-        }
-        return loadedButNotInitalizedClass;
-    }
+        Map<String, List<ClassInfo>> temporaryNodeEntitiesByLabel = new HashMap<>();
+        Map<String, List<ClassInfo>> temporaryRelationshipEntitiesByType = new HashMap<>();
 
-    private void buildAnnotationNameToClassInfoMap() {
-
-        LOGGER.info("Building annotation class map");
         for (ClassInfo classInfo : classNameToClassInfo.values()) {
-            for (AnnotationInfo annotation : classInfo.annotations()) {
-                ArrayList<ClassInfo> classInfoList = annotationNameToClassInfo.get(annotation.getName());
-                if (classInfoList == null) {
-                    classInfoList = new ArrayList<>();
-                    annotationNameToClassInfo.put(annotation.getName(), classInfoList);
-                }
-                classInfoList.add(classInfo);
+
+            AnnotationInfo nodeEntityAnnotation = classInfo.annotationsInfo().get(NodeEntity.class);
+            if (nodeEntityAnnotation != null) {
+                String label = nodeEntityAnnotation.get(NodeEntity.LABEL, classInfo.neo4jName());
+                List<ClassInfo> classInfos = temporaryNodeEntitiesByLabel.computeIfAbsent(label, k -> new ArrayList());
+                classInfos.add(classInfo);
+            }
+
+            AnnotationInfo relationshipEntityAnnotation = classInfo.annotationsInfo().get(RelationshipEntity.class);
+            if (relationshipEntityAnnotation != null) {
+                String type = relationshipEntityAnnotation.get(RelationshipEntity.TYPE, classInfo.neo4jName());
+                List<ClassInfo> classInfos = temporaryRelationshipEntitiesByType
+                    .computeIfAbsent(type, k -> new ArrayList());
+                classInfos.add(classInfo);
             }
         }
+
+        this.nodeEntitiesByLabel = Collections.unmodifiableMap(temporaryNodeEntitiesByLabel);
+        this.relationshipEntitiesByType = Collections.unmodifiableMap(temporaryRelationshipEntitiesByType);
     }
 
     private void buildInterfaceNameToClassInfoMap() {
+
         LOGGER.info("Building interface class map for {} classes", classNameToClassInfo.values().size());
         for (ClassInfo classInfo : classNameToClassInfo.values()) {
             LOGGER.debug(" - {} implements {} interfaces", classInfo.simpleName(),
                 classInfo.interfacesInfo().list().size());
             for (InterfaceInfo iface : classInfo.interfacesInfo().list()) {
-                ArrayList<ClassInfo> classInfoList = interfaceNameToClassInfo.get(iface.name());
-                if (classInfoList == null) {
-                    classInfoList = new ArrayList<>();
-                    interfaceNameToClassInfo.put(iface.name(), classInfoList);
-                }
                 LOGGER.debug("   - {}", iface.name());
+                List<ClassInfo> classInfoList = interfaceNameToClassInfo
+                    .computeIfAbsent(iface.name(), key -> new ArrayList<>());
                 classInfoList.add(classInfo);
             }
         }
@@ -204,7 +186,7 @@ public class DomainInfo {
 
         LOGGER.info("Starting Post-processing phase");
 
-        buildAnnotationNameToClassInfoMap();
+        buildByLabelLookupMaps();
         buildInterfaceNameToClassInfoMap();
 
         List<ClassInfo> transientClasses = new ArrayList<>();
@@ -235,8 +217,8 @@ public class DomainInfo {
         LOGGER.debug("Checking for @Transient classes....");
 
         // find transient interfaces
-        Collection<ArrayList<ClassInfo>> interfaceInfos = interfaceNameToClassInfo.values();
-        for (ArrayList<ClassInfo> classInfos : interfaceInfos) {
+        Collection<List<ClassInfo>> interfaceInfos = interfaceNameToClassInfo.values();
+        for (List<ClassInfo> classInfos : interfaceInfos) {
             for (ClassInfo classInfo : classInfos) {
                 if (classInfo.isTransient()) {
                     LOGGER.debug("Registering @Transient baseclass: {}", classInfo.name());
@@ -355,9 +337,14 @@ public class DomainInfo {
     }
 
     private ClassInfo getClassInfo(String fullOrPartialClassName, Map<String, ClassInfo> infos) {
-        ClassInfo match = null;
+
+        ClassInfo match = infos.get(fullOrPartialClassName);
+        if (match != null) {
+            return match;
+        }
+
         for (String fqn : infos.keySet()) {
-            if (fqn.endsWith("." + fullOrPartialClassName) || fqn.equals(fullOrPartialClassName)) {
+            if (fqn.endsWith("." + fullOrPartialClassName)) {
                 if (match == null) {
                     match = infos.get(fqn);
                 } else {
@@ -368,8 +355,12 @@ public class DomainInfo {
         return match;
     }
 
-    List<ClassInfo> getClassInfosWithAnnotation(String annotation) {
-        return annotationNameToClassInfo.get(annotation);
+    Map<String, List<ClassInfo>> getNodeEntitiesByLabel() {
+        return nodeEntitiesByLabel;
+    }
+
+    Map<String, List<ClassInfo>> getRelationshipEntitiesByType() {
+        return relationshipEntitiesByType;
     }
 
     private void registerDefaultFieldConverters(ClassInfo classInfo, FieldInfo fieldInfo) {

--- a/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
@@ -20,7 +20,7 @@ package org.neo4j.ogm.metadata;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class MetaData {
 
@@ -47,7 +48,6 @@ public class MetaData {
 
     private final DomainInfo domainInfo;
     private final Schema schema;
-    private Map<String, ClassInfo> classInfos = new HashMap<>();
 
     public MetaData(String... packages) {
         this(NoNativeTypes.INSTANCE, packages);
@@ -70,30 +70,23 @@ public class MetaData {
      * @return A ClassInfo matching the supplied name, or null if it doesn't exist
      */
     public ClassInfo classInfo(String name) {
-        if (classInfos.containsKey(name)) {
-            return classInfos.get(name);
-        }
 
-        ClassInfo classInfo = _classInfo(name, NodeEntity.class.getName(), NodeEntity.LABEL);
+        ClassInfo classInfo = _classInfo(name, NodeEntity.class);
         if (classInfo != null) {
-            classInfos.put(name, classInfo);
             return classInfo;
         }
 
-        classInfo = _classInfo(name, RelationshipEntity.class.getName(), RelationshipEntity.TYPE);
+        classInfo = _classInfo(name, RelationshipEntity.class);
         if (classInfo != null) {
-            classInfos.put(name, classInfo);
             return classInfo;
         }
 
         classInfo = domainInfo.getClassSimpleName(name);
         if (classInfo != null) {
-            classInfos.put(name, classInfo);
             return classInfo;
         }
 
         // not found
-        classInfos.put(name, null);
         return null;
     }
 
@@ -117,34 +110,24 @@ public class MetaData {
         return classInfo(object.getClass().getName());
     }
 
-    private ClassInfo _classInfo(String name, String nodeEntityAnnotation, String annotationPropertyName) {
-        List<ClassInfo> labelledClasses = domainInfo.getClassInfosWithAnnotation(nodeEntityAnnotation);
-        if (labelledClasses != null) {
-            for (ClassInfo labelledClass : labelledClasses) {
-                AnnotationInfo annotationInfo = labelledClass.annotationsInfo().get(nodeEntityAnnotation);
-                String value = annotationInfo.get(annotationPropertyName, labelledClass.neo4jName());
-                if (value.equals(name)) {
-                    return labelledClass;
-                }
-            }
-        }
-        return null;
-    }
+    private ClassInfo _classInfo(String name, Class<?> nodeEntityAnnotation) {
 
-    private Set<ClassInfo> _classInfos(String name, String nodeEntityAnnotation) {
-
-        Set<ClassInfo> newClassInfos = new HashSet<>();
-        List<ClassInfo> labelledClasses = domainInfo.getClassInfosWithAnnotation(nodeEntityAnnotation);
-        if (labelledClasses != null) {
-            for (ClassInfo labelledClass : labelledClasses) {
-                AnnotationInfo annotationInfo = labelledClass.annotationsInfo().get(nodeEntityAnnotation);
-                String value = annotationInfo.get("type", labelledClass.neo4jName());
-                if (value.equals(name)) {
-                    newClassInfos.add(labelledClass);
-                }
-            }
+        Map<String, List<ClassInfo>> labelledClasses;
+        if (nodeEntityAnnotation == NodeEntity.class) {
+            labelledClasses = domainInfo.getNodeEntitiesByLabel();
+        } else if (nodeEntityAnnotation == RelationshipEntity.class) {
+            labelledClasses = domainInfo.getRelationshipEntitiesByType();
+        } else {
+            throw new IllegalArgumentException(
+                "Cannot retrieve class infos for annotation " + nodeEntityAnnotation.toString());
         }
-        return newClassInfos;
+
+        // Make it explicit that duplicate labels are not dealt with.
+        // Usually, the class infos list contains the classes for a specific label in the reverse order of
+        // processing. That is: The last class found by class graph is the first one in the list.
+        // So returning the first one reassembles the previous behaviour (before working on GH-678).
+        List<ClassInfo> classInfos = labelledClasses.getOrDefault(name, Collections.emptyList());
+        return classInfos.isEmpty() ? null : classInfos.get(0);
     }
 
     /**
@@ -232,15 +215,13 @@ public class MetaData {
 
         Set<ClassInfo> matchingClassInfos = new HashSet<>();
 
-        ClassInfo classInfo = _classInfo(name, NodeEntity.class.getName(), NodeEntity.LABEL);
+        ClassInfo classInfo = _classInfo(name, NodeEntity.class);
         if (classInfo != null) {
             matchingClassInfos.add(classInfo);
         }
 
-        //Potentially many relationship entities annotated with the same type
-        for (ClassInfo info : _classInfos(name, RelationshipEntity.class.getName())) {
-            matchingClassInfos.add(info);
-        }
+        // Potentially many relationship entities annotated with the same type
+        matchingClassInfos.addAll(domainInfo.getRelationshipEntitiesByType().getOrDefault(name, Collections.emptyList()));
 
         classInfo = domainInfo.getClassSimpleName(name);
         if (classInfo != null) {
@@ -313,5 +294,4 @@ public class MetaData {
     public void registerConversionCallback(ConversionCallback conversionCallback) {
         this.domainInfo.registerConversionCallback(conversionCallback);
     }
-
 }

--- a/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
@@ -157,7 +157,7 @@ public class MetaData {
                 // if there is, use that, otherwise this label cannot be resolved
                 if (taxonClassInfo.isInterface()) {
                     LOGGER.debug("label is on an interface. Looking for a single implementing class...");
-                    taxonClassInfo = findSingleImplementor(taxon);
+                    taxonClassInfo = findSingleImplementor(taxonClassInfo);
                 } else if (taxonClassInfo.isAbstract()) {
                     LOGGER.debug("label is on an abstract class. Looking for a single concrete subclass...");
                     taxonClassInfo = findFirstSingleConcreteClass(taxonClassInfo, taxonClassInfo.directSubclasses());
@@ -253,7 +253,7 @@ public class MetaData {
         // replace with its single implementing class - iff exactly one implementing class exists
         ClassInfo classInfo = classInfoList.iterator().next();
         if (classInfo.isInterface()) {
-            classInfo = findSingleImplementor(classInfo.name());
+            classInfo = findSingleImplementor(classInfo);
         }
 
         // if we have a potential concrete class, keep going!
@@ -265,8 +265,7 @@ public class MetaData {
         return classInfo != null && null != classInfo.annotationsInfo().get(RelationshipEntity.class);
     }
 
-    private ClassInfo findSingleImplementor(String taxon) {
-        ClassInfo interfaceInfo = domainInfo.getClassInfoForInterface(taxon);
+    private ClassInfo findSingleImplementor(ClassInfo interfaceInfo) {
         if (interfaceInfo != null && interfaceInfo.directImplementingClasses() != null
             && interfaceInfo.directImplementingClasses().size() == 1) {
             return interfaceInfo.directImplementingClasses().get(0);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/io/github/classgraph/issues/issue267/FakeRestartClassLoader.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/io/github/classgraph/issues/issue267/FakeRestartClassLoader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.classgraph.issues.issue267;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * This class loader would normally live under {@link org.neo4j.ogm.metadata.DomainInfoTest}, but ClassGraph removed
+ * the ability to add custom handlers. This one hooks into {@code nonapi.io.github.classgraph.classloaderhandler.ParentLastDelegationOrderTestClassLoaderHandler}.
+ * This is sadly rather fragile, but a) it is for a test and b) I'd rather have the test myself again (class graph already has the test),
+ * but I want to make sure it works in the context OGM indirectly via our domain info as well.
+ *
+ * @author Michael J. Simons
+ */
+public class FakeRestartClassLoader extends ClassLoader {
+
+    public static final String DOMAIN_CLASS_TESTED = "org.neo4j.ogm.domain.policy.Person";
+
+    private Class getClass(final String name) throws ClassNotFoundException {
+        try {
+            final byte[] b = loadClassFileData(name.replace('.', File.separatorChar) + ".class");
+            return defineClass(name, b, 0, b.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name);
+        }
+    }
+
+    @Override
+    public Class loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+        if (name.startsWith(DOMAIN_CLASS_TESTED) || name
+            .startsWith("org.neo4j.ogm.metadata.DomainInfoTestClassLoaderTestStub")) {
+            Class clazz = getClass(name);
+            if (resolve) {
+                resolveClass(clazz);
+            }
+        }
+        return super.loadClass(name, resolve);
+    }
+
+    private byte[] loadClassFileData(final String name) throws IOException {
+        try (final DataInputStream in = new DataInputStream(getClass().getClassLoader().getResourceAsStream(name))) {
+            int size = in.available();
+            byte buff[] = new byte[size];
+            in.readFully(buff);
+            return buff;
+        }
+    }
+
+    /**
+     * Don't remove, the handler calls this.
+     * @return
+     */
+    public String getClasspath() {
+        final String classfileName = DOMAIN_CLASS_TESTED.replace('.', '/') + ".class";
+        final URL classfileResource = getClass().getClassLoader().getResource(classfileName);
+        if (classfileResource == null) {
+            throw new IllegalArgumentException("Could not find classfile " + classfileName);
+        }
+        final String classfilePath = classfileResource.getFile();
+        final String packageRoot = classfilePath.substring(0, classfilePath.length() - classfileName.length() - 1);
+        return packageRoot;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/LabelsAnnotationWithWrongType.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/LabelsAnnotationWithWrongType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.metadata;
+
+import org.neo4j.ogm.annotation.Labels;
+
+/**
+ * @author Jasper Blues
+ * @author Michael J. Simons
+ */
+public class LabelsAnnotationWithWrongType {
+
+    /**
+     * The labels field must be applied to a type of collection.
+     */
+    @Labels
+    private String labels = "";
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/POJO.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/POJO.java
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.ogm.metadata;
+package org.neo4j.ogm.domain.metadata;
 
 import java.io.Serializable;
 import java.util.List;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/PersistableClass.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/PersistableClass.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.metadata;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Transient;
+import org.neo4j.ogm.domain.hierarchy.domain.trans.TransientSingleClass;
+
+/**
+ * @author Mark Angrish
+ * @author Luanne Misquitta
+ * @author Michael J. Simons
+ */
+@NodeEntity(label = "PersistableClass")
+public class PersistableClass {
+
+    private Long id;
+
+    @Transient
+    private transient String transientObject;
+
+    @Transient
+    private Integer chickenCounting;
+
+    public TransientSingleClass transientSingleClassField;
+
+    public String getTransientObject() {
+        return transientObject;
+    }
+
+    public void setTransientObject(String value) {
+        transientObject = value;
+    }
+
+    public TransientSingleClass getTransientSingleClass() {
+        return null;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/TransientClass.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/metadata/TransientClass.java
@@ -16,15 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.ogm.metadata;
+package org.neo4j.ogm.domain.metadata;
 
-import org.neo4j.ogm.annotation.Labels;
+import org.neo4j.ogm.annotation.Transient;
 
-public class LabelsAnnotationWithWrongTye {
+/**
+ * @author Mark Angrish
+ * @author Luanne Misquitta
+ * @author Michael J. Simons
+ */
+@Transient
+public class TransientClass {
 
-    /**
-     * The labels field must be applied to a type of collection.
-     */
-    @Labels
-    private String labels = new String();
+    private Long id;
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
@@ -38,6 +38,7 @@ import org.neo4j.ogm.domain.education.Student;
 import org.neo4j.ogm.domain.forum.Member;
 import org.neo4j.ogm.domain.forum.activity.Activity;
 import org.neo4j.ogm.domain.forum.activity.Post;
+import org.neo4j.ogm.domain.metadata.LabelsAnnotationWithWrongType;
 import org.neo4j.ogm.domain.pizza.Pizza;
 import org.neo4j.ogm.exception.core.InvalidPropertyFieldException;
 import org.neo4j.ogm.exception.core.MappingException;
@@ -55,7 +56,7 @@ public class ClassInfoTest {
     public void setUp() {
         metaData = new MetaData("org.neo4j.ogm.domain.forum",
             "org.neo4j.ogm.domain.pizza",
-            "org.neo4j.ogm.metadata",
+            "org.neo4j.ogm.domain.metadata",
             "org.neo4j.ogm.domain.canonical",
             "org.neo4j.ogm.domain.hierarchy.domain",
             "org.neo4j.ogm.domain.cineasts.partial",
@@ -371,10 +372,7 @@ public class ClassInfoTest {
         assertThat(nonAnnotatedClassInfo.staticLabels()).isEqualTo(asList("Student", "DomainObject"));
     }
 
-    /**
-     * @see issue #159
-     */
-    @Test
+    @Test // GH-159
     public void labelFieldOrNull() {
         ClassInfo classInfo = metaData.classInfo(Pizza.class.getSimpleName());
         FieldInfo fieldInfo = classInfo.labelFieldOrNull();
@@ -382,16 +380,13 @@ public class ClassInfoTest {
         assertThat(fieldInfo.getName()).isEqualTo("labels");
     }
 
-    /**
-     * @see issue #159
-     */
-    @Test
+    @Test // GH-159
     public void labelFieldOrNullThrowsMappingExceptionForInvalidType() {
         assertThatThrownBy(() -> {
-            LabelsAnnotationWithWrongTye entity = new LabelsAnnotationWithWrongTye();
+            LabelsAnnotationWithWrongType entity = new LabelsAnnotationWithWrongType();
             Collection<String> collatedLabels = EntityUtils.labels(entity, metaData);
         }).isInstanceOf(MappingException.class)
-            .hasMessage("Field 'labels' in class 'org.neo4j.ogm.metadata.LabelsAnnotationWithWrongTye' "
+            .hasMessage("Field 'labels' in class 'org.neo4j.ogm.domain.metadata.LabelsAnnotationWithWrongType' "
                 + "includes the @Labels annotation, however this field is not a type of collection.");
     }
 
@@ -430,19 +425,19 @@ public class ClassInfoTest {
         assertThat(fieldInfo.isScalar()).isTrue();
     }
 
-    @Test // see DATAGRAPH-615
+    @Test // DATAGRAPH-615
     public void testDefaultLabelOfNodeEntities() {
         ClassInfo classInfo = metaData.classInfo("Forum");
         assertThat(classInfo.neo4jName()).isEqualTo("Forum");
     }
 
-    @Test // see DATAGRAPH-615
+    @Test // DATAGRAPH-615
     public void testDefaultLabelOfRelationshipEntities() {
         ClassInfo classInfo = metaData.classInfo("Nomination");
         assertThat(classInfo.neo4jName()).isEqualTo("NOMINATION");
     }
 
-    @Test // see DATAGRAPH-690
+    @Test // DATAGRAPH-690
     public void testTypeParameterDescriptorForRelationships() {
         ClassInfo classInfo = metaData.classInfo("Topic");
         assertThat(classInfo.getTypeParameterDescriptorForRelationship("HAS_POSTS", OUTGOING)).isEqualTo(Post.class);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
@@ -20,6 +20,10 @@ package org.neo4j.ogm.metadata;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.github.classgraph.issues.issue267.FakeRestartClassLoader;
+
+import java.lang.reflect.Method;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,4 +66,53 @@ public class DomainInfoTest {
         assertThat(classInfo).isNotNull();
         assertThat(classInfo.interfacesInfo().list()).hasSize(1);
     }
+
+    @Test
+    public void shouldLoadClassesCorrectlyWithSimpleClassLoader() throws Exception {
+        final String classLoaderName = Thread.currentThread().getContextClassLoader().getClass().getSimpleName();
+        new DomainInfoTestClassLoaderTestStub().assertCorrectClassLoaders(classLoaderName, classLoaderName);
+    }
+
+    /**
+     * This recreates the behaviour of Spring Boots dev tools reloader.
+     * @throws Throwable
+     */
+    @Test
+    public void shouldLoadClassesCorrectlyWithParentLastClassLoader() throws Throwable {
+        final String classLoaderName = Thread.currentThread().getContextClassLoader().getClass().getSimpleName();
+        final TestLauncher launcher = new TestLauncher(classLoaderName);
+        launcher.start();
+        launcher.join();
+        if (launcher.error != null) {
+            throw launcher.error;
+        }
+    }
 }
+
+class TestLauncher extends Thread {
+
+    private final String parentClassLoader;
+
+    Throwable error;
+
+    TestLauncher(final String parentClassLoader) {
+        this.parentClassLoader = parentClassLoader;
+        setDaemon(false);
+        setContextClassLoader(new FakeRestartClassLoader());
+    }
+
+    @Override
+    public void run() {
+        try {
+            final Class<?> mainClass = getContextClassLoader()
+                .loadClass("org.neo4j.ogm.metadata.DomainInfoTestClassLoaderTestStub");
+            final Method mainMethod = mainClass
+                .getDeclaredMethod("assertCorrectClassLoaders", String.class, String.class);
+            mainMethod
+                .invoke(mainClass.getDeclaredConstructor().newInstance(), parentClassLoader, "FakeRestartClassLoader");
+        } catch (Throwable ex) {
+            error = ex;
+        }
+    }
+}
+

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTestClassLoaderTestStub.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTestClassLoaderTestStub.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.metadata;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.neo4j.ogm.domain.policy.Person;
+
+/**
+ * Stub to be run from within different threads, asserting loaded classes can be correctly assigned when
+ * reloading and "parent last" class loaders are in play.
+ * The code is basically the same as the one originally contributed to ClassGraph, but adapted having OGM indirection
+ * in between.
+ *
+ * @author Michael J. Simons
+ */
+public class DomainInfoTestClassLoaderTestStub {
+    public void assertCorrectClassLoaders(final String parentClassLoader, final String expectedClassLoader) {
+
+        Person a = new Person();
+        // Checking the precondition here: We forced our classloader onto "everything"
+        assertThat(DomainInfoTestClassLoaderTestStub.class.getClassLoader().getClass().getSimpleName())
+            .isEqualTo(expectedClassLoader);
+        assertThat(a.getClass().getClassLoader().getClass().getSimpleName()).isEqualTo(expectedClassLoader);
+
+        DomainInfo classGraph = DomainInfo.create("org.neo4j.ogm.domain.policy");
+
+        // ClassGraph is in that setup not part of the RestartClass loader. That one takes by default only
+        // URLs from the current project into consideration and can only be modified by adding additional
+        // directories, see https://github.com/spring-projects/spring-boot/issues/12869
+        assertThat(classGraph.getClass().getClassLoader().getClass().getSimpleName()).isEqualTo(parentClassLoader);
+
+        // Now use ClassGraph to find everything
+
+        ClassInfo classInfo = classGraph.getClass("org.neo4j.ogm.domain.policy.Person");
+
+        // And it should load it through the same class loader it found it with
+        Class<?> aClassLoadedThroughClassGraph = classInfo.getUnderlyingClass();
+        assertThat(aClassLoadedThroughClassGraph.getClassLoader().getClass().getSimpleName())
+            .isEqualTo(expectedClassLoader);
+        // and thus assignable
+        assertThat(a.getClass().isAssignableFrom(aClassLoadedThroughClassGraph));
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/GenericsFieldsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/GenericsFieldsTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.neo4j.ogm.domain.gh492.BaseUser;
+import org.neo4j.ogm.domain.metadata.POJO;
 
 /**
  * @author Vince Bickers
@@ -49,7 +50,7 @@ public class GenericsFieldsTest extends TestMetaDataTypeResolution {
 
     @Test
     public void testGenericSelfReference() {
-        checkField("next", "org.neo4j.ogm.metadata.POJO", POJO.class, null);
+        checkField("next", "org.neo4j.ogm.domain.metadata.POJO", POJO.class, null);
     }
 
     @Test // List<S>
@@ -59,7 +60,7 @@ public class GenericsFieldsTest extends TestMetaDataTypeResolution {
 
     @Test // List<POJO<S, T, U>> neighbours;
     public void testCollectionWithConcreteParameterizedType() {
-        checkField("neighbours", "org.neo4j.ogm.metadata.POJO", POJO.class, "java.util.List");
+        checkField("neighbours", "org.neo4j.ogm.domain.metadata.POJO", POJO.class, "java.util.List");
     }
 
     @Test // List<? extends Integer> superIntegers

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
@@ -20,14 +20,34 @@ package org.neo4j.ogm.metadata;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.ogm.exception.core.AmbiguousBaseClassException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class MetaDataTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataTest.class);
 
     private MetaData metaData;
 
@@ -72,20 +92,19 @@ public class MetaDataTest {
         metaData.resolve("Login", "Topic");
     }
 
-    @Test
     /**
      * Taxa corresponding to interfaces with multiple implementations can't be resolved
      */
+    @Test
     public void testInterfaceWithMultipleImplTaxa() {
         assertThat(metaData.resolve("IMembership")).isEqualTo(null);
     }
 
-    @Test
     /**
      * Taxa corresponding to interfaces with a single implementor can be resolved
-     *
-     * @see DATAGRAPH-577
+     * DATAGRAPH-577
      */
+    @Test
     public void testInterfaceWithSingleImplTaxa() {
         ClassInfo classInfo = metaData.resolve("AnnotatedInterfaceWithSingleImpl");
         assertThat(classInfo).isNotNull();
@@ -93,26 +112,26 @@ public class MetaDataTest {
             .isEqualTo("org.neo4j.ogm.domain.hierarchy.domain.annotated.AnnotatedChildWithAnnotatedInterface");
     }
 
-    @Test
     /**
      * Taxa corresponding to abstract classes can't be resolved
      */
+    @Test
     public void testAbstractClassTaxa() {
         assertThat(metaData.resolve("Membership")).isEqualTo(null);
     }
 
-    @Test(expected = AmbiguousBaseClassException.class)
     /**
      * Taxa not forming a class hierarchy cannot be resolved.
      */
+    @Test(expected = AmbiguousBaseClassException.class)
     public void testNoCommonLeafInTaxa() {
         metaData.resolve("Topic", "Member");
     }
 
-    @Test
     /**
      * The ordering of taxa is unimportant.
      */
+    @Test
     public void testOrderingOfTaxaIsUnimportant() {
         assertThat(metaData.resolve("Bronze", "Membership", "IMembership").name())
             .isEqualTo("org.neo4j.ogm.domain.forum.BronzeMembership");
@@ -128,10 +147,7 @@ public class MetaDataTest {
             .isEqualTo("org.neo4j.ogm.domain.forum.BronzeMembership");
     }
 
-    /**
-     * @see DATAGRAPH-634
-     */
-    @Test
+    @Test // DATAGRAPH-634
     public void testLiskovSubstitutionPrinciple() {
         assertThat(metaData.resolve("Member").name()).isEqualTo("org.neo4j.ogm.domain.forum.Member");
         assertThat(metaData.resolve("Login", "Member").name()).isEqualTo("org.neo4j.ogm.domain.forum.Member");
@@ -139,20 +155,188 @@ public class MetaDataTest {
         assertThat(metaData.resolve("Member", "Login").name()).isEqualTo("org.neo4j.ogm.domain.forum.Member");
     }
 
-    @Test
     /**
      * Taxa not in the domain will be ignored.
      */
+    @Test
     public void testAllNonMemberTaxa() {
         assertThat(metaData.resolve("Knight", "Baronet")).isNull();
     }
 
-    @Test
     /**
      * Mixing domain and non-domain taxa is permitted.
      */
+    @Test
     public void testNonMemberAndMemberTaxa() {
         assertThat(metaData.resolve("Silver", "Pewter", "Tin").name())
             .isEqualTo("org.neo4j.ogm.domain.forum.SilverMembership");
     }
+
+    /**
+     * Ensure that performance does not degrade with a huge number of domain classes.
+     */
+    @Test // GH-678
+    public void performanceSmokeTest() throws Exception {
+
+        // Compile numberOfDomainClasses classes
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        StandardJavaFileManager manager = compiler.getStandardFileManager(null, null, null);
+
+        String domainPackageName = this.getClass().getPackage().getName() + ".gh678";
+        Path tmpDir = Files.createTempDirectory("ogmTest");
+
+        int numberOfDomainClasses = 1_000;
+        List<CharSequenceJavaFileObject> files = new ArrayList<>();
+
+        final String defaultDummyNodeEntity = "DummyNodeEntity";
+        final String defaultDummyRelationshipEntity = "DummyRelationshipEntity";
+        for (int i = 0; i < numberOfDomainClasses; ++i) {
+            files.add(new CharSequenceJavaFileObject(domainPackageName + "." + defaultDummyNodeEntity + i,
+                NODE_ENTITY_DUMMY_TEMPLATE.replaceAll(defaultDummyNodeEntity, defaultDummyNodeEntity + i)));
+            if (i < numberOfDomainClasses - 1) {
+                files.add(
+                    new CharSequenceJavaFileObject(
+                        domainPackageName + "." + defaultDummyRelationshipEntity + i,
+                        RELATIONSHIP_ENTITY_DUMMY_TEMPLATE
+                            .replaceAll(defaultDummyRelationshipEntity, defaultDummyRelationshipEntity + i)
+                            .replaceAll("START", defaultDummyNodeEntity + i)
+                            .replaceAll("END", defaultDummyNodeEntity + (i + 1))
+                    )
+                );
+            }
+        }
+        compiler.getTask(null, manager, null, Arrays.asList("-d", tmpDir.toString()), null, files).call();
+
+        // Add the generated classes to our class loader
+        Thread currentThread = Thread.currentThread();
+        ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+
+        try {
+            URLClassLoader urlClassLoader = new URLClassLoader(new URL[] { tmpDir.toUri().toURL() },
+                currentThread.getContextClassLoader());
+            currentThread.setContextClassLoader(urlClassLoader);
+
+            long start = System.currentTimeMillis();
+            MetaData metaData = new MetaData(domainPackageName);
+            long duration = (System.currentTimeMillis() - start);
+            LOGGER.warn("Scanning took {}ms", duration);
+
+            for(int i = numberOfDomainClasses-2; i>=0; --i) {
+                start = System.currentTimeMillis();
+                ClassInfo classInfo = metaData.classInfo("DummyNodeEntity" + i);
+                duration = (System.currentTimeMillis() - start);
+                LOGGER.info("Retrieval of class info for {} took {}ms", classInfo.getUnderlyingClass().getSimpleName(), duration);
+
+                start = System.currentTimeMillis();
+                classInfo = metaData.classInfo("DummyRelationshipEntity" + i);
+                duration = (System.currentTimeMillis() - start);
+                LOGGER.info("Retrieval of class info for {} took {}ms", classInfo.getUnderlyingClass().getSimpleName(), duration);
+            }
+        } finally {
+            // Remove the modified class loader from the current thread
+            currentThread.setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    private static final class CharSequenceJavaFileObject
+        extends SimpleJavaFileObject {
+        final CharSequence content;
+
+        public CharSequenceJavaFileObject(
+            String className,
+            CharSequence content
+        ) {
+            super(URI.create(
+                "string:///"
+                    + className.replace('.', '/')
+                    + JavaFileObject.Kind.SOURCE.extension),
+                JavaFileObject.Kind.SOURCE);
+            this.content = content;
+        }
+
+        @Override
+        public CharSequence getCharContent(
+            boolean ignoreEncodingErrors
+        ) {
+            return content;
+        }
+    }
+
+    private final static String NODE_ENTITY_DUMMY_TEMPLATE = ""
+        + "package org.neo4j.ogm.metadata.gh678;\n\n"
+        + "import org.neo4j.ogm.annotation.GeneratedValue;\n"
+        + "import org.neo4j.ogm.annotation.Id;\n"
+        + "import org.neo4j.ogm.annotation.NodeEntity;\n"
+        + "import org.neo4j.ogm.annotation.Property;\n"
+        + "\n"
+        + "@NodeEntity\n"
+        + "public class DummyNodeEntity {\n"
+        + "\n"
+        + "    @Id @GeneratedValue\n"
+        + "    private Long id;\n"
+        + "\n"
+        + "    @Property(name = \"weirdo\")\n"
+        + "    private String a;\n"
+        + "\n"
+        + "    private String b;\n"
+        + "\n"
+        + "    private Double n;\n"
+        + "\n"
+        + "    private Long l;\n"
+        + "\n"
+        + "    public Long getId() {\n"
+        + "        return id;\n"
+        + "    }\n"
+        + "\n"
+        + "    public void setId(Long id) {\n"
+        + "        this.id = id;\n"
+        + "    }\n"
+        + "\n"
+        + "    public String getA() {\n"
+        + "        return a;\n"
+        + "    }\n"
+        + "\n"
+        + "    public void setA(String a) {\n"
+        + "        this.a = a;\n"
+        + "    }\n"
+        + "\n"
+        + "    public String getB() {\n"
+        + "        return b;\n"
+        + "    }\n"
+        + "\n"
+        + "    public void setB(String b) {\n"
+        + "        this.b = b;\n"
+        + "    }\n"
+        + "\n"
+        + "    public Double getN() {\n"
+        + "        return n;\n"
+        + "    }\n"
+        + "\n"
+        + "    public void setN(Double n) {\n"
+        + "        this.n = n;\n"
+        + "    }\n"
+        + "\n"
+        + "    public Long getL() {\n"
+        + "        return l;\n"
+        + "    }\n"
+        + "\n"
+        + "    public void setL(Long l) {\n"
+        + "        this.l = l;\n"
+        + "    }\n"
+        + "}\n";
+
+    private static final String RELATIONSHIP_ENTITY_DUMMY_TEMPLATE = ""
+        + "package org.neo4j.ogm.metadata.gh678;\n\n"
+        + "import org.neo4j.ogm.annotation.RelationshipEntity;\n"
+        + "import org.neo4j.ogm.annotation.EndNode;\n"
+        + "import org.neo4j.ogm.annotation.StartNode;\n"
+        + "\n"
+        + "@RelationshipEntity\n"
+        + "public class DummyRelationshipEntity {\n"
+        + "    @StartNode\n"
+        + "    private START startNode;\n"
+        + "    \n"
+        + "    @EndNode\n"
+        + "    private END endNode;"
+        + "};";
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
@@ -53,7 +53,7 @@ public class MetaDataTest {
 
     @Before
     public void setUp() {
-        metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.pizza", "org.neo4j.ogm.metadata",
+        metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.pizza",
             "org.neo4j.ogm.domain.canonical", "org.neo4j.ogm.domain.hierarchy.domain");
     }
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/TestMetaDataTypeResolution.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/TestMetaDataTypeResolution.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class TestMetaDataTypeResolution {
 
-    private MetaData metaData = new MetaData("org.neo4j.ogm.metadata");
+    private MetaData metaData = new MetaData("org.neo4j.ogm.domain.metadata");
 
     public void checkField(String name, String expectedDescriptor, Class expectedPersistableType) {
         this.checkField(name, expectedDescriptor, expectedPersistableType, null);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/TransientObjectsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/TransientObjectsTest.java
@@ -29,6 +29,7 @@ import org.neo4j.ogm.domain.hierarchy.domain.trans.TransientSingleClass;
 /**
  * @author Mark Angrish
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class TransientObjectsTest {
 
@@ -36,7 +37,7 @@ public class TransientObjectsTest {
 
     @Before
     public void setUp() {
-        metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.pizza", "org.neo4j.ogm.metadata",
+        metaData = new MetaData("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.pizza", "org.neo4j.ogm.domain.metadata",
             "org.neo4j.ogm.domain.canonical", "org.neo4j.ogm.domain.hierarchy.domain",
             "org.neo4j.ogm.domain.cineasts.annotated");
     }
@@ -74,35 +75,4 @@ public class TransientObjectsTest {
         }
     }
 
-    @NodeEntity(label = "PersistableClass")
-    public class PersistableClass {
-
-        private Long id;
-
-        @Transient
-        private transient String transientObject;
-
-        @Transient
-        private Integer chickenCounting;
-
-        public TransientSingleClass transientSingleClassField;
-
-        public String getTransientObject() {
-            return transientObject;
-        }
-
-        public void setTransientObject(String value) {
-            transientObject = value;
-        }
-
-        public TransientSingleClass getTransientSingleClass() {
-            return null;
-        }
-    }
-
-    @Transient
-    public class TransientClass {
-
-        private Long id;
-    }
 }


### PR DESCRIPTION
This PR now uses ClassGraph’s build in class loading mechanismn to load the scanned classes in one go, without first mapping them to strings and than loading them.

While ClassGraph has tests ins place (we added them originally) to verify that this works with Spring Boots restart class loaded, I have added the tests adapted to OGM as well.

Furthermore, this commit optimizes the cache of annotated classes, similar like suggested in the original issue, so that classes don’t need to be iterated over and over again. There’s a test for it to ensure scanning with 1000 domain classes runs in reasonable time.

The caching in MetaData has been removed alltogether, as it doesn’t add performance benefits but only increases memory pressure.

@digitalillusion Please checkout if that improves the situation for you.