### PR TITLE
GH-651 - Use all mapped labels when querying domain objects.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/config/Configuration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/Configuration.java
@@ -589,12 +589,12 @@ public class Configuration {
         }
 
         /**
-         * Tuzns on strict querying. In strict querying mode, Neo4j-OGM uses all reachable static labels in a class inheritance
+         * Turns on strict querying. In strict querying mode, Neo4j-OGM uses all reachable static labels in a class inheritance
          * scenario when querying a domain object, either all, one by id oder all by ids. That is, in strict mode, a node
          * needs to have {@code n:LabelA:LabelB} when a domain class has this two labels due to inheritance. In relaxed mode,
          * the label of the concrete class is enough.
          * <p>
-         * Turning strict mode on can improve query performance, when indixes are defined on labels spotted by parent classes.
+         * Turning strict mode on can improve query performance, when indexes are defined on labels spotted by parent classes.
          * <p>
          * Strict query mode is the default since 4.0.
          *
@@ -608,7 +608,7 @@ public class Configuration {
 
         /**
          * Turns strict querying off and uses only the single static label of a domain class, even if this class is part
-         * of an inheritance hierachy exposing more than one static label. This may have impact on performance as indexes
+         * of an inheritance hierrachy exposing more than one static label. This may have impact on performance as indexes
          * may not be used. However, turning it off may be necessary to query nodes that have been created outside Neo4j-OGM
          * and are missing some labels.
          *

--- a/api/src/main/java/org/neo4j/ogm/config/Configuration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/Configuration.java
@@ -608,7 +608,7 @@ public class Configuration {
 
         /**
          * Turns strict querying off and uses only the single static label of a domain class, even if this class is part
-         * of an inheritance hierrachy exposing more than one static label. This may have impact on performance as indexes
+         * of an inheritance hierarchy exposing more than one static label. This may have impact on performance as indexes
          * may not be used. However, turning it off may be necessary to query nodes that have been created outside Neo4j-OGM
          * and are missing some labels.
          *

--- a/api/src/main/java/org/neo4j/ogm/config/Configuration.java
+++ b/api/src/main/java/org/neo4j/ogm/config/Configuration.java
@@ -69,6 +69,15 @@ public class Configuration {
     private Boolean useNativeTypes;
     private Map<String, Object> customProperties;
     /**
+     * This flag instructs OGM to use all static labels when querying domain objects. Until 3.2.4 only the label of the
+     * concrete domain has been used to query domain objects in inheritance scenarios. When storing those objects again,
+     * OGM writes all labels in any case.
+     * <p>
+     * Using all reachable, static labels in a class hierarchy for querying and thus enforcing strict queries is the default
+     * in Neo4j-OGM 4.0. Use this flag to restore the old behaviour.
+     */
+    private Boolean useStrictQuerying;
+    /**
      * Base packages to scan for annotated components. They will be merged into a unique list
      * of packages with the programmatically registered packages to scan.
      */
@@ -97,6 +106,7 @@ public class Configuration {
         this.customProperties = builder.customProperties;
         this.useNativeTypes = builder.useNativeTypes;
         this.basePackages = builder.basePackages;
+        this.useStrictQuerying = builder.useStrictQuerying;
 
         URI parsedUri = getSingleURI();
 
@@ -227,6 +237,10 @@ public class Configuration {
         return useNativeTypes;
     }
 
+    public Boolean getUseStrictQuerying() {
+        return useStrictQuerying;
+    }
+
     public String[] getBasePackages() {
         return basePackages;
     }
@@ -265,7 +279,8 @@ public class Configuration {
             Objects.equals(connectionLivenessCheckTimeout, that.connectionLivenessCheckTimeout) &&
             Objects.equals(verifyConnection, that.verifyConnection) &&
             Objects.equals(useNativeTypes, that.useNativeTypes) &&
-            Arrays.equals(basePackages, that.basePackages);
+            Arrays.equals(basePackages, that.basePackages) &&
+            Objects.equals(useStrictQuerying, that.useStrictQuerying);
     }
 
     @Override
@@ -301,6 +316,7 @@ public class Configuration {
         private static final String NEO4J_CONF_LOCATION = "neo4j.conf.location";
         private static final String USE_NATIVE_TYPES = "use-native-types";
         private static final String BASE_PACKAGES = "base-packages";
+        private static final String USE_STRICT_QUERYING = "use-strict-querying";
         private String uri;
         private String[] uris;
         private Integer connectionPoolSize;
@@ -318,6 +334,8 @@ public class Configuration {
         private boolean useNativeTypes;
         private Map<String, Object> customProperties = new HashMap<>();
         private String[] basePackages;
+        private boolean useStrictQuerying = true;
+
         /**
          * Creates new Configuration builder
          * Use for Java configuration.
@@ -332,54 +350,60 @@ public class Configuration {
          */
         public Builder(ConfigurationSource configurationSource) {
             for (Map.Entry<Object, Object> entry : configurationSource.properties().entrySet()) {
+                final String value = (String) entry.getValue();
                 switch (entry.getKey().toString()) {
                     case URI:
-                        this.uri = (String) entry.getValue();
+                        this.uri = value;
                         break;
                     case USERNAME:
-                        this.username = (String) entry.getValue();
+                        this.username = value;
                         break;
                     case PASSWORD:
-                        this.password = (String) entry.getValue();
+                        this.password = value;
                         break;
                     case URIS:
                         this.uris = splitValue(entry.getValue());
                         break;
                     case CONNECTION_POOL_SIZE:
-                        this.connectionPoolSize = Integer.parseInt((String) entry.getValue());
+                        this.connectionPoolSize = Integer.parseInt(value);
                         break;
                     case ENCRYPTION_LEVEL:
-                        this.encryptionLevel = (String) entry.getValue();
+                        this.encryptionLevel = value;
                         break;
                     case TRUST_STRATEGY:
-                        this.trustStrategy = (String) entry.getValue();
+                        this.trustStrategy = value;
                         break;
                     case TRUST_CERT_FILE:
-                        this.trustCertFile = (String) entry.getValue();
+                        this.trustCertFile = value;
                         break;
                     case CONNECTION_LIVENESS_CHECK_TIMEOUT:
-                        this.connectionLivenessCheckTimeout = Integer.valueOf((String) entry.getValue());
+                        this.connectionLivenessCheckTimeout = Integer.valueOf(value);
                         break;
                     case VERIFY_CONNECTION:
-                        this.verifyConnection = Boolean.valueOf((String) entry.getValue());
+                        this.verifyConnection = Boolean.valueOf(value);
                         break;
                     case AUTO_INDEX:
-                        this.autoIndex = (String) entry.getValue();
+                        this.autoIndex = value;
                         break;
                     case GENERATED_INDEXES_OUTPUT_DIR:
-                        this.generatedIndexesOutputDir = (String) entry.getValue();
+                        this.generatedIndexesOutputDir = value;
                         break;
                     case GENERATED_INDEXES_OUTPUT_FILENAME:
-                        this.generatedIndexesOutputFilename = (String) entry.getValue();
+                        this.generatedIndexesOutputFilename = value;
                         break;
                     case NEO4J_CONF_LOCATION:
-                        this.neo4jConfLocation = (String) entry.getValue();
+                        this.neo4jConfLocation = value;
                         break;
                     case USE_NATIVE_TYPES:
-                        this.useNativeTypes = Boolean.valueOf((String) entry.getValue());
+                        this.useNativeTypes = Boolean.valueOf(value);
                         break;
                     case BASE_PACKAGES:
                         this.basePackages = splitValue(entry.getValue());
+                        break;
+                    case USE_STRICT_QUERYING:
+                        if (!(value == null || value.isEmpty())) {
+                            this.useStrictQuerying = Boolean.valueOf(value);
+                        }
                         break;
                     default:
                         LOGGER.warn("Could not process property with key: {}", entry.getKey());
@@ -388,7 +412,7 @@ public class Configuration {
         }
 
         public static Builder copy(Builder builder) {
-            return new Builder()
+            Builder copiedBuilder = new Builder()
                 .uri(builder.uri)
                 .connectionPoolSize(builder.connectionPoolSize)
                 .encryptionLevel(builder.encryptionLevel)
@@ -402,6 +426,13 @@ public class Configuration {
                 .neo4jConfLocation(builder.neo4jConfLocation)
                 .credentials(builder.username, builder.password)
                 .customProperties(new HashMap<>(builder.customProperties));
+
+            if (builder.useStrictQuerying) {
+                copiedBuilder.strictQuerying();
+            } else {
+                copiedBuilder.relaxedQuerying();
+            }
+            return copiedBuilder;
         }
 
         private static String[] splitValue(Object value) {
@@ -554,6 +585,38 @@ public class Configuration {
          */
         public Builder useNativeTypes() {
             this.useNativeTypes = true;
+            return this;
+        }
+
+        /**
+         * Tuzns on strict querying. In strict querying mode, Neo4j-OGM uses all reachable static labels in a class inheritance
+         * scenario when querying a domain object, either all, one by id oder all by ids. That is, in strict mode, a node
+         * needs to have {@code n:LabelA:LabelB} when a domain class has this two labels due to inheritance. In relaxed mode,
+         * the label of the concrete class is enough.
+         * <p>
+         * Turning strict mode on can improve query performance, when indixes are defined on labels spotted by parent classes.
+         * <p>
+         * Strict query mode is the default since 4.0.
+         *
+         * @return the changed builder
+         * @since 3.2.4
+         */
+        public Builder strictQuerying() {
+            this.useStrictQuerying = true;
+            return this;
+        }
+
+        /**
+         * Turns strict querying off and uses only the single static label of a domain class, even if this class is part
+         * of an inheritance hierachy exposing more than one static label. This may have impact on performance as indexes
+         * may not be used. However, turning it off may be necessary to query nodes that have been created outside Neo4j-OGM
+         * and are missing some labels.
+         *
+         * @return the changed builder
+         * @since 3.2.4
+         */
+        public Builder relaxedQuerying() {
+            this.useStrictQuerying = false;
             return this;
         }
 

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -101,6 +101,7 @@ public class ClassInfo {
     private volatile boolean labelFieldMapped = false;
     private volatile boolean isPostLoadMethodMapped = false;
     private volatile MethodInfo postLoadMethod;
+    private volatile Collection<String> staticLabels;
     private boolean primaryIndexFieldChecked = false;
     private Class<?> cls;
     private Class<? extends IdStrategy> idStrategyClass;
@@ -223,7 +224,18 @@ public class ClassInfo {
      * any, never <code>null</code>
      */
     public Collection<String> staticLabels() {
-        return collectLabels(new ArrayList<>());
+
+        Collection<String> knownStaticLabels = this.staticLabels;
+        if (knownStaticLabels == null) {
+            synchronized (this) {
+                knownStaticLabels = this.staticLabels;
+                if (knownStaticLabels == null) {
+                    this.staticLabels = Collections.unmodifiableCollection(collectLabels(new ArrayList<>()));
+                    knownStaticLabels = this.staticLabels;
+                }
+            }
+        }
+        return knownStaticLabels;
     }
 
     public String neo4jName() {

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -230,7 +230,7 @@ public class ClassInfo {
             synchronized (this) {
                 knownStaticLabels = this.staticLabels;
                 if (knownStaticLabels == null) {
-                    this.staticLabels = Collections.unmodifiableCollection(collectLabels(new ArrayList<>()));
+                    this.staticLabels = Collections.unmodifiableCollection(collectLabels());
                     knownStaticLabels = this.staticLabels;
                 }
             }
@@ -257,20 +257,22 @@ public class ClassInfo {
         return neo4jName;
     }
 
-    private Collection<String> collectLabels(Collection<String> labelNames) {
+    private Collection<String> collectLabels() {
+
+        List<String> labels = new ArrayList<>();
         if (!isAbstract || annotationsInfo.get(NodeEntity.class) != null) {
-            labelNames.add(neo4jName());
+            labels.add(neo4jName());
         }
         if (directSuperclass != null && !"java.lang.Object".equals(directSuperclass.className)) {
-            directSuperclass.collectLabels(labelNames);
+            labels.addAll(directSuperclass.collectLabels());
         }
         for (ClassInfo interfaceInfo : directInterfaces()) {
-            interfaceInfo.collectLabels(labelNames);
+            labels.addAll(interfaceInfo.collectLabels());
         }
         for (ClassInfo indirectSuperClass : indirectSuperClasses) {
-            indirectSuperClass.collectLabels(labelNames);
+            labels.addAll(indirectSuperClass.collectLabels());
         }
-        return labelNames;
+        return labels;
     }
 
     public List<ClassInfo> directSubclasses() {

--- a/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
@@ -292,7 +292,10 @@ public class MetaData {
 
     public String entityType(String name) {
         ClassInfo classInfo = classInfo(name);
-        if (isRelationshipEntity(classInfo.name())) {
+        if (classInfo == null) {
+            return null;
+        }
+        if (classInfo.isRelationshipEntity()) {
             AnnotationInfo annotation = classInfo.annotationsInfo().get(RelationshipEntity.class);
             return annotation.get(RelationshipEntity.TYPE, classInfo.name());
         }

--- a/core/src/main/java/org/neo4j/ogm/metadata/schema/SchemaImpl.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/schema/SchemaImpl.java
@@ -42,7 +42,7 @@ class SchemaImpl implements Schema {
     public Node findNode(String label) {
 
         if (!nodes.containsKey(label)) {
-            throw new IllegalArgumentException("Unknown label " + label);
+            throw new IllegalArgumentException("Unknown label `" + label + "`");
         }
         return nodes.get(label);
     }

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.neo4j.ogm.context.MappingContext;
 import org.neo4j.ogm.context.WriteProtectionTarget;

--- a/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
+++ b/core/src/main/java/org/neo4j/ogm/session/Neo4jSession.java
@@ -668,7 +668,7 @@ public class Neo4jSession implements Session {
             if (classInfo != null) {
                 result = classInfo.isRelationshipEntity() ?
                     classInfo.neo4jName() :
-                    classInfo.staticLabels().stream().collect(Collectors.joining("`:`"));
+                    String.join("`:`", classInfo.staticLabels());
             }
             labelsOrType = Optional.ofNullable(result);
         } else {

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByTypeDelegate.java
@@ -20,6 +20,7 @@ package org.neo4j.ogm.session.delegates;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.neo4j.ogm.context.GraphRowListModelMapper;
 import org.neo4j.ogm.context.GraphRowModelMapper;
@@ -69,8 +70,8 @@ public class LoadByTypeDelegate extends SessionDelegate {
     public <T> Collection<T> loadAll(Class<T> type, Filters filters, SortOrder sortOrder, Pagination pagination,
         int depth) {
 
-        String entityLabel = session.entityType(type.getName());
-        if (entityLabel == null) {
+        Optional<String> labelsOrType = session.determineLabelsOrTypeForLoading(type);
+        if (!labelsOrType.isPresent()) {
             LOG.warn("Unable to find database label for entity " + type.getName()
                 + " : no results will be returned. Make sure the class is registered, "
                 + "and not abstract without @NodeEntity annotation");
@@ -82,10 +83,10 @@ public class LoadByTypeDelegate extends SessionDelegate {
 
         PagingAndSortingQuery query;
         if (filters == null || filters.isEmpty()) {
-            query = queryStatements.findByType(entityLabel, depth);
+            query = queryStatements.findByType(labelsOrType.get(), depth);
         } else {
             resolvePropertyAnnotations(type, filters);
-            query = queryStatements.findByType(entityLabel, filters, depth);
+            query = queryStatements.findByType(labelsOrType.get(), filters, depth);
         }
 
         query.setSortOrder(sortOrderWithResolvedProperties)

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -19,6 +19,7 @@
 package org.neo4j.ogm.session.delegates;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.context.GraphRowModelMapper;
@@ -66,17 +67,19 @@ public class LoadOneDelegate extends SessionDelegate {
 
         if (primaryIndexField == null && !(id instanceof Long)) {
             throw new IllegalArgumentException("Supplied id must be of type Long (native graph id) when supplied class "
-                + "does not have primary id" + type.getName());
+                + "does not have primary id " + type.getName());
         }
 
-        QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
-        String entityType = session.entityType(type.getName());
-        if (entityType == null) {
+        Optional<String> labelsOrType = session.determineLabelsOrTypeForLoading(type);
+        if (!labelsOrType.isPresent()) {
             logger.warn("Unable to find database label for entity " + type.getName()
                 + " : no results will be returned. Make sure the class is registered, "
                 + "and not abstract without @NodeEntity annotation");
+            return null;
         }
-        PagingAndSortingQuery qry = queryStatements.findOneByType(entityType, id, depth);
+
+        QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
+        PagingAndSortingQuery qry = queryStatements.findOneByType(labelsOrType.get(), id, depth);
 
         GraphModelRequest request = new DefaultGraphModelRequest(qry.getStatement(), qry.getParameters());
 

--- a/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaNodeLoadClauseBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/strategy/impl/SchemaNodeLoadClauseBuilder.java
@@ -26,6 +26,7 @@ import org.neo4j.ogm.session.request.strategy.LoadClauseBuilder;
  * Schema based load clause builder for nodes - starts from given node variable
  *
  * @author Frantisek Hartman
+ * @author Michael J. Simons
  */
 public class SchemaNodeLoadClauseBuilder extends AbstractSchemaLoadClauseBuilder implements LoadClauseBuilder {
 
@@ -47,7 +48,14 @@ public class SchemaNodeLoadClauseBuilder extends AbstractSchemaLoadClauseBuilder
         sb.append(variable);
         newLine(sb);
 
-        Node node = schema.findNode(label);
+        Node node;
+        final int separatorIndex = label.indexOf("`:`");
+        if (separatorIndex < 0) {
+            node = schema.findNode(label);
+        } else {
+            node = schema.findNode(label.substring(0, separatorIndex));
+        }
+
         expand(sb, variable, node, depth);
 
         return sb.toString();

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/ConfigurationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/config/ConfigurationTest.java
@@ -78,8 +78,6 @@ public class ConfigurationTest {
         assertThat(configuration.getCredentials().credentials().toString()).isEqualTo("ZnJhbnRpxaFlazpQYXNzMTIz");
     }
 
-
-
     @Test(expected = RuntimeException.class)
     public void uriWithNoScheme() {
         Configuration configuration = new Configuration.Builder().uri("target/noe4j/my.db").build();
@@ -202,5 +200,49 @@ public class ConfigurationTest {
 
         String[] basePackages = configuration.mergeBasePackagesWith("A", "B", "a");
         assertThat(basePackages).containsExactlyInAnyOrder("A", "B", "a", "b");
+    }
+
+    @Test
+    public void shouldDefaultToStrictQuerying() {
+        Configuration.Builder builder = new Configuration.Builder();
+        Configuration configuration = builder.build();
+        assertThat(configuration.getUseStrictQuerying()).isTrue();
+    }
+
+    @Test
+    public void changingQueryingModeShouldWork() {
+        Configuration.Builder builder = new Configuration.Builder();
+        Configuration configuration = builder.relaxedQuerying().build();
+        assertThat(configuration.getUseStrictQuerying()).isFalse();
+    }
+
+    @Test
+    public void shouldParseQUeryingMode() {
+
+        Configuration configuration;
+
+        configuration = new Configuration.Builder(() -> new Properties()).build();
+        assertThat(configuration.getUseStrictQuerying()).isTrue();
+
+        configuration = new Configuration.Builder(() -> {
+            Properties properties = new Properties();
+            properties.setProperty("use-strict-querying", "");
+            return properties;
+        }).build();
+        assertThat(configuration.getUseStrictQuerying()).isTrue();
+
+        configuration = new Configuration.Builder(() -> {
+            Properties properties = new Properties();
+            properties.setProperty("use-strict-querying", "true");
+            return properties;
+        }).build();
+        assertThat(configuration.getUseStrictQuerying()).isTrue();
+
+        configuration = new Configuration.Builder(() -> {
+            Properties properties = new Properties();
+            properties.setProperty("use-strict-querying", "false");
+            return properties;
+        }).build();
+        assertThat(configuration.getUseStrictQuerying()).isFalse();
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/BaseRelationshipEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/BaseRelationshipEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh651;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+
+/**
+ * @author Michael J. Simons
+ */
+@RelationshipEntity("BASE")
+abstract class BaseRelationshipEntity {
+
+    @StartNode
+    private SomeEntity unrelatedEntity;
+
+    @EndNode
+    private PersistentCategory persistentCategory;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/PersistentCategory.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/PersistentCategory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh651;
+
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity(label = "Category")
+public class PersistentCategory extends PersistentEntity {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/PersistentEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/PersistentEntity.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh651;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity(label = "Entity")
+public abstract class PersistentEntity {
+    @Id
+    private String uuid;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/SomeEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/SomeEntity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh651;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class SomeEntity {
+
+    @Id @GeneratedValue
+    private long id;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/SomeRelationshipEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh651/SomeRelationshipEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh651;
+
+import org.neo4j.ogm.annotation.RelationshipEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@RelationshipEntity("SOME_RELATIONSHIP")
+public class SomeRelationshipEntity extends BaseRelationshipEntity {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/ClassInfoTest.java
@@ -49,7 +49,6 @@ public class ClassInfoTest {
     @Rule
     public final ExpectedException expectedException = none();
 
-
     private MetaData metaData;
 
     @Before
@@ -362,14 +361,14 @@ public class ClassInfoTest {
     @Test
     public void testStaticLabelsForClassInfo() {
         ClassInfo annotatedClassInfo = metaData.classInfo(Member.class.getSimpleName());
-        assertThat(annotatedClassInfo.staticLabels()).isEqualTo(asList("User", "Login"));
+        assertThat(annotatedClassInfo.staticLabels()).containsExactly("User", "Login");
 
         ClassInfo simpleClassInfo = metaData.classInfo("Topic");
-        assertThat(simpleClassInfo.staticLabels()).isEqualTo(asList("Topic"));
+        assertThat(simpleClassInfo.staticLabels()).containsOnly("Topic");
 
         ClassInfo nonAnnotatedClassInfo = new MetaData("org.neo4j.ogm.domain.education")
             .classInfo(Student.class.getSimpleName());
-        assertThat(nonAnnotatedClassInfo.staticLabels()).isEqualTo(asList("Student", "DomainObject"));
+        assertThat(nonAnnotatedClassInfo.staticLabels()).containsExactly("Student", "DomainObject");
     }
 
     @Test // GH-159

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/bike/BikeTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/bike/BikeTest.java
@@ -34,7 +34,7 @@ import org.neo4j.ogm.session.Neo4jSession;
 public class BikeTest {
 
     private static MetaData metadata = new MetaData("org.neo4j.ogm.domain.bike");
-    private static Neo4jSession session = new Neo4jSession(metadata, new BikeRequest());
+    private static Neo4jSession session = new Neo4jSession(metadata, true, new BikeRequest());
 
     @Test
     public void testDeserialiseBikeModel() {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/MovieTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/MovieTest.java
@@ -38,7 +38,7 @@ public class MovieTest {
     public void testDeserialiseMovie() {
 
         MetaData metadata = new MetaData("org.neo4j.ogm.domain.cineasts.annotated");
-        Neo4jSession session = new Neo4jSession(metadata, new MoviesRequest());
+        Neo4jSession session = new Neo4jSession(metadata, true, new MoviesRequest());
 
         Movie movie = session.load(Movie.class, UUID.fromString("38ebe777-bc85-4810-8217-096f29a361f1"), 1);
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/UserTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/UserTest.java
@@ -35,7 +35,7 @@ public class UserTest {
     public void testDeserialiseUserWithArrayOfEnums() {
 
         MetaData metadata = new MetaData("org.neo4j.ogm.domain.cineasts.annotated");
-        Neo4jSession session = new Neo4jSession(metadata, new UsersRequest());
+        Neo4jSession session = new Neo4jSession(metadata, true, new UsersRequest());
 
         User user = session.load(User.class, "luanne", 1);
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationTest.java
@@ -41,7 +41,7 @@ import org.neo4j.ogm.session.Neo4jSession;
 public class EducationTest {
 
     private static MetaData metadata = new MetaData("org.neo4j.ogm.domain.education");
-    private static Neo4jSession session = new Neo4jSession(metadata, new EducationRequest());
+    private static Neo4jSession session = new Neo4jSession(metadata, true, new EducationRequest());
 
     @Test
     public void testTeachers() throws Exception {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -108,9 +108,9 @@ public class EntityGraphMapperTest extends TestContainersTestBase {
     }
 
     @Test
-    public void updateObjectPropertyAndLabel() {
+    public void updateObjectProperty() {
 
-        Long sid = (Long) session.query("CREATE (s:Student {name:'Sheila Smythe'}) RETURN id(s) AS id", emptyMap())
+        Long sid = (Long) session.query("CREATE (s:Student:DomainObject {name:'Sheila Smythe'}) RETURN id(s) AS id", emptyMap())
             .queryResults().iterator().next().get("id");
         session.clear();
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/EntityGraphMapperTest.java
@@ -108,21 +108,24 @@ public class EntityGraphMapperTest extends TestContainersTestBase {
     }
 
     @Test
-    public void updateObjectProperty() {
+    public void updateObjectPropertyAndLabel() {
 
-        Long sid = (Long) session.query("CREATE (s:Student:DomainObject {name:'Sheila Smythe'}) RETURN id(s) AS id", emptyMap())
+        // This does only work in non-strict querying
+        Session customSession = new SessionFactory(getDriver(), false, "org.neo4j.ogm.domain.education").openSession();
+
+        Long sid = (Long) customSession.query("CREATE (s:Student {name:'Sheila Smythe'}) RETURN id(s) AS id", emptyMap())
             .queryResults().iterator().next().get("id");
-        session.clear();
+        customSession.clear();
 
-        Student sheila = session.load(Student.class, sid);
+        Student sheila = customSession.load(Student.class, sid);
 
         // now update the object's properties locally
         sheila.setName("Sheila Smythe-Jones");
 
-        session.save(sheila);
+        customSession.save(sheila);
 
-        session.clear();
-        assertThat(session.query("MATCH (s:DomainObject:Student {name:'Sheila Smythe-Jones'}) return s", emptyMap()).queryResults())
+        customSession.clear();
+        assertThat(customSession.query("MATCH (s:DomainObject:Student {name:'Sheila Smythe-Jones'}) return s", emptyMap()).queryResults())
             .isNotEmpty();
     }
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadByDelegateTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadByDelegateTest.java
@@ -67,7 +67,7 @@ public class LoadByDelegateTest {
     private final MetaData metaData = new MetaData("org.neo4j.ogm.domain.gh651");
 
     @Spy
-    Neo4jSession neo4jSession = new Neo4jSession(metaData, new AbstractConfigurableDriver() {
+    Neo4jSession neo4jSession = new Neo4jSession(metaData, true, new AbstractConfigurableDriver() {
         @Override protected String getTypeSystemName() {
             throw new UnsupportedOperationException();
         }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadByDelegateTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadByDelegateTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.persistence.session.capability;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.neo4j.ogm.domain.gh651.PersistentCategory;
+import org.neo4j.ogm.domain.gh651.SomeRelationshipEntity;
+import org.neo4j.ogm.domain.gh651.SomeEntity;
+import org.neo4j.ogm.driver.AbstractConfigurableDriver;
+import org.neo4j.ogm.driver.Driver;
+import org.neo4j.ogm.metadata.MetaData;
+import org.neo4j.ogm.model.GraphModel;
+import org.neo4j.ogm.request.GraphModelRequest;
+import org.neo4j.ogm.request.GraphRowListModelRequest;
+import org.neo4j.ogm.request.Request;
+import org.neo4j.ogm.response.Response;
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.delegates.LoadByIdsDelegate;
+import org.neo4j.ogm.session.delegates.LoadByTypeDelegate;
+import org.neo4j.ogm.session.delegates.LoadOneDelegate;
+import org.neo4j.ogm.session.transaction.support.TransactionalUnitOfWork;
+import org.neo4j.ogm.transaction.Transaction;
+import org.neo4j.ogm.transaction.TransactionManager;
+
+/**
+ * This test is to ensure that we correctly add the labels from class hierachies to queries, depending on whether we
+ * match all or one of a type by id or all of a type.
+ * <p>
+ * A type can be either represent a node or relationship entity
+ *
+ * @author Michael J. Simons
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LoadByDelegateTest {
+
+    private final MetaData metaData = new MetaData("org.neo4j.ogm.domain.gh651");
+
+    @Spy
+    Neo4jSession neo4jSession = new Neo4jSession(metaData, new AbstractConfigurableDriver() {
+        @Override protected String getTypeSystemName() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Function<TransactionManager, BiFunction<Transaction.Type, Iterable<String>, Transaction>> getTransactionFactorySupplier() {
+            return transactionManager -> null;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public Request request(Transaction transaction) {
+            return null;
+        }
+    });
+
+    @Mock
+    Request request;
+
+    @Before
+    public void prepareMocks() {
+        doReturn(metaData).when(neo4jSession).metaData();
+        doReturn(request).when(neo4jSession).requestHandler();
+        doAnswer(invocation -> ((TransactionalUnitOfWork) invocation.getArgument(0)).doInTransaction())
+            .when(neo4jSession).doInTransaction(any(TransactionalUnitOfWork.class), any(Transaction.Type.class));
+        Response<GraphModel> response = new Response<GraphModel>() {
+            @Override
+            public GraphModel next() {
+                return null;
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override public String[] columns() {
+                return new String[0];
+            }
+        };
+        doReturn(response).when(request).execute(Mockito.any(GraphModelRequest.class));
+        doReturn(response).when(request).execute(Mockito.any(GraphRowListModelRequest.class));
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForStandardEntity() {
+
+        LoadByIdsDelegate delegate = new LoadByIdsDelegate(neo4jSession);
+        delegate.loadAll(SomeEntity.class, Arrays.asList(1L, 2L));
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`SomeEntity`) WHERE ID(n) IN $ids WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForOneStandardEntity() {
+
+        LoadOneDelegate delegate = new LoadOneDelegate(neo4jSession);
+        delegate.load(SomeEntity.class, 4711L);
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`SomeEntity`) WHERE ID(n) = $id WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForAllStandardEntities() {
+
+        LoadByTypeDelegate delegate = new LoadByTypeDelegate(neo4jSession);
+        delegate.loadAll(SomeEntity.class);
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`SomeEntity`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseAllLabelsInInheritanceScenario() {
+
+        LoadByIdsDelegate delegate = new LoadByIdsDelegate(neo4jSession);
+        delegate.loadAll(PersistentCategory.class, Collections.singletonList("abc"));
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`Category`:`Entity`) WHERE n.`uuid` IN $ids WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseAllLabelsForOneEntityInInheritanceScenario() {
+
+        LoadOneDelegate delegate = new LoadOneDelegate(neo4jSession);
+        delegate.load(PersistentCategory.class, "abc");
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`Category`:`Entity`) WHERE n.`uuid` = $id WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseAllLabelsForAllEntitiesInInheritanceScenario() {
+
+        LoadByTypeDelegate delegate = new LoadByTypeDelegate(neo4jSession);
+        delegate.loadAll(PersistentCategory.class);
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).isEqualTo("MATCH (n:`Category`:`Entity`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p");
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForRelationshipEntities() {
+
+        LoadByIdsDelegate delegate = new LoadByIdsDelegate(neo4jSession);
+        delegate.loadAll(SomeRelationshipEntity.class, Arrays.asList(1L, 2L));
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).startsWith("MATCH ()-[r0:`SOME_RELATIONSHIP`]-() WHERE ID(r0) IN $ids");
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForOneRelationshipEntity() {
+
+        LoadOneDelegate delegate = new LoadOneDelegate(neo4jSession);
+        delegate.load(SomeRelationshipEntity.class, 1L);
+        ArgumentCaptor<GraphModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).startsWith("MATCH ()-[r0:`SOME_RELATIONSHIP`]->() WHERE ID(r0)=$id");
+    }
+
+    @Test // GH-651
+    public void shouldUseOnlyOneLabelForAllRelationshipEntities() {
+
+        LoadByTypeDelegate delegate = new LoadByTypeDelegate(neo4jSession);
+        delegate.loadAll(SomeRelationshipEntity.class);
+        ArgumentCaptor<GraphRowListModelRequest> argumentCaptor = ArgumentCaptor.forClass(GraphRowListModelRequest.class);
+
+        verify(request).execute(argumentCaptor.capture());
+        assertThat(argumentCaptor.getValue().getStatement()).startsWith("MATCH ()-[r0:`SOME_RELATIONSHIP`]-()");
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -661,9 +661,9 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
     @Test
     public void shouldReadHierarchy4() {
         session.query(
-            "CREATE (:Female {name:'Daniela'})," +
-                "(:Male {name:'Michal'})," +
-                "(:Bloke:Male {name:'Adam'})",
+            "CREATE (:Person:Female {name:'Daniela'})," +
+                "(:Male:Person {name:'Michal'})," +
+                "(:Bloke:Male:Person {name:'Adam'})",
             emptyMap());
         session.clear();
 
@@ -677,34 +677,6 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
 
         assertThat(males).hasSize(2);
         assertThat(males.containsAll(Arrays.asList(michal, adam))).isTrue();
-
-        assertThat(females).hasSize(1);
-        assertThat(females.contains(daniela)).isTrue();
-
-        assertThat(blokes).hasSize(1);
-        assertThat(blokes.contains(adam)).isTrue();
-    }
-
-    @Test
-    // the logic of this test is debatable. the domain model and persisted schema are not the same.
-    public void shouldReadHierarchy5() {
-        session.query(
-            "CREATE (:Female {name:'Daniela'})," +
-                "(:Male {name:'Michal'})," +
-                "(:Bloke {name:'Adam'})",
-            emptyMap());
-        session.clear();
-
-        Female daniela = new Female("Daniela");
-        Male michal = new Male("Michal");
-        Bloke adam = new Bloke("Adam");
-
-        Collection<Male> males = session.loadAll(Male.class);
-        Collection<Female> females = session.loadAll(Female.class);
-        Collection<Bloke> blokes = session.loadAll(Bloke.class);
-
-        assertThat(males).hasSize(1);
-        assertThat(males.containsAll(Arrays.asList(michal))).isTrue();
 
         assertThat(females).hasSize(1);
         assertThat(females.contains(daniela)).isTrue();

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/ClassHierarchiesIntegrationTest.java
@@ -65,6 +65,7 @@ import org.neo4j.ogm.testutil.TestContainersTestBase;
  *
  * @author Michal Bachman
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
 
@@ -89,10 +90,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedChildWithAnnotatedAbstractNamedParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void annotatedChildWithAnnotatedNamedInterfaceParent() {
         session.save(new AnnotatedChildWithAnnotatedNamedInterfaceParent());
 
@@ -107,10 +105,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedChildWithAnnotatedAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void annotatedChildWithAnnotatedInterfaceParent() {
         session.save(new AnnotatedChildWithAnnotatedInterfaceParent());
 
@@ -138,10 +133,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedChildWithPlainAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void annotatedChildWithPlainInterfaceParent() {
         session.save(new AnnotatedChildWithPlainInterfaceParent());
 
@@ -164,10 +156,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
             .isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     @Ignore("class hierarchies are invalid for this test: multiple classes labelled 'Child' and 'Parent'")
     public void annotatedNamedChildWithAnnotatedNamedInterface() {
         session.save(new AnnotatedNamedChildWithAnnotatedNamedInterfaceParent());
@@ -184,10 +173,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedNamedChildWithAnnotatedAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     @Ignore("class hierarchies are invalid for this test: multiple classes labelled 'Child' and 'Parent'")
     public void annotatedNamedChildWithAnnotatedInterfaceParent() {
         session.save(new AnnotatedNamedChildWithAnnotatedInterfaceParent());
@@ -221,10 +207,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedNamedChildWithPlainAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     @Ignore("class hierarchies are invalid for this test: multiple classes labelled 'Child' and 'Parent'")
     public void annotatedNamedChildWithPlainInterfaceParent() {
         session.save(new AnnotatedNamedChildWithPlainInterfaceParent());
@@ -261,10 +244,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainChildWithAnnotatedAbstractNamedParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithAnnotatedNamedInterfaceParent() {
         session.save(new PlainChildWithAnnotatedNamedInterfaceParent());
 
@@ -278,10 +258,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainChildWithAnnotatedAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithAnnotatedInterfaceParent() {
         session.save(new PlainChildWithAnnotatedInterfaceParent());
 
@@ -309,10 +286,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainChildWithPlainAbstractParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithPlainInterfaceParent() {
         session.save(new PlainChildWithPlainInterfaceParent());
 
@@ -326,10 +300,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainChildWithPlainConcreteParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithPlainConcreteParentImplementingInterface() {
         session.save(new PlainChildWithPlainConcreteParentImplementingInterface());
 
@@ -338,20 +309,14 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainConcreteParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithPlainInterfaceChild() {
         session.save(new PlainChildWithPlainInterfaceChild());
 
         assertThat(session.loadAll(PlainChildWithPlainInterfaceChild.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithAnnotatedSuperInterface() {
         /*
         PlainChildWithAnnotatedSuperInterface->PlainInterfaceChildWithAnnotatedParentInterface->AnnotatedInterface
@@ -361,10 +326,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(PlainChildWithAnnotatedSuperInterface.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void annotatedChildWithAnnotatedInterface() {
         /*
         AnnotatedChildWithAnnotatedInterface->AnnotatedInterfaceWithSingleImpl
@@ -378,10 +340,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
             .isEqualTo("org.neo4j.ogm.domain.hierarchy.domain.annotated.AnnotatedChildWithAnnotatedInterface");
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithAnnotatedSuperclass() {
         /*
            PlainChildWithAnnotatedConcreteSuperclass->PlainChildWithAnnotatedConcreteParent->AnnotatedConcreteParent
@@ -393,10 +352,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedConcreteParent.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildWithAbstractParentAndAnnotatedSuperclass() {
         /*
            PlainChildWithAbstractParentAndAnnotatedSuperclass->PlainAbstractWithAnnotatedParent->AnnotatedSingleClass
@@ -408,10 +364,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(AnnotatedSingleClass.class).iterator().next()).isNotNull();
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void annotatedChildWithMultipleAnnotatedInterfaces() {
         session.save(new AnnotatedChildWithMultipleAnnotatedInterfaces());
 
@@ -436,10 +389,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.query("MATCH (n) return n", emptyMap())).hasSize(0);
     }
 
-    /**
-     * @see DATAGRAPH-577
-     */
-    @Test
+    @Test // DATAGRAPH-577
     public void plainChildOfTransientInterface() {
         assertThatThrownBy(() -> session.save(new PlainChildOfTransientInterface()))
             .isInstanceOf(IllegalArgumentException.class)
@@ -660,23 +610,54 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
 
     @Test
     public void shouldReadHierarchy4() {
-        session.query(
-            "CREATE (:Person:Female {name:'Daniela'})," +
-                "(:Male:Person {name:'Michal'})," +
-                "(:Bloke:Male:Person {name:'Adam'})",
+        Session customSession = new SessionFactory(getDriver(), false, "org.neo4j.ogm.domain.hierarchy.domain").openSession();
+        customSession.query(
+            "CREATE (:Female {name:'Daniela'})," +
+                "(:Male {name:'Michal'})," +
+                "(:Bloke:Male {name:'Adam'})",
             emptyMap());
-        session.clear();
+        customSession.clear();
 
         Female daniela = new Female("Daniela");
         Male michal = new Male("Michal");
         Bloke adam = new Bloke("Adam");
 
-        Collection<Male> males = session.loadAll(Male.class);
-        Collection<Female> females = session.loadAll(Female.class);
-        Collection<Bloke> blokes = session.loadAll(Bloke.class);
+        Collection<Male> males = customSession.loadAll(Male.class);
+        Collection<Female> females = customSession.loadAll(Female.class);
+        Collection<Bloke> blokes = customSession.loadAll(Bloke.class);
 
         assertThat(males).hasSize(2);
         assertThat(males.containsAll(Arrays.asList(michal, adam))).isTrue();
+
+        assertThat(females).hasSize(1);
+        assertThat(females.contains(daniela)).isTrue();
+
+        assertThat(blokes).hasSize(1);
+        assertThat(blokes.contains(adam)).isTrue();
+    }
+
+    @Test
+    // the logic of this test is debatable. the domain model and persisted schema are not the same.
+    public void shouldReadHierarchy5() {
+        // ^^ Yep, the debatable behaviour became much more appearant with strict querying.
+        Session customSession = new SessionFactory(getDriver(), false, "org.neo4j.ogm.domain.hierarchy.domain").openSession();
+        customSession.query(
+            "CREATE (:Female {name:'Daniela'})," +
+                "(:Male {name:'Michal'})," +
+                "(:Bloke {name:'Adam'})",
+            emptyMap());
+        customSession.clear();
+
+        Female daniela = new Female("Daniela");
+        Male michal = new Male("Michal");
+        Bloke adam = new Bloke("Adam");
+
+        Collection<Male> males = customSession.loadAll(Male.class);
+        Collection<Female> females = customSession.loadAll(Female.class);
+        Collection<Bloke> blokes = customSession.loadAll(Bloke.class);
+
+        assertThat(males).hasSize(1);
+        assertThat(males.containsAll(Arrays.asList(michal))).isTrue();
 
         assertThat(females).hasSize(1);
         assertThat(females.contains(daniela)).isTrue();
@@ -716,10 +697,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(session.loadAll(Female.class)).isEmpty();
     }
 
-    /**
-     * @see DATAGRAPH-735
-     */
-    @Test
+    @Test // DATAGRAPH-735
     public void shouldLoadRelatedSuperclasses() {
         session.query(
             "CREATE (f1:Female:Person {name:'f1'})," +
@@ -735,10 +713,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(m1.getChildren().iterator().next().getName()).isEqualTo("c1");
     }
 
-    /**
-     * #553
-     */
-    @Test
+    @Test // GH-553
     public void shouldLoadImplementationWhenParentClassIsQueriedDirectSubclass() {
         UUID uuid = UUID.randomUUID();
         SubEntity subEntity = new SubEntity();
@@ -753,10 +728,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(rootEntity).isNotNull();
     }
 
-    /**
-     * #553
-     */
-    @Test
+    @Test // GH-553
     public void shouldLoadImplementationWhenParentClassIsQueriedDeepSubclass() {
         UUID uuid = UUID.randomUUID();
         SubSubEntity subsubEntity = new SubSubEntity();
@@ -771,10 +743,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(rootEntity).isNotNull();
     }
 
-    /**
-     * #553
-     */
-    @Test
+    @Test // GH-553
     public void shouldLoadImplementationWhenParentClassIsQueriedDeepSubclasWithsMostBasicEntity() {
         UUID uuid = UUID.randomUUID();
         SubSubEntity subsubEntity = new SubSubEntity();
@@ -789,10 +758,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(rootEntity).isNull();
     }
 
-    /**
-     * #553
-     */
-    @Test
+    @Test // GH-553
     public void shouldLoadImplementationWhenParentClassIsQueriedLoadAll() {
         UUID uuid = UUID.randomUUID();
         SubSubEntity subsubEntity = new SubSubEntity();
@@ -807,10 +773,7 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
         assertThat(rootEntity).isNotEmpty();
     }
 
-    /**
-     * #553
-     */
-    @Test
+    @Test // GH-553
     public void shouldLoadImplementationWhenParentClassIsQueriedLoadAllWithAbstractNonAnnotatedBaseClass() {
         UUID uuid = UUID.randomUUID();
         SubSubEntity subsubEntity = new SubSubEntity();
@@ -824,5 +787,4 @@ public class ClassHierarchiesIntegrationTest extends TestContainersTestBase {
 
         assertThat(rootEntity).isEmpty();
     }
-
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/BookmarkTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/BookmarkTest.java
@@ -62,7 +62,7 @@ public class BookmarkTest {
     @Before
     public void setUp() {
         BoltDriver driver = new BoltDriver(nativeDriver);
-        session = new Neo4jSession(new MetaData("org.neo4j.ogm.empty"), driver);
+        session = new Neo4jSession(new MetaData("org.neo4j.ogm.empty"), true, driver);
     }
 
     @Test

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/SessionFactoryTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/SessionFactoryTest.java
@@ -97,4 +97,21 @@ public class SessionFactoryTest extends TestContainersTestBase {
         assertThatIllegalArgumentException()
             .isThrownBy(() -> sessionFactory.unwrap(GraphDatabaseService.class));
     }
+
+    @Test
+    public void correctUseStrictQueryingSettingShouldBeApplied() {
+
+        SessionFactory sessionFactory;
+        sessionFactory = new SessionFactory("org.neo4j.ogm.domain.gh651");
+        assertThat(sessionFactory.isUseStrictQuerying()).isTrue();
+
+        sessionFactory = new SessionFactory(new Configuration.Builder().relaxedQuerying().build(), "org.neo4j.ogm.domain.gh651");
+        assertThat(sessionFactory.isUseStrictQuerying()).isFalse();
+
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh651");
+        assertThat(sessionFactory.isUseStrictQuerying()).isTrue();
+
+        sessionFactory = new SessionFactory(getDriver(), false, "org.neo4j.ogm.domain.gh651");
+        assertThat(sessionFactory.isUseStrictQuerying()).isFalse();
+    }
 }


### PR DESCRIPTION
OGM is an Object Graph Mapping framework. This makes the object model the schema of the graph. Schema and graph must fit together.

When users map out their domain, they often use inheritance, defining base labels etc. Those labels should be taken into consideration, not only during writes (as it is currently implemented) but also during reads. 

This makes indexes defined at a parent class actually usable and it also keeps users from surprises when the object model suddenly adds labels to nodes.

While this started out as an improvement for the index (see #651), it actually changes some behaviour, notable the fact that a query may find less nodes than expected. That is always the case when nodes have been created outside ogm and users forgot labels.

Two tests have been changed to reflect that, see `EntityGraphMapperTest#updateObjectPropertyAndLabel` and `ClassHierarchiesIntegrationTest`. 

Apart from that, please have a look at the detailed message of the 2nd commit.

The first one is independent from the changes and a general improvement.

@steffen-harbich-itc please chime in if you have an opinion on the behavioural change. I would assume that not many users are affect. Even without having the argument of indexes actually working, I like the changed behaviour proposed here much better.

We shall either accept that for all (`loadOneById`, `loadAllByIds`, `loadAll`) or none. Having one of those methods behave different than others makes things worse.