### PR TITLE
GH-718 - Recursively traverse variable length relationship patterns.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/result/adapter/GraphModelAdapter.java
+++ b/api/src/main/java/org/neo4j/ogm/result/adapter/GraphModelAdapter.java
@@ -32,8 +32,9 @@ import org.neo4j.ogm.response.model.RelationshipModel;
 /**
  * This adapter will transform an embedded response into a json response
  *
- * @author vince
+ * @author Vince Bickers
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 public abstract class GraphModelAdapter extends BaseAdapter implements ResultAdapter<Map<String, Object>, GraphModel> {
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/cineasts/minimum/SomeQueryResult.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/cineasts/minimum/SomeQueryResult.java
@@ -18,47 +18,43 @@
  */
 package org.neo4j.ogm.domain.cineasts.minimum;
 
-import org.neo4j.ogm.annotation.EndNode;
-import org.neo4j.ogm.annotation.RelationshipEntity;
-import org.neo4j.ogm.annotation.StartNode;
+import java.util.Set;
 
 /**
- * @author Vince Bickers
+ * Query result that contains mapped relationship entities. Comes from GH-718, the user used a variable length relationship
+ * query that wasn't correctly mapped.
+ *
+ * @author Michael J. Simons
  */
-@RelationshipEntity(type = "ACTS_IN")
-public class Role {
+public class SomeQueryResult {
 
-    Long id;
-    String played;
+    private Actor actor;
 
-    @StartNode
-    Actor actor;
+    private Set<Role> roles;
 
-    @EndNode
-    Movie movie;
+    private Set<Movie> movies;
 
-    public Role() {
+    public Actor getActor() {
+        return actor;
     }
 
-    public Role(String played, Actor actor, Movie movie) {
-        this.played = played;
+    public void setActor(Actor actor) {
         this.actor = actor;
-        this.movie = movie;
     }
 
-    public Long getId() {
-        return id;
+    public Set<Role> getRoles() {
+        return roles;
     }
 
-    public Movie getMovie() {
-        return movie;
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
     }
 
-    public String getPlayed() {
-        return played;
+    public Set<Movie> getMovies() {
+        return movies;
     }
 
-    public void setMovie(Movie movie) {
-        this.movie = movie;
+    public void setMovies(Set<Movie> movies) {
+        this.movies = movies;
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/RelationshipEntityMappingTest.java
@@ -63,12 +63,6 @@ public class RelationshipEntityMappingTest extends TestContainersTestBase {
     }
 
     @Test
-    public void f() {
-
-
-    }
-
-    @Test
     public void testThatAnnotatedRelationshipOnRelationshipEntityCreatesTheCorrectRelationshipTypeInTheGraph() {
         Movie hp = new Movie("Goblet of Fire", 2005);
 


### PR DESCRIPTION
This change fixes the inconsistent behavior of the `org.neo4j.ogm.result.adapter.RestModelAdapter` that didn’t traverse nested things as the `org.neo4j.ogm.result.adapter.GraphModelAdapter` does. Would a fixed length pattern had been used in #718 the mapping would have worked as expected.

However, it is actual the point to collect all of the relationship entities of the given point, so we have to traverse the collection of relationships we get back.

This fixes #718.