### PR TITLE
GH-693 - Deprecate public `Utils.size`.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/Utils.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Utils.java
@@ -40,6 +40,12 @@ public class Utils {
         return newMap;
     }
 
+    /**
+     * @param iterable The iterable who's size should be determined.
+     * @return The size of the iterable.
+     * @deprecated Since 3.2.3, no replacement.
+     */
+    @Deprecated
     public static int size(Iterable<?> iterable) {
         return (iterable instanceof Collection)
             ? ((Collection<?>) iterable).size()


### PR DESCRIPTION
This is used only in one place, which can now avoid iterating the iterable two times.

This closes #693.