### PR TITLE
GH-613 - Fix incomplete removal of stale relationships and nodes from context.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -222,7 +222,7 @@ public class EntityGraphMapper implements EntityMapper {
 
         do {
             // Remove all nodes that are not isolated (that is only in one relationship)
-            // Don't do this as a filter, as this list is needed to calculate further stalte nodes
+            // Don't do this as a filter, as this list is needed to calculate further stale nodes
             staleNodeIds.removeIf(canNotBeStale);
             // Remove all the stale nodes
             staleNodeIds.stream()

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -220,10 +220,10 @@ public class EntityGraphMapper implements EntityMapper {
             }
         }
 
-        do {
+        while (!staleNodeIds.isEmpty()) {
             // Remove all nodes that are not isolated (that is only in one relationship)
             // Don't do this as a filter, as this list is needed to calculate further stale nodes
-            staleNodeIds.removeIf(canNotBeStale);
+            staleNodeIds.removeIf(cannotBeStale);
             // Remove all the stale nodes
             staleNodeIds.stream()
                 .map(mappingContext::getNodeEntity)
@@ -231,7 +231,7 @@ public class EntityGraphMapper implements EntityMapper {
                 .forEach(node -> mappingContext.removeNodeEntity(node, true));
             // Remove now stale relationship and possibly creating new stale nodes
             staleNodeIds = mappingContext.removeStaleRelationships(staleNodeIds);
-        } while (!staleNodeIds.isEmpty());
+        }
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -186,7 +186,7 @@ public class EntityGraphMapper implements EntityMapper {
         Set<Long> staleNodeIds = new HashSet<>();
         Set<MappedRelationship> relationships = new HashSet<>(mappingContext.getRelationships());
         // A node can only be stale if it's only reachable via one relationship originally in the context
-        Predicate<Long> canNotBeStale = nodeId -> relationships.stream()
+        Predicate<Long> cannotBeStale = nodeId -> relationships.stream()
             .filter(r -> r.getStartNodeId() == nodeId || r.getEndNodeId() == nodeId)
             .count() > 1;
 

--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -272,10 +272,6 @@ public class MappingContext {
         relationshipEntityRegister.clear();
     }
 
-    public Map<Long, Object> getSnapshotOfRelationshipEntityRegister() {
-        return new HashMap<>(this.relationshipEntityRegister);
-    }
-
     public Object getRelationshipEntity(Long relationshipId) {
         return relationshipEntityRegister.get(relationshipId);
     }
@@ -529,6 +525,31 @@ public class MappingContext {
             }
             return graphId;
         }
+    }
+
+    Set<Long> removeStaleRelationships(Set<Long> staleNodeIds) {
+
+        Set<Long> newStaleNodeIds = new HashSet<>();
+        Iterator<MappedRelationship> it = this.relationshipRegister.iterator();
+        while (it.hasNext()) {
+            MappedRelationship r = it.next();
+
+            // Not touched by a stale node
+            if (!staleNodeIds.contains(r.getStartNodeId()) && !staleNodeIds.contains(r.getEndNodeId())) {
+                continue;
+            }
+
+            // Possible further stale nodes
+            newStaleNodeIds.add(r.getStartNodeId());
+            newStaleNodeIds.add(r.getEndNodeId());
+
+            // Remove the stale relationship in one go
+            it.remove();
+        }
+
+        // Remove possible duplicate stale nodes upfront
+        newStaleNodeIds.removeAll(staleNodeIds);
+        return newStaleNodeIds;
     }
 
     private static void generateIdIfNecessary(Object entity, ClassInfo classInfo) {

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/RelationshipBuilder.java
@@ -24,6 +24,7 @@ import org.neo4j.ogm.model.Edge;
  * Builds a relationship to be persisted in the database
  *
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public interface RelationshipBuilder extends PropertyContainerBuilder<RelationshipBuilder> {
 
@@ -50,8 +51,6 @@ public interface RelationshipBuilder extends PropertyContainerBuilder<Relationsh
     boolean isRelationshipEntity();
 
     void setRelationshipEntity(boolean relationshipEntity);
-
-    boolean isNew();
 
     Edge edge();
 

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/node/DefaultRelationshipBuilder.java
@@ -87,11 +87,6 @@ public class DefaultRelationshipBuilder extends AbstractPropertyContainerBuilder
     }
 
     @Override
-    public boolean isNew() {
-        return true;
-    }
-
-    @Override
     public void setSingleton(boolean b) {
         this.singleton = b;
     }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/CompilerTest.java
@@ -559,11 +559,7 @@ public class CompilerTest {
         assertThat(mrWhite.getSchool()).isNull();
         assertThat(hillsRoad.getTeachers()).doesNotContain(mrWhite);
 
-        // we expect hillsRoad relationship to mrWhite to be removed.
-        // however, the change to MrWhite's relationship is not detected.
-        // this is because MrWhite is not "visited" during the traversal of
-        // hillsRoad - his reference is now inaccessible. this looks like a FIXME
-
+        // we expect hillsRoad relationship to mrWhite to be removed. OGM correctly detects this.
         Compiler compiler = mapAndCompile(hillsRoad, -1);
 
         List<Statement> statements = compiler.createNodesStatements();
@@ -578,10 +574,6 @@ public class CompilerTest {
         );
         assertThat(((List) statements.get(0).getParameters().get("rows"))).hasSize(1);
 
-        // we expect mrWhite's relationship to hillsRoad to be removed
-        // but the change to hillsRoad's relationship with MrWhite is not detected
-        // this is because hillsRoad object is no longer directly accessible from MrWhite
-        // looks like a FIXME (infer symmetric deletions)
         compiler = mapAndCompile(mrWhite, -1);
 
         statements = compiler.createNodesStatements();

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/compiler/SavingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.cypher.compiler;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.domain.gh613.Node;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.TestContainersTestBase;
+import org.neo4j.ogm.testutil.TestUtils;
+
+/**
+ * @author Andreas Berger
+ * @author Michael J. Simons
+ */
+public class SavingTest extends TestContainersTestBase {
+
+    private static SessionFactory sessionFactory;
+    private Session session;
+
+    @BeforeClass
+    public static void initSesssionFactory() {
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh613");
+    }
+
+    @Before
+    public void init() {
+        session = sessionFactory.openSession();
+        session.purgeDatabase();
+        session.clear();
+
+        session.query(TestUtils.readCQLFile("org/neo4j/ogm/cql/gh613.cql").toString(), Collections.emptyMap());
+    }
+
+    @Test // GH-613
+    public void testSaveParentAfterChild() {
+
+        Node loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getNodeType()).isNotNull();
+        loc1_1.setLabels(null);
+        session.save(loc1_1);
+
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getChildNodes()).hasSize(3)
+            .first().extracting(Node::getNodeType).isNull(); // The thing hasn't been initialized on purpose, see below
+        assertThat(loc1.getNodeType()).isNotNull();
+        session.save(loc1);
+
+        loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getNodeType()).isNotNull();
+    }
+
+    @Test
+    public void testChangeParent() {
+
+        Node loc2 = queryNode("loc2");
+        Node loc1_1 = queryNode("loc1_1");
+        Node loc1_2 = queryNode("loc1_2");
+
+        Node oldParentOfLoc1_1 = loc1_1.setChildOfBidirectional(loc2);
+        session.save(loc1_1);
+        session.save(oldParentOfLoc1_1);
+        Node oldParentOfLoc1_2 = loc1_2.setChildOfBidirectional(loc2);
+        session.save(loc1_2);
+        session.save(oldParentOfLoc1_2);
+
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getChildNodes()).hasSize(1);
+
+        loc2 = queryNode("loc2");
+        assertThat(loc2.getChildNodes()).hasSize(2);
+    }
+
+    @Test
+    public void indirectReachableStaleRelationshipsShouldBeCleared() {
+        Node loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+
+        Node loc1_1 = queryNode("loc1_1");
+        assertThat(loc1_1.getLabels()).hasSize(1);
+
+        loc1_1.setLabels(null);
+        session.save(loc1_1);
+
+        Node root = queryNode("root");
+        assertThat(root.getChildNodes()).hasSize(2);
+        session.save(root);
+
+        loc1 = queryNode("loc1");
+        assertThat(loc1.getNodeType()).isNotNull();
+    }
+
+    @Test
+    public void moveNode() {
+        Node m1 = queryNode("m1");
+        Node company2 = queryNode("company2");
+        Node loc2 = queryNode("loc2");
+
+        Node oldParent = m1.setChildOfBidirectional(loc2);
+        session.save(m1);
+        session.save(oldParent);
+        m1.setBelongsTo(company2);
+        session.save(m1);
+
+        Iterable<Node> belongsTo;
+        belongsTo = getNodesBelongingToOtherNode("company2");
+        assertThat(belongsTo).hasSize(1);
+
+        belongsTo = getNodesBelongingToOtherNode("company1");
+        assertThat(belongsTo).hasSize(0);
+    }
+
+    private Iterable<Node> getNodesBelongingToOtherNode(String otherNodeId) {
+        return session
+            .query(Node.class, "MATCH (c:Node)<-[:BELONGS_TO]-(m:Node) WHERE c.nodeId = $c RETURN m",
+                Collections.singletonMap("c", otherNodeId));
+    }
+
+    private Node queryNode(String nodeId) {
+        Collection<Node> nodeTypes = session
+            .loadAll(Node.class, new Filters(new Filter("nodeId", ComparisonOperator.EQUALS, nodeId)), 1);
+        assertThat(nodeTypes).hasSize(1);
+        return nodeTypes.iterator().next();
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/BaseEntity.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+/**
+ * @author Andreas Berger
+ */
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Label.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Label extends BaseEntity {
+
+    @Index
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public Label setKey(String key) {
+        this.key = key;
+        return this;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/Node.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh613;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class Node extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeId;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.OUTGOING)
+    private Node childOf;
+
+    @Relationship(type = "CHILD_OF", direction = Relationship.INCOMING)
+    protected Set<Node> childNodes;
+
+    @Relationship(type = "HAS_TYPE", direction = Relationship.OUTGOING)
+    private NodeType nodeType;
+
+    @Relationship(type = "LABELED", direction = Relationship.OUTGOING)
+    private Set<Label> labels;
+
+    @Relationship(type = "BELONGS_TO")
+    protected Node belongsTo;
+
+    public Node() {
+    }
+
+    public Node(String nodeId) {
+        setNodeId(nodeId);
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public Node setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+        return this;
+    }
+
+    public Node getChildOf() {
+        return childOf;
+    }
+
+    public Set<Node> getChildNodes() {
+        return childNodes;
+    }
+
+    public Node setChildNodes(Set<Node> childNodes) {
+        this.childNodes = childNodes;
+        return this;
+    }
+
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    public Set<Label> getLabels() {
+        return labels;
+    }
+
+    public Node setLabels(Set<Label> labels) {
+        this.labels = labels;
+        return this;
+    }
+
+    public Node setChildOfBidirectional(Node newParent) {
+        Node currentParent = this.getChildOf();
+        if (newParent == currentParent) {
+            return currentParent;
+        }
+        if (currentParent != null
+            && currentParent.getChildNodes() != null
+            && !currentParent.getChildNodes().isEmpty()) {
+            // updating both sides of the bidirectional mapping
+            // this is to workaround this issue https://github.com/neo4j/neo4j-ogm/issues/591
+            currentParent.getChildNodes().remove(this);
+        }
+        if (newParent != null) {
+            if (newParent.getChildNodes() == null) {
+                newParent.setChildNodes(new HashSet<>());
+            }
+            newParent.getChildNodes().add(this);
+        }
+        this.childOf = newParent;
+        return currentParent;
+    }
+
+
+    public void setBelongsTo(Node belongsTo) {
+        this.belongsTo = belongsTo;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh613/NodeType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh613;
+
+import org.neo4j.ogm.annotation.Index;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Andreas Berger
+ */
+@NodeEntity
+public class NodeType extends BaseEntity {
+
+    @Index(unique = true)
+    private String nodeTypeId;
+
+    public NodeType() {
+    }
+
+    public NodeType(String nodeTypeId) {
+        this.nodeTypeId = nodeTypeId;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/resources/org/neo4j/ogm/cql/gh613.cql
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/resources/org/neo4j/ogm/cql/gh613.cql
@@ -1,0 +1,25 @@
+CREATE
+  (location:NodeType {nodeTypeId: 'location'})
+CREATE
+  (l1:Label {key: 'l1'})
+CREATE
+  (root:Node {nodeId: 'root'})-[:HAS_TYPE]->(location),
+  (company1:Node {nodeId: 'company1'}),
+  (company2:Node {nodeId: 'company2'}),
+  (loc1:Node {nodeId: 'loc1'})-[:HAS_TYPE]->(location),
+  (loc2:Node {nodeId: 'loc2'})-[:HAS_TYPE]->(location),
+  (loc1_1:Node {nodeId: 'loc1_1'})-[:HAS_TYPE]->(location),
+  (m1:Node {nodeId: 'm1'}),
+  (loc1_2:Node {nodeId: 'loc1_2'})-[:HAS_TYPE]->(location),
+  (loc1_3:Node {nodeId: 'loc1_3'})-[:HAS_TYPE]->(location),
+  (root)<-[:CHILD_OF]-(company1),
+  (root)<-[:CHILD_OF]-(company2),
+  (company1)<-[:CHILD_OF]-(loc1),
+  (company2)<-[:CHILD_OF]-(loc2),
+  (loc1)<-[:CHILD_OF]-(loc1_1),
+  (loc1)<-[:CHILD_OF]-(loc1_2),
+  (loc1)<-[:CHILD_OF]-(loc1_3),
+  (loc1_1)<-[:CHILD_OF]-(m1),
+  (company1)<-[:BELONGS_TO]-(m1),
+  (loc1_1)-[:LABELED]->(l1),
+  (loc1_2)-[:LABELED]->(l1);


### PR DESCRIPTION
The deleteObsoleteRelationships() method now marks all nodes reachable from stale relationship stale as well. If a node was only reachable via one of the original relationships, than it can actually be stale and will be removed.

If it get’s removed, it will in turn mark more relationships as stale, which also will be removed.

This fixes #613.