### PR TITLE
GH-729 - Fix class loading issues with Spring Boot Devtools.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -103,7 +103,7 @@ public class ClassInfo {
     private volatile MethodInfo postLoadMethod;
     private volatile Collection<String> staticLabels;
     private boolean primaryIndexFieldChecked = false;
-    private Class<?> cls;
+    private final Class<?> cls;
     private Class<? extends IdStrategy> idStrategyClass;
     private IdStrategy idStrategy;
 
@@ -836,14 +836,7 @@ public class ClassInfo {
     private synchronized Map<String, FieldInfo> initIndexFields() {
         Map<String, FieldInfo> indexes = new HashMap<>();
 
-        // No way to get declared fields from current byte code impl. Using reflection instead.
-        Field[] declaredFields;
-        try {
-            declaredFields = Class.forName(className, false, Thread.currentThread().getContextClassLoader())
-                .getDeclaredFields();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Could not reflectively read declared fields", e);
-        }
+        Field[] declaredFields = cls.getDeclaredFields();
 
         for (FieldInfo fieldInfo : fieldsInfo().fields()) {
             if (isDeclaredField(declaredFields, fieldInfo.getName()) &&
@@ -880,13 +873,6 @@ public class ClassInfo {
         // init property fields to be able to check existence of properties
         propertyFields();
 
-        if (cls == null) {
-            try {
-                cls = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Could not get annotation info for class " + className, e);
-            }
-        }
         CompositeIndex[] annotations = cls.getDeclaredAnnotationsByType(CompositeIndex.class);
         ArrayList<CompositeIndex> result = new ArrayList<>(annotations.length);
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <dropwizard-metrics.version>4.0.2</dropwizard-metrics.version>
-        <classgraph.version>4.8.41</classgraph.version>
+        <classgraph.version>4.8.59</classgraph.version>
         <httpclient.version>4.5.2</httpclient.version>
         <httpcore.version>4.4.10</httpcore.version>
         <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
This change replaces ClassGraphs class loading facility with the
previous solution of using the current threads class loader, as the
integration with Spring Boot's devtools stopped working in ClassGraph
4.8.19.

It also fixes two places where a previous loaded domain class is loaded
again just to determine fields.

Last, it upgrades ClassGraph to the latest version.
