### PR TITLE
GH-551 - Make SingleUseEntityMapper aware of nested objects.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/GraphEntityMapper.java
@@ -294,15 +294,12 @@ public class GraphEntityMapper {
             Object value = property.getValue();
             // merge iterable / arrays and co-erce to the correct attribute type
             if (writer.type().isArray() || Iterable.class.isAssignableFrom(writer.type())) {
-                FieldInfo reader = classInfo.getFieldInfo(property.getKey().toString());
-                if (reader != null) {
-                    Class<?> paramType = writer.type();
-                    Class elementType = underlyingElementType(classInfo, property.getKey().toString());
-                    if (paramType.isArray()) {
-                        value = EntityAccessManager.merge(paramType, value, new Object[] {}, elementType);
-                    } else {
-                        value = EntityAccessManager.merge(paramType, value, Collections.emptyList(), elementType);
-                    }
+                Class<?> paramType = writer.type();
+                Class elementType = underlyingElementType(classInfo, property.getKey().toString());
+                if (paramType.isArray()) {
+                    value = EntityAccessManager.merge(paramType, value, new Object[] {}, elementType);
+                } else {
+                    value = EntityAccessManager.merge(paramType, value, Collections.emptyList(), elementType);
                 }
             }
             writer.write(instance, value);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/AnotherThing.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/AnotherThing.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh551;
+
+/**
+ * @author Michael J. Simons
+ */
+public class AnotherThing  {
+
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ThingEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ThingEntity.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh551;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class ThingEntity {
+	@Id @GeneratedValue
+	private Long id;
+
+	private String name;
+
+    public ThingEntity() {
+    }
+
+    public ThingEntity(String name) {
+		this.name = name;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}
+

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ThingResult.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ThingResult.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh551;
+
+import java.util.List;
+
+/**
+ * @author Michael J. Simons
+ */
+public class ThingResult {
+	private String something;
+
+	public String getSomething() {
+		return something;
+	}
+
+	public void setSomething(String something) {
+		this.something = something;
+	}
+
+	private List<AnotherThing> things;
+
+	public List<AnotherThing> getThings() {
+		return things;
+	}
+
+	public void setThings(List<AnotherThing> things) {
+		this.things = things;
+	}
+}


### PR DESCRIPTION
This change allows for returning nested objects, that are actually part of the scanned classes, to be returned from the `SingleUseEntityMapper` when the target type of a collection fits. Otherwise the `SingleUseEntityMapper` would silently put `Map<String, Object>` instances in collections, which would fail with a late `ClassCastException` when items of the collection property are eventually accessed.

While implementing the functionality, it became obvious that `GraphEntityMapper` could be optimized by not looking up the field info several times.

The commit fixes #551.