### PR TITLE
GH-685 - Add support for Kotlin’s „implementation by delegation“.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -23,7 +23,6 @@ import static org.neo4j.ogm.annotation.Relationship.*;
 import static org.neo4j.ogm.metadata.reflect.EntityAccessManager.*;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -193,20 +192,18 @@ public class GraphEntityMapper {
 
         ClassInfo classInfo = metadata.classInfo(instance);
         MethodInfo postLoadMethod = classInfo.postLoadMethodOrNull();
-        if (postLoadMethod != null) {
-            final Method method = classInfo.getMethod(postLoadMethod);
-            try {
-                if (!method.isAccessible()) {
-                    method.setAccessible(true);
-                }
-                method.invoke(instance);
-            } catch (SecurityException e) {
-                logger.warn("Cannot call PostLoad annotated method {} on class {}, "
-                    + "security manager denied access.", method.getName(), classInfo.name(), e);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                logger.warn("Cannot call PostLoad annotated method {} on class {}. "
-                    + "Make sure it is public and has no arguments", method.getName(), classInfo.name(), e);
-            }
+        if (postLoadMethod == null) {
+            return;
+        }
+
+        try {
+            postLoadMethod.invoke(instance);
+        } catch (SecurityException e) {
+            logger.warn("Cannot call PostLoad annotated method {} on class {}, "
+                + "security manager denied access.", postLoadMethod.getMethod().getName(), classInfo.name(), e);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            logger.warn("Cannot call PostLoad annotated method {} on class {}. "
+                + "Make sure it is public and has no arguments", postLoadMethod.getMethod().getName(), classInfo.name(), e);
         }
     }
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldInfo.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.ogm.metadata;
 
+import static org.neo4j.ogm.metadata.ClassInfo.*;
 import static org.neo4j.ogm.metadata.reflect.GenericUtils.*;
 
 import java.lang.reflect.Field;
@@ -62,6 +63,10 @@ public class FieldInfo {
     private final boolean isArray;
     private final boolean isSupportedNativeType;
     private final ClassInfo containingClassInfo;
+    /**
+     * Optional field holding a delegate, from which this method was derived.
+     */
+    private final Field delegateHolder;
     private final Field field;
     private final Class<?> fieldType;
     /**
@@ -81,9 +86,10 @@ public class FieldInfo {
      *                                if that's not appropriate
      * @param annotations             The {@link ObjectAnnotations} applied to the field
      */
-    public FieldInfo(ClassInfo classInfo, Field field, String typeParameterDescriptor, ObjectAnnotations annotations,
+    FieldInfo(ClassInfo classInfo, Field delegateHolder, Field field, String typeParameterDescriptor, ObjectAnnotations annotations,
         Predicate<Class<?>> isSupportedNativeType) {
         this.containingClassInfo = classInfo;
+        this.delegateHolder = delegateHolder;
         this.field = field;
         this.fieldType = isGenericField(field) ? findFieldType(field, classInfo.getUnderlyingClass()) : field.getType();
         this.isArray = fieldType.isArray();
@@ -364,14 +370,14 @@ public class FieldInfo {
 
         if (hasPropertyConverter()) {
             value = getPropertyConverter().toEntityAttribute(value);
-            write(field, instance, value);
         } else {
             if (isScalar()) {
                 String actualTypeDescriptor = getTypeDescriptor();
                 value = Utils.coerceTypes(DescriptorMappings.getType(actualTypeDescriptor), value);
             }
-            write(field, instance, value);
         }
+
+        write(field, getInstanceOrDelegate(instance, delegateHolder), value);
     }
 
     /**
@@ -405,7 +411,7 @@ public class FieldInfo {
     }
 
     public Object read(Object instance) {
-        return read(containingClassInfo.getField(this), instance);
+        return read(containingClassInfo.getField(this), getInstanceOrDelegate(instance, delegateHolder));
     }
 
     public Object readProperty(Object instance) {
@@ -413,7 +419,7 @@ public class FieldInfo {
             throw new IllegalStateException(
                 "The readComposite method should be used for fields with a CompositeAttributeConverter");
         }
-        Object value = read(containingClassInfo.getField(this), instance);
+        Object value = read(containingClassInfo.getField(this), getInstanceOrDelegate(instance, delegateHolder));
         if (hasPropertyConverter()) {
             value = getPropertyConverter().toGraphProperty(value);
         }
@@ -425,7 +431,7 @@ public class FieldInfo {
             throw new IllegalStateException(
                 "readComposite should only be used when a field is annotated with a CompositeAttributeConverter");
         }
-        Object value = read(containingClassInfo.getField(this), instance);
+        Object value = read(containingClassInfo.getField(this), getInstanceOrDelegate(instance, delegateHolder));
         return getCompositeConverter().toGraphProperties(value);
     }
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/FieldsInfo.java
@@ -49,7 +49,7 @@ public class FieldsInfo {
         this.fields = new HashMap<>();
     }
 
-    FieldsInfo(ClassInfo classInfo, Class<?> clazz, TypeSystem typeSystem) {
+    FieldsInfo(ClassInfo classInfo, Class<?> clazz, Field delegateHolder, TypeSystem typeSystem) {
         this.fields = new HashMap<>();
 
         // Fields influenced by this class are all all declared fields plus
@@ -69,7 +69,7 @@ public class FieldsInfo {
 
                     String typeParameterDescriptor = findTypeParameterDescriptor(field, clazz, objectAnnotations);
                     fields.put(field.getName(),
-                        new FieldInfo(classInfo, field, typeParameterDescriptor, objectAnnotations,
+                        new FieldInfo(classInfo, delegateHolder, field, typeParameterDescriptor, objectAnnotations,
                             typeSystem::supportsAsNativeType));
                 }
             }

--- a/core/src/main/java/org/neo4j/ogm/metadata/MethodsInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MethodsInfo.java
@@ -20,6 +20,7 @@ package org.neo4j.ogm.metadata;
 
 import static java.util.stream.Collectors.*;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -41,14 +42,14 @@ public class MethodsInfo {
         this.methods = new HashSet<>();
     }
 
-    public MethodsInfo(Class<?> cls) {
+    MethodsInfo(Class<?> cls, Field delegateHolder) {
         this.methods = new HashSet<>();
 
         Class<?> currentClass = cls;
         do {
             Set<MethodInfo> methodInfoOfCurrentClass = Arrays.stream(currentClass.getDeclaredMethods()) //
                 .filter(MethodsInfo::includeMethod) //
-                .map(MethodInfo::of) //
+                .map(method -> MethodInfo.of(method, delegateHolder)) //
                 .collect(toSet());
 
             // Prioritize annotated methods from concrete classes respectively classes lower in the hierarchy.

--- a/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/extension/OgmPluginInitializer.java
+++ b/embedded-driver/src/main/java/org/neo4j/ogm/drivers/embedded/extension/OgmPluginInitializer.java
@@ -40,7 +40,7 @@ import org.neo4j.server.plugins.PluginLifecycle;
  *
  * @author Frantisek Hartman
  * @since 3.0
- * @deprecated 3.2.0 this class implements the {@code PluginLifecycle} that is part of the Neo4j server plugins.
+ * @deprecated since 3.2.0 this class implements the {@code PluginLifecycle} that is part of the Neo4j server plugins.
  * Those plugins are also deprecated for removal in future releases.
  * If you plan to use this in an unmanaged extension in the future, please create the Neo4j-OGM embedded driver manually
  * within your extension.

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaA.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaA.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh685;
+
+/**
+ * @author Michael J. Simons
+ */
+public interface JavaA {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaAImpl.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaAImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh685;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity(label = "A")
+public class JavaAImpl extends JavaBaseImpl implements JavaA {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String ownAttr;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaBase.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaBase.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh685;
+
+/**
+ * @author Michael J. Simons
+ */
+public interface JavaBase {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaBaseImpl.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh685/JavaBaseImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh685;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.PostLoad;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity(label = "Base")
+public class JavaBaseImpl {
+
+    private String baseName;
+
+    @PostLoad
+    public void doPostLoad() {
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/delegation/Gh685.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/delegation/Gh685.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.delegation
+
+import org.neo4j.ogm.annotation.GeneratedValue
+import org.neo4j.ogm.annotation.Id
+import org.neo4j.ogm.annotation.NodeEntity
+import org.neo4j.ogm.annotation.PostLoad
+
+interface KotlinBase {
+    var baseName: String?
+
+    fun bar();
+}
+
+interface KotlinA : KotlinBase {
+    var ownAttr: String?
+}
+
+@NodeEntity(label = "Base")
+class KotlinBaseImpl : KotlinBase {
+    @Id
+    @GeneratedValue
+    val id: Long? = null
+
+    override var baseName: String? = null
+
+    @PostLoad
+    override fun bar() {
+        baseName = "someValue"
+    }
+}
+
+@NodeEntity(label = "A")
+class KotlinAImpl : KotlinA, KotlinBase by KotlinBaseImpl() {
+    @Id
+    @GeneratedValue
+    val id: Long? = null
+
+    override var ownAttr: String? = null
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/kotlin/KotlinMetaDataTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/kotlin/KotlinMetaDataTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.neo4j.ogm.domain.delegation.KotlinAImpl
+import org.neo4j.ogm.metadata.MetaData
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Die Toten Hosen - Kauf MICH!
+ */
+class KotlinMetaDataTest {
+
+    @Test // GH-685
+    fun `Kotlin's "implementation by delegation" should yield same result as Java equivalent`() {
+        val metaData = MetaData("org.neo4j.ogm.domain.gh685", "org.neo4j.ogm.domain.delegation")
+
+        val javaClassInfo = metaData.classInfo("JavaAImpl")
+        assertThat<String>(javaClassInfo.staticLabels()).containsExactlyInAnyOrder("Base", "A")
+        val javaFields = javaClassInfo.fieldsInfo().fields().map { it.name }
+        assertThat<String>(javaFields).containsExactlyInAnyOrder("id", "ownAttr", "baseName")
+        assertThat(javaClassInfo.postLoadMethodOrNull()).isNotNull
+
+        val kotlinClassInfo = metaData.classInfo("KotlinAImpl")
+
+        assertThat<String>(kotlinClassInfo.staticLabels()).containsExactlyInAnyOrderElementsOf(javaClassInfo.staticLabels())
+        assertThat<String>(kotlinClassInfo.fieldsInfo().fields().stream().map { it.name })
+                .containsExactlyInAnyOrderElementsOf(javaFields)
+        assertThat(kotlinClassInfo.postLoadMethodOrNull()).isNotNull
+
+        val aKotlinClass = KotlinAImpl()
+        val baseNameField = kotlinClassInfo.getFieldInfo("baseName")
+
+        baseNameField.write(aKotlinClass, "something")
+        assertThat(aKotlinClass.baseName).isEqualTo("something")
+
+        aKotlinClass.baseName = "somethingElse"
+        assertThat(baseNameField.read(aKotlinClass)).isEqualTo("somethingElse")
+    }
+}


### PR DESCRIPTION
By keeping an optional field around that may hold access to the delegate object synthesized by the Kotlin compiler, we can support Kotlins implementation by delegation with relative ease.

This closes #685.