### PR TITLE
GH-345 - Decouple filter and filter functions.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/ComparisonOperator.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/ComparisonOperator.java
@@ -18,12 +18,17 @@
  */
 package org.neo4j.ogm.cypher;
 
+import java.util.EnumSet;
+
+import org.neo4j.ogm.cypher.function.PropertyComparison;
+
 /**
  * Comparison operators used in queries.
  *
  * @author Luanne Misquitta
  * @author Adam George
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
 public enum ComparisonOperator {
     EQUALS("="),
@@ -54,22 +59,25 @@ public enum ComparisonOperator {
     }
 
     /**
+     * Creates a new property comparision with this operator.
+     *
+     * @param possiblePropertyValue        The possiblePropertyValue to compare
+     * @return A functional comparision
+     */
+    PropertyComparison compare(Object possiblePropertyValue) {
+        if (possiblePropertyValue == null && !EnumSet.of(EXISTS, IS_TRUE, IS_NULL).contains(this)) {
+            throw new RuntimeException(
+                "A null possiblePropertyValue can only be used with unary comparison operators (EXISTS, IS_TRUE and IS_NULL)");
+        }
+
+        return new PropertyComparison(this, possiblePropertyValue);
+    }
+
+    /**
      * @return The textual comparison operator to use in the Cypher query
      */
     public String getValue() {
         return value;
-    }
-
-    /**
-     *
-     */
-    public boolean isOneOf(ComparisonOperator... these) {
-        for (ComparisonOperator candidate : these) {
-            if (this.equals(candidate)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -78,5 +86,4 @@ public enum ComparisonOperator {
     public PropertyValueTransformer getPropertyValueTransformer() {
         return valueTransformer;
     }
-
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
@@ -342,7 +342,8 @@ public class Filter implements FilterWithRelationship {
     private String uniqueParameterName(String originalName) {
 
         // We should maybe include the original name here as well. This changes the generated queries,
-        // but would prevent bugs with multiple filters of the same type.
+        // but would prevent bugs with multiple filters of the same type or filter functions using
+        // more than one parameter (as {@link org.neo4j.ogm.cypher.function.NativeDistanceComparison} currently does)
         String format = "%2$d";
 
         if (isNested()) {

--- a/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/Filter.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.function.UnaryOperator;
 
 import org.neo4j.ogm.cypher.function.DistanceComparison;
 import org.neo4j.ogm.cypher.function.FilterFunction;
@@ -198,9 +197,8 @@ public class Filter implements FilterWithRelationship {
                         CONTAINING.name())
                 );
             }
-            FilterFunction caseInsensitiveFilter = new CaseInsensitiveEqualsComparison(
+            this.function = new PropertyComparison.CaseInsensitiveEqualsComparison(
                 propertyComparision.getOperator(), propertyComparision.getValue());
-            this.function = caseInsensitiveFilter;
             return this;
         }
     }
@@ -413,19 +411,4 @@ public class Filter implements FilterWithRelationship {
         return String.format("NOT(%s) ", expression);
     }
 
-    /**
-     * Internal class for modifying an EQUALS or CONTAINS comparison to ignore the case of both attribute and parameter.
-     */
-    static final class CaseInsensitiveEqualsComparison extends PropertyComparison {
-        CaseInsensitiveEqualsComparison(ComparisonOperator operator, Object value) {
-            super(operator, value);
-        }
-
-        @Override
-        public String expression(final String nodeIdentifier, String filteredProperty,
-            UnaryOperator<String> createUniqueParameterName) {
-            return String.format("toLower(%s.`%s`) %s toLower({ `%s` }) ", nodeIdentifier, filteredProperty,
-                operator.getValue(), createUniqueParameterName.apply(PARAMETER_NAME));
-        }
-    }
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/PropertyValueTransformer.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/PropertyValueTransformer.java
@@ -23,7 +23,9 @@ package org.neo4j.ogm.cypher;
  * when building a Cypher query.
  *
  * @author Adam George
+ * @author Michael J. Simons
  */
+@FunctionalInterface
 public interface PropertyValueTransformer {
 
     /**
@@ -34,4 +36,16 @@ public interface PropertyValueTransformer {
      * @return The transformed property value or <code>null</code> if invoked with <code>null</code>
      */
     Object transformPropertyValue(Object propertyValue);
+
+    /**
+     * Applies this transformer first, then {@literal after} as the next transformation.
+     *
+     * @param after The next transformation.
+     * @return A new property value transformer.
+     */
+    default PropertyValueTransformer andThen(PropertyValueTransformer after) {
+
+        return (t) -> after.transformPropertyValue(this.transformPropertyValue(t));
+    }
+
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/FilterFunction.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/FilterFunction.java
@@ -19,21 +19,19 @@
 package org.neo4j.ogm.cypher.function;
 
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
-import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.PropertyValueTransformer;
 
 /**
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
 public interface FilterFunction<T> {
 
-    Filter getFilter();
-
-    void setFilter(Filter filter);
-
     T getValue();
 
-    String expression(String nodeIdentifier);
+    String expression(String nodeIdentifier, String filteredProperty, UnaryOperator<String> createUniqueParameterName);
 
-    Map<String, Object> parameters();
+    Map<String, Object> parameters(UnaryOperator<String> createUniqueParameterName, PropertyValueTransformer valueTransformer);
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/FilterFunction.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/FilterFunction.java
@@ -31,7 +31,20 @@ public interface FilterFunction<T> {
 
     T getValue();
 
+    /**
+     * Generates a cypher expression for this function
+     * @param nodeIdentifier The identifier of the node to be filtered in the query
+     * @param filteredProperty The identifier of the filtered property
+     * @param createUniqueParameterName An operator to create unique parameter names, the same as in {@link #parameters(UnaryOperator, PropertyValueTransformer)}
+     * @return The fragment to use
+     */
     String expression(String nodeIdentifier, String filteredProperty, UnaryOperator<String> createUniqueParameterName);
 
+    /**
+     * Provides the map of parameters to use. It is advised to use the provided operator for creating unique parameter names
+     * @param createUniqueParameterName An operator to create unique parameter names
+     * @param valueTransformer Transformer for adapting possible values to the domain
+     * @return The map of parameters
+     */
     Map<String, Object> parameters(UnaryOperator<String> createUniqueParameterName, PropertyValueTransformer valueTransformer);
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
@@ -43,7 +43,12 @@ public class NativeDistanceComparison implements FilterFunction<DistanceFromNati
     }
 
     public static NativeDistanceComparison distanceComparisonFor(DistanceFromNativePoint distanceFromNativePoint) {
-        return new NativeDistanceComparison(ComparisonOperator.LESS_THAN, distanceFromNativePoint);
+        return distanceComparisonFor(ComparisonOperator.LESS_THAN, distanceFromNativePoint);
+    }
+
+    public static NativeDistanceComparison distanceComparisonFor(ComparisonOperator operator,
+        DistanceFromNativePoint distanceFromNativePoint) {
+        return new NativeDistanceComparison(operator, distanceFromNativePoint);
     }
 
     @Override
@@ -60,8 +65,7 @@ public class NativeDistanceComparison implements FilterFunction<DistanceFromNati
 
         return String.format(
             "distance({%s},%s) %s {%s} ",
-            createUniqueParameterName.apply(OGM_POINT_PARAMETER), pointPropertyOfEntity, comparisonOperator,
-            createUniqueParameterName.apply(DISTANCE_VALUE_PARAMETER));
+            OGM_POINT_PARAMETER, pointPropertyOfEntity, comparisonOperator, DISTANCE_VALUE_PARAMETER);
     }
 
     @Override
@@ -69,8 +73,8 @@ public class NativeDistanceComparison implements FilterFunction<DistanceFromNati
 
         Map<String, Object> map = new HashMap<>();
 
-        map.put(createUniqueParameterName.apply(OGM_POINT_PARAMETER), distanceFromNativePoint.getPoint());
-        map.put(createUniqueParameterName.apply(DISTANCE_VALUE_PARAMETER), distanceFromNativePoint.getDistance());
+        map.put(OGM_POINT_PARAMETER, distanceFromNativePoint.getPoint());
+        map.put(DISTANCE_VALUE_PARAMETER, distanceFromNativePoint.getDistance());
         return map;
 
     }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
@@ -20,32 +20,30 @@ package org.neo4j.ogm.cypher.function;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
-import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.PropertyValueTransformer;
 
+/**
+ * @author Gerrit Meier
+ * @author Michael J. Simons
+ */
 public class NativeDistanceComparison implements FilterFunction<DistanceFromNativePoint> {
 
     private static final String DISTANCE_VALUE_PARAMETER = "distanceValue";
     private static final String OGM_POINT_PARAMETER = "ogmPoint";
-    private final DistanceFromNativePoint distanceFromNativePoint;
-    private Filter filter;
 
-    private NativeDistanceComparison(DistanceFromNativePoint distanceFromNativePoint) {
+    protected final ComparisonOperator operator;
+    protected final DistanceFromNativePoint distanceFromNativePoint;
+
+    private NativeDistanceComparison(ComparisonOperator operator, DistanceFromNativePoint distanceFromNativePoint) {
+        this.operator = operator;
         this.distanceFromNativePoint = distanceFromNativePoint;
     }
 
     public static NativeDistanceComparison distanceComparisonFor(DistanceFromNativePoint distanceFromNativePoint) {
-        return new NativeDistanceComparison(distanceFromNativePoint);
-    }
-
-    @Override
-    public Filter getFilter() {
-        return filter;
-    }
-
-    @Override
-    public void setFilter(Filter filter) {
-        this.filter = filter;
+        return new NativeDistanceComparison(ComparisonOperator.LESS_THAN, distanceFromNativePoint);
     }
 
     @Override
@@ -54,23 +52,25 @@ public class NativeDistanceComparison implements FilterFunction<DistanceFromNati
     }
 
     @Override
-    public String expression(String nodeIdentifier) {
+    public String expression(String nodeIdentifier, String filteredProperty,
+        UnaryOperator<String> createUniqueParameterName) {
 
-        String pointPropertyOfEntity = nodeIdentifier + "." + getFilter().getPropertyName();
-        String comparisonOperator = getFilter().getComparisonOperator().getValue();
+        String pointPropertyOfEntity = nodeIdentifier + "." + filteredProperty;
+        String comparisonOperator = operator.getValue();
 
         return String.format(
             "distance({%s},%s) %s {%s} ",
-            OGM_POINT_PARAMETER, pointPropertyOfEntity, comparisonOperator, DISTANCE_VALUE_PARAMETER);
+            createUniqueParameterName.apply(OGM_POINT_PARAMETER), pointPropertyOfEntity, comparisonOperator,
+            createUniqueParameterName.apply(DISTANCE_VALUE_PARAMETER));
     }
 
     @Override
-    public Map<String, Object> parameters() {
+    public Map<String, Object> parameters(UnaryOperator<String> createUniqueParameterName, PropertyValueTransformer valueTransformer) {
 
         Map<String, Object> map = new HashMap<>();
 
-        map.put(OGM_POINT_PARAMETER, distanceFromNativePoint.getPoint());
-        map.put(DISTANCE_VALUE_PARAMETER, distanceFromNativePoint.getDistance());
+        map.put(createUniqueParameterName.apply(OGM_POINT_PARAMETER), distanceFromNativePoint.getPoint());
+        map.put(createUniqueParameterName.apply(DISTANCE_VALUE_PARAMETER), distanceFromNativePoint.getDistance());
         return map;
 
     }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/PropertyComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/PropertyComparison.java
@@ -80,4 +80,20 @@ public class PropertyComparison implements FilterFunction<Object> {
                     .transformPropertyValue(this.value));
         }
     }
+
+    /**
+     * Internal class for modifying an EQUALS or CONTAINS comparison to ignore the case of both attribute and parameter.
+     */
+    public static final class CaseInsensitiveEqualsComparison extends PropertyComparison {
+        public CaseInsensitiveEqualsComparison(ComparisonOperator operator, Object value) {
+            super(operator, value);
+        }
+
+        @Override
+        public String expression(final String nodeIdentifier, String filteredProperty,
+            UnaryOperator<String> createUniqueParameterName) {
+            return String.format("toLower(%s.`%s`) %s toLower({ `%s` }) ", nodeIdentifier, filteredProperty,
+                operator.getValue(), createUniqueParameterName.apply(PARAMETER_NAME));
+        }
+    }
 }

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
@@ -37,6 +37,7 @@ import org.neo4j.ogm.utils.RelationshipUtils;
 
 /**
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 abstract class SessionDelegate {
 
@@ -62,7 +63,6 @@ abstract class SessionDelegate {
             FieldInfo fieldInfo = classInfo.getFieldInfo(filter.getPropertyName());
             if (fieldInfo != null) {
                 filter.setPropertyConverter(fieldInfo.getPropertyConverter());
-                filter.setCompositeConverter(fieldInfo.getCompositeConverter());
             }
 
             if (filter.isNested()) {

--- a/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
@@ -160,7 +160,7 @@ public class FilteredQueryBuilder {
         Map<String, Object> properties) {
         for (Filter filter : filters) {
             query.append(filter.toCypher(nodeIdentifier, false));
-            properties.putAll(filter.getFunction().parameters());
+            properties.putAll(filter.parameters());
         }
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/FilterTest.java
@@ -21,6 +21,7 @@ package org.neo4j.ogm.cypher;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -45,6 +46,7 @@ public class FilterTest {
         Filter filter = new Filter("moons", ComparisonOperator.LESS_THAN, 23);
         filter.setBooleanOperator(BooleanOperator.AND);
         assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`moons` < { `moons_0` } ");
+        assertThat(filter.parameters()).containsEntry("moons_0", 23);
     }
 
     @Test
@@ -56,6 +58,11 @@ public class FilterTest {
         assertThat(filter.toCypher("n", true))
             .isEqualTo(
                 "WHERE NOT(distance(point({latitude: n.latitude, longitude: n.longitude}),point({latitude:{lat}, longitude:{lon}})) < {distance} ) ");
+
+        Map<String, Object> parameters = filter.parameters();
+        assertThat(parameters).containsEntry("lat", 37.4);
+        assertThat(parameters).containsEntry("lon", 112.1);
+        assertThat(parameters).containsEntry("distance", 1000.0);
     }
 
     @Test
@@ -119,7 +126,6 @@ public class FilterTest {
     public void equalComparisionShouldWork() {
         final String value = "someOtherThing";
         Filter filter = new Filter("thing", ComparisonOperator.EQUALS, value);
-        filter.setFunction(new PropertyComparison(value));
         assertThat(filter.toCypher("n", true)).isEqualTo("WHERE n.`thing` = { `thing_0` } ");
 
         filter = new Filter("thing", ComparisonOperator.EQUALS, value);

--- a/neo4j-ogm-tests/neo4j-ogm-native-types-tests/src/test/java/org/neo4j/ogm/persistence/types/nativetypes/filter/DistanceComparisonTestBase.java
+++ b/neo4j-ogm-tests/neo4j-ogm-native-types-tests/src/test/java/org/neo4j/ogm/persistence/types/nativetypes/filter/DistanceComparisonTestBase.java
@@ -35,6 +35,10 @@ import org.neo4j.ogm.types.spatial.CartesianPoint3d;
 import org.neo4j.ogm.types.spatial.GeographicPoint2d;
 import org.neo4j.ogm.types.spatial.GeographicPoint3d;
 
+/**
+ * @author Gerrit Meier
+ * @author Michael J. Simons
+ */
 abstract class DistanceComparisonTestBase {
 
     static SessionFactory sessionFactory;
@@ -48,8 +52,7 @@ abstract class DistanceComparisonTestBase {
         session.save(spatial);
 
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(new CartesianPoint2d(2, 2), 2);
-        Filter filter = new Filter("cartesianPoint2d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("cartesianPoint2d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -66,8 +69,7 @@ abstract class DistanceComparisonTestBase {
         session.save(spatial);
 
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(new CartesianPoint2d(2, 2), 1);
-        Filter filter = new Filter("cartesianPoint2d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("cartesianPoint2d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -84,8 +86,7 @@ abstract class DistanceComparisonTestBase {
         session.save(spatial);
 
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(new CartesianPoint3d(2, 2, 3), 2);
-        Filter filter = new Filter("cartesianPoint3d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("cartesianPoint3d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -102,8 +103,7 @@ abstract class DistanceComparisonTestBase {
         session.save(spatial);
 
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(new CartesianPoint3d(2, 2, 3), 1);
-        Filter filter = new Filter("cartesianPoint3d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("cartesianPoint3d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -122,8 +122,7 @@ abstract class DistanceComparisonTestBase {
 
         GeographicPoint2d office = new GeographicPoint2d(55.611851, 12.9949028);
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(office, 449);
-        Filter filter = new Filter("geographicPoint2d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("geographicPoint2d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -142,8 +141,7 @@ abstract class DistanceComparisonTestBase {
 
         GeographicPoint2d office = new GeographicPoint2d(55.611851, 12.9949028);
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(office, 448);
-        Filter filter = new Filter("geographicPoint2d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("geographicPoint2d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -162,8 +160,7 @@ abstract class DistanceComparisonTestBase {
 
         GeographicPoint3d office = new GeographicPoint3d(55.611851, 12.9949028, 15);
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(office, 448.9591);
-        Filter filter = new Filter("geographicPoint3d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("geographicPoint3d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);
@@ -182,8 +179,7 @@ abstract class DistanceComparisonTestBase {
 
         GeographicPoint3d office = new GeographicPoint3d(55.611851, 12.9949028, 15);
         DistanceFromNativePoint distanceFromNativePoint = new DistanceFromNativePoint(office, 448.950);
-        Filter filter = new Filter("geographicPoint3d", distanceComparisonFor(distanceFromNativePoint),
-            ComparisonOperator.LESS_THAN);
+        Filter filter = new Filter("geographicPoint3d", distanceComparisonFor(distanceFromNativePoint));
         filter.setOwnerEntityType(SomethingSpatial.class);
 
         Collection<SomethingSpatial> somethingSpatials = session.loadAll(SomethingSpatial.class, filter);


### PR DESCRIPTION
_NOTE_ A separate PR deprecating things in 3.2. will follow.

This removes the tight coupling of filters and filter functions. The property name that is filtered will now be injected into the filter function and so will be an operator to generate a unique parameter name. This will break API for users running their own filter functions, but make things a lot simpelr in the future.

Also, the API of the filter has been reduced, so that is now clearer which constructor to use.