### PR TITLE
Update classgraph dependency to start up in low-memory environments

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -81,9 +81,10 @@ public class DomainInfo {
         Predicate<Class<?>> classIsMappable = clazz -> !(clazz.isAnnotation() || clazz.isAnonymousClass() || clazz
             .equals(Object.class));
 
-        // We cannot use the ClassGraph class loader as the order of class loaders used is broken since
-        // ClassGraph 4.8.19 again when `org.springframework.boot.devtools.restart.classloader.RestartClassLoader`
-        // is present.
+        // We only use ClassGraph for scanning classes and than use our default class loader to load them.
+        // There's some chance that our configuration might not be able to find or load the classes.
+        // On the other hand, we were not able to override ClassGraph's class loader in such a way that
+        // when classes have been loaded from class graph, they would work with Spring Boot devtools.
         ClassLoader classLoader = Configuration.getDefaultClassLoader();
         try (ScanResult scanResult = findClasses(packages)) {
             for (String className : scanResult.getAllClasses().getNames()) {

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <dropwizard-metrics.version>4.0.2</dropwizard-metrics.version>
-        <classgraph.version>4.8.60</classgraph.version>
+        <classgraph.version>4.8.64</classgraph.version>
         <httpclient.version>4.5.11</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
See https://github.com/classgraph/classgraph/issues/400 for more details.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Bump a version number of `classgraph` so that Neo4J OGM can work in lower-memory setups easily. It should be a minor change as it was updated only 4 releases ago which was a month ago.

## Related Issue
There's no issue in this repo, the "Background" in https://github.com/classgraph/classgraph/issues/400  is the issue.

## Motivation and Context
I'm following up on https://github.com/classgraph/classgraph/issues/400#issuecomment-586705917
[4.8.63](https://github.com/classgraph/classgraph/releases/tag/classgraph-4.8.63) has a fix for an infinite loop on OOM and significantly lowers the memory consumption of classgraph itself. But it doesn't work on JDK7-8, so using the latest 4.8.64 which fixes that compatibility issue.

## How Has This Been Tested?
I have a project where I overrode the `classloader` dependency with
```kotlin
allprojects {
	configurations.all {
		resolutionStrategy.dependencySubstitution.all {
			val requested = this.requested
			if (requested is ModuleComponentSelector
				&& requested.module == "classgraph"
				&& requested.group == "io.github.classgraph"
			) {
				if (VersionNumber.parse(requested.version) < VersionNumber.parse("4.8.62")) {
					// 4.8.63 doesn't work on JDK 8
					useTarget(
						"${requested.group}:${requested.module}:4.8.64",
						"Performance issue with low memory: https://github.com/classgraph/classgraph/issues/400"
					)
				}
			}
		}
	}
}
```
My harness integration tests pass and app works as before on JDK 8 and -Xmx64M (previously it was sometimes failing with -Xmx256M and consistently failing with -Xmx128M).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.  
       **(I still didn't read it as it still doesn't exist... I commented on this in #501 too :)**
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.  
   _I'll leave this up to the CI_
