### PR TITLE
Select correct string converter.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ObjectAnnotations.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ObjectAnnotations.java
@@ -23,6 +23,7 @@ import static java.util.stream.Collectors.*;
 import java.lang.annotation.Annotation;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -32,10 +33,12 @@ import org.neo4j.ogm.annotation.typeconversion.DateString;
 import org.neo4j.ogm.annotation.typeconversion.EnumString;
 import org.neo4j.ogm.annotation.typeconversion.NumberString;
 import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.typeconversion.DateLongConverter;
 import org.neo4j.ogm.typeconversion.DateStringConverter;
 import org.neo4j.ogm.typeconversion.EnumStringConverter;
 import org.neo4j.ogm.typeconversion.InstantLongConverter;
+import org.neo4j.ogm.typeconversion.InstantStringConverter;
 import org.neo4j.ogm.typeconversion.NumberStringConverter;
 
 /**
@@ -101,7 +104,14 @@ public class ObjectAnnotations {
         AnnotationInfo dateStringConverterInfo = get(DateString.class);
         if (dateStringConverterInfo != null) {
             String format = dateStringConverterInfo.get(DateString.FORMAT, DateString.ISO_8601);
-            return new DateStringConverter(format, isLenientConversion(dateStringConverterInfo));
+
+            if (fieldType == Date.class) {
+                return new DateStringConverter(format, isLenientConversion(dateStringConverterInfo));
+            } else if (fieldType == Instant.class) {
+                return new InstantStringConverter(format, isLenientConversion(dateStringConverterInfo));
+            } else {
+                throw new MappingException("Cannot use @DateString with attribute of type " + fieldType);
+            }
         }
 
         AnnotationInfo enumStringConverterInfo = get(EnumString.class);

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/InstantStringConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/InstantStringConverter.java
@@ -21,6 +21,9 @@ package org.neo4j.ogm.typeconversion;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.ogm.annotation.typeconversion.DateString;
+
 /**
  * Converter to convert between {@link Instant} and {@link String}.
  * Stores values in database as string in format specified by
@@ -29,13 +32,25 @@ import java.time.format.DateTimeFormatter;
  *
  * @author Nicolas Mervaillie
  * @author Róbert Papp
+ * @author Michael J. Simons
  */
 public class InstantStringConverter implements AttributeConverter<Instant, String> {
 
     private final DateTimeFormatter formatter;
+    private final boolean lenient;
 
     public InstantStringConverter() {
-        formatter = DateTimeFormatter.ISO_INSTANT;
+
+        this.formatter = DateTimeFormatter.ISO_INSTANT;
+        this.lenient = false;
+    }
+
+    public InstantStringConverter(String userDefinedFormat, boolean lenient) {
+
+        this.formatter = DateString.ISO_8601.equals(userDefinedFormat) ?
+            DateTimeFormatter.ISO_INSTANT :
+            DateTimeFormatter.ofPattern(userDefinedFormat);
+        this.lenient = lenient;
     }
 
     @Override
@@ -48,7 +63,7 @@ public class InstantStringConverter implements AttributeConverter<Instant, Strin
 
     @Override
     public Instant toEntityAttribute(String value) {
-        if (value == null) {
+        if (value == null || (lenient && StringUtils.isBlank(value))) {
             return null;
         }
         return Instant.parse(value);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/convertible/date/Memo.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/convertible/date/Memo.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.ogm.domain.convertible.date;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Set;
 
@@ -53,6 +54,9 @@ public class Memo {
 
     @DateLong
     private Date closed;
+
+    @DateString
+    private Instant actionedAsInstant;
 
     // uses default ISO 8601 date format
     private Date[] escalations;
@@ -93,6 +97,14 @@ public class Memo {
 
     public void setActioned(Date actioned) {
         this.actioned = actioned;
+    }
+
+    public Instant getActionedAsInstant() {
+        return actionedAsInstant;
+    }
+
+    public void setActionedAsInstant(Instant actionedAsInstant) {
+        this.actionedAsInstant = actionedAsInstant;
     }
 
     public Date getModified() {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/convertible/ConvertibleIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/types/convertible/ConvertibleIntegrationTest.java
@@ -121,11 +121,8 @@ public class ConvertibleIntegrationTest extends TestContainersTestBase {
             .equals(Education.PHD)).isTrue();
     }
 
-    /**
-     * @see DATAGRAPH-550
-     */
-    @Test
-    public void shouldSaveAndRetrieveDates() throws ParseException {
+    @Test // DATAGRAPH-550 GH-758
+    public void shouldSaveAndRetrieveDates() {
         SimpleDateFormat simpleDateISO8601format = new SimpleDateFormat(DateString.ISO_8601);
         simpleDateISO8601format.setTimeZone(TimeZone.getTimeZone("UTC"));
 
@@ -152,6 +149,7 @@ public class ConvertibleIntegrationTest extends TestContainersTestBase {
         memo.setEscalations(escalations);
         memo.setActioned(actioned.getTime());
         memo.setClosed(new Date());
+        memo.setActionedAsInstant(actioned.toInstant());
         session.save(memo);
 
         Memo loadedMemo = session.loadAll(Memo.class, new Filter("memo", ComparisonOperator.EQUALS, "theMemo"))
@@ -162,6 +160,7 @@ public class ConvertibleIntegrationTest extends TestContainersTestBase {
         assertThat(loadedCal.get(Calendar.DAY_OF_MONTH)).isEqualTo(actioned.get(Calendar.DAY_OF_MONTH));
         assertThat(loadedCal.get(Calendar.MONTH)).isEqualTo(actioned.get(Calendar.MONTH));
         assertThat(loadedCal.get(Calendar.YEAR)).isEqualTo(actioned.get(Calendar.YEAR));
+        assertThat(loadedMemo.getActionedAsInstant()).isEqualTo(actioned.toInstant());
 
         assertThat(loadedMemo.getImplementations()).hasSize(2);
         Iterator<Date> implementationsIter = loadedMemo.getImplementations().iterator();


### PR DESCRIPTION
We state that `@DateString` can be used both on  `java.util.Date` and `java.time.Instant`. However, that is not true: Both underlying converters maybe used, but the annotation picked always the `DateStringConverter`. This change fixes that behaviour and closes #758.