### PR TITLE
GH-391 - Fix lookup of inner, static classes.

### DIFF
--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/context/SingleUseEntityMapperTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.neo4j.ogm.domain.gh391.SomeContainer;
 import org.neo4j.ogm.domain.gh551.AnotherThing;
 import org.neo4j.ogm.domain.gh551.ThingResult;
 import org.neo4j.ogm.domain.gh552.Thing;
@@ -47,7 +48,7 @@ public class SingleUseEntityMapperTest extends TestContainersTestBase {
 
     @BeforeClass
     public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh551");
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh551", "org.neo4j.ogm.domain.gh391");
 
         // Prepare test data
         sessionFactory.openSession()
@@ -84,6 +85,23 @@ public class SingleUseEntityMapperTest extends TestContainersTestBase {
         SingleUseEntityMapper entityMapper = new SingleUseEntityMapper(metaData, new ReflectionEntityInstantiator(metaData));
         Thing thing = entityMapper.map(Thing.class, properties);
         assertThat(thing.getNotAName()).isEqualTo(properties.get(propertyKey));
+    }
+
+    @Test // GH-391
+    public void shouldDealWithStaticInnerClasses() {
+
+        SingleUseEntityMapper entityMapper =
+            new SingleUseEntityMapper(sessionFactory.metaData(),
+                new ReflectionEntityInstantiator(sessionFactory.metaData()));
+
+        Iterable<Map<String, Object>> results = sessionFactory.openSession()
+            .query("MATCH (t:ThingEntity) RETURN 'a name' as something LIMIT 1", EMPTY_MAP)
+            .queryResults();
+
+        assertThat(results).hasSize(1);
+
+        SomeContainer.StaticInnerThingResult thingResult = entityMapper.map(SomeContainer.StaticInnerThingResult.class, results.iterator().next());
+        assertThat(thingResult.getSomething()).isEqualTo("a name");
     }
 
     @Test

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh391/ClassWithNonUniqueSimpleName.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh391/ClassWithNonUniqueSimpleName.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh391;
+
+/**
+ * Don't delete, they are used in testing lookup scenarios of classes in the meta data.
+ *
+ * @author Michael J. Simons
+ */
+public class ClassWithNonUniqueSimpleName {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh391/SomeContainer.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh391/SomeContainer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh391;
+
+/**
+ * @author Michael J. Simons
+ */
+public interface SomeContainer {
+
+    class StaticInnerThingResult {
+
+        private String something;
+
+        public String getSomething() {
+            return something;
+        }
+
+        public void setSomething(String something) {
+            this.something = something;
+        }
+    }
+
+    /**
+     * Don't delete, they are used in testing lookup scenarios of classes in the meta data.
+     */
+    class ClassWithNonUniqueSimpleName {
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ClassWithNonUniqueSimpleName.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/ClassWithNonUniqueSimpleName.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh551;
+
+/**
+ * Don't delete, they are used in testing lookup scenarios of classes in the meta data.
+ *
+ * @author Michael J. Simons
+ */
+public class ClassWithNonUniqueSimpleName {
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
@@ -68,7 +68,7 @@ public class DomainInfoTest {
     }
 
     @Test
-    public void shouldLoadClassesCorrectlyWithSimpleClassLoader() throws Exception {
+    public void shouldLoadClassesCorrectlyWithSimpleClassLoader() {
         final String classLoaderName = Thread.currentThread().getContextClassLoader().getClass().getSimpleName();
         new DomainInfoTestClassLoaderTestStub().assertCorrectClassLoaders(classLoaderName, classLoaderName);
     }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MetaDataTest.java
@@ -37,7 +37,11 @@ import javax.tools.ToolProvider;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.neo4j.ogm.domain.gh391.ClassWithNonUniqueSimpleName;
+import org.neo4j.ogm.domain.gh391.SomeContainer;
+import org.neo4j.ogm.domain.gh551.ThingResult;
 import org.neo4j.ogm.exception.core.AmbiguousBaseClassException;
+import org.neo4j.ogm.exception.core.MappingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +89,22 @@ public class MetaDataTest {
     public void testCanResolveClassHierarchies() {
         ClassInfo classInfo = metaData.resolve("Login", "User");
         assertThat(classInfo.name()).isEqualTo("org.neo4j.ogm.domain.forum.Member");
+    }
+
+    @Test // GH-391
+    public void shouldLookupClassesByTheirSimpleNameCorrectly() {
+
+        MetaData metaData1 = new MetaData("org.neo4j.ogm.domain.gh551", "org.neo4j.ogm.domain.gh391");
+
+        assertThat(metaData1.classInfo(SomeContainer.StaticInnerThingResult.class.getSimpleName())).isNotNull();
+        assertThat(metaData1.classInfo("I dont't exist")).isNull();
+        assertThat(metaData1.classInfo(".*")).isNull();
+        assertThat(metaData1.classInfo(ThingResult.class.getName())).isNotNull();
+        assertThat(metaData1.classInfo(ThingResult.class.getSimpleName())).isNotNull();
+        assertThat(metaData1.classInfo(ClassWithNonUniqueSimpleName.class.getName())).isNotNull();
+        assertThat(metaData1.classInfo(SomeContainer.ClassWithNonUniqueSimpleName.class.getName())).isNotNull();
+        assertThatExceptionOfType(MappingException.class)
+            .isThrownBy(() -> metaData1.classInfo("ClassWithNonUniqueSimpleName"));
     }
 
     @Test(expected = AmbiguousBaseClassException.class)


### PR DESCRIPTION
While the original issue has been fixed in the case of `SingleUseEntityMapper`, the issue still applies for all other possible entities.

The change makes the `DomainInfo` search for classes that end with either `.Partial` or `$Partial` name.

This closes #391.