### PR TITLE
GH-746 - Fix optimistic locking for relationship entities.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -544,7 +544,7 @@ public class EntityGraphMapper implements EntityMapper {
             if (relationshipIsNew || relationshipEndsChanged) {
                 relationshipBuilder = cypherBuilder.newRelationship(directedRelationship.type());
                 if (relationshipEndsChanged) {
-                    // since this relationship will get recreated but all properties will be copied
+                    // since this relationship will get recreated and all properties will be copied in the process,
                     // we have to reset the control fields for version and identifier.
                     FieldInfo versionField = metaData.classInfo(entity).getVersionField();
                     if (versionField != null) {

--- a/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/EntityGraphMapper.java
@@ -544,6 +544,12 @@ public class EntityGraphMapper implements EntityMapper {
             if (relationshipIsNew || relationshipEndsChanged) {
                 relationshipBuilder = cypherBuilder.newRelationship(directedRelationship.type());
                 if (relationshipEndsChanged) {
+                    // since this relationship will get recreated but all properties will be copied
+                    // we have to reset the control fields for version and identifier.
+                    FieldInfo versionField = metaData.classInfo(entity).getVersionField();
+                    if (versionField != null) {
+                        versionField.write(entity, null);
+                    }
                     EntityUtils.setIdentity(entity, null, metaData);
                 }
             } else {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/locking/User.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/locking/User.java
@@ -88,6 +88,11 @@ public class User {
         return friendOf;
     }
 
+    public void addFriend(FriendOf friendOf) {
+        friends.add(friendOf);
+        friendOf.setTo(this);
+    }
+
     public void clearFriends() {
         friends.clear();
     }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/locking/RelationshipEntityOptimisticLockingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/locking/RelationshipEntityOptimisticLockingTest.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.ogm.persistence.examples.locking;
 
+import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Collection;
@@ -224,6 +225,32 @@ public class RelationshipEntityOptimisticLockingTest extends TestContainersTestB
         michael.clearFriends();
 
         session.save(michael);
+
+        ensureFriendsOfRelationshipsHaveCount(0);
+    }
+
+    @Test // GH-746
+    public void updateVersionedRelationship() {
+        User michael = new User("Michael");
+        User oliver = new User("Oliver");
+        FriendOf friendOf = michael.addFriend(oliver);
+
+        session.save(michael);
+
+        oliver.clearFriends();
+
+        User george = new User("George");
+        george.addFriend(friendOf);
+        session.save(michael);
+
+        ensureFriendsOfRelationshipsHaveCount(1);
+    }
+
+    private void ensureFriendsOfRelationshipsHaveCount(long count) {
+        session.clear();
+        Long relationshipCount = (Long) session.query("MATCH ()-[r:FRIEND_OF]->() return count(r) as c", emptyMap())
+            .queryResults().iterator().next().get("c");
+        assertThat(relationshipCount).isEqualTo(count);
     }
 
 }


### PR DESCRIPTION
Reset the version attribute on a virtually new relationship entity if the target node has changed.
The solution is pretty much straight-forward but there is no better place to not affect other parts of the mapping to track a "new" relationship entity.

Closes #746