### PR TITLE
Fix compilation error on Windows

### DIFF
--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
@@ -40,10 +40,9 @@ class KotlinMetaDataTest {
         assertThat(javaClassInfo.postLoadMethodOrNull()).isNotNull
 
         val kotlinClassInfo = metaData.classInfo("KotlinAImpl")
-
         assertThat<String>(kotlinClassInfo.staticLabels()).containsExactlyInAnyOrderElementsOf(javaClassInfo.staticLabels())
-        assertThat<String>(kotlinClassInfo.fieldsInfo().fields().map { it.name })
-                .containsExactlyInAnyOrderElementsOf(javaFields)
+        val kotlinFields = kotlinClassInfo.fieldsInfo().fields().map { it.name }
+        assertThat<String>(kotlinFields).containsExactlyInAnyOrderElementsOf(javaFields)
         assertThat(kotlinClassInfo.postLoadMethodOrNull()).isNotNull
 
         val aKotlinClass = KotlinAImpl()

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
@@ -42,7 +42,7 @@ class KotlinMetaDataTest {
         val kotlinClassInfo = metaData.classInfo("KotlinAImpl")
 
         assertThat<String>(kotlinClassInfo.staticLabels()).containsExactlyInAnyOrderElementsOf(javaClassInfo.staticLabels())
-        assertThat<String>(kotlinClassInfo.fieldsInfo().fields().stream().map { it.name })
+        assertThat<String>(kotlinClassInfo.fieldsInfo().fields().map { it.name })
                 .containsExactlyInAnyOrderElementsOf(javaFields)
         assertThat(kotlinClassInfo.postLoadMethodOrNull()).isNotNull
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
@@ -34,15 +34,15 @@ class KotlinMetaDataTest {
         val metaData = MetaData("org.neo4j.ogm.domain.gh685", "org.neo4j.ogm.domain.delegation")
 
         val javaClassInfo = metaData.classInfo("JavaAImpl")
-        assertThat<String>(javaClassInfo.staticLabels()).containsExactlyInAnyOrder("Base", "A")
+        assertThat(javaClassInfo.staticLabels()).containsExactlyInAnyOrder("Base", "A")
         val javaFields = javaClassInfo.fieldsInfo().fields().map { it.name }
-        assertThat<String>(javaFields).containsExactlyInAnyOrder("id", "ownAttr", "baseName")
+        assertThat(javaFields).containsExactlyInAnyOrder("id", "ownAttr", "baseName")
         assertThat(javaClassInfo.postLoadMethodOrNull()).isNotNull
 
         val kotlinClassInfo = metaData.classInfo("KotlinAImpl")
-        assertThat<String>(kotlinClassInfo.staticLabels()).containsExactlyInAnyOrderElementsOf(javaClassInfo.staticLabels())
+        assertThat(kotlinClassInfo.staticLabels()).containsExactlyInAnyOrderElementsOf(javaClassInfo.staticLabels())
         val kotlinFields = kotlinClassInfo.fieldsInfo().fields().map { it.name }
-        assertThat<String>(kotlinFields).containsExactlyInAnyOrderElementsOf(javaFields)
+        assertThat(kotlinFields).containsExactlyInAnyOrderElementsOf(javaFields)
         assertThat(kotlinClassInfo.postLoadMethodOrNull()).isNotNull
 
         val aKotlinClass = KotlinAImpl()


### PR DESCRIPTION
## Description
<details><summary>Fix this compilation error on Windows:

  > java.io.FileNotFoundException: P:\projects\contrib\github-neo4j-ogm\neo4j-ogm-tests\neo4j-ogm-integration-tests\target\test-classes\org\neo4j\ogm\kotlin\KotlinMetaDataTest$Kotlin's "implementation by delegation" should yield same result as Java equivalent$1.class (The filename, directory name, or volume label syntax is incorrect)

 [click to expand]</summary>

  ```
  [ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.3.61:test-compile (test-compile) on project neo4j-ogm-integration-tests: Compilation failure
  [ERROR] java.lang.IllegalStateException: Backend Internal error: Exception during code generation
  [ERROR] File being compiled at position: file://P:/projects/contrib/github-neo4j-ogm/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
  [ERROR] The root cause java.io.FileNotFoundException was thrown at: java.io.FileOutputStream.open0(Native Method)
  [ERROR]         at org.jetbrains.kotlin.codegen.CompilationErrorHandler.lambda$static$0(CompilationErrorHandler.java:35)
  [ERROR]         at org.jetbrains.kotlin.codegen.PackageCodegenImpl.generate(PackageCodegenImpl.java:76)
  [ERROR]         at org.jetbrains.kotlin.codegen.DefaultCodegenFactory.generatePackage(CodegenFactory.kt:96)
  [ERROR]         at org.jetbrains.kotlin.codegen.DefaultCodegenFactory.generateModule(CodegenFactory.kt:67)
  [ERROR]         at org.jetbrains.kotlin.codegen.KotlinCodegenFacade.doGenerateFiles(KotlinCodegenFacade.java:47)
  [ERROR]         at org.jetbrains.kotlin.codegen.KotlinCodegenFacade.compileCorrectFiles(KotlinCodegenFacade.java:39)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.generate(KotlinToJVMBytecodeCompiler.kt:637)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.compileModules$cli(KotlinToJVMBytecodeCompiler.kt:195)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:165)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:55)
  [ERROR]         at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:84)
  [ERROR]         at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:42)
  [ERROR]         at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:104)
  [ERROR]         at org.jetbrains.kotlin.maven.KotlinCompileMojoBase.execCompiler(KotlinCompileMojoBase.java:228)
  [ERROR]         at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execCompiler(K2JVMCompileMojo.java:237)
  [ERROR]         at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execCompiler(K2JVMCompileMojo.java:55)
  [ERROR]         at org.jetbrains.kotlin.maven.KotlinCompileMojoBase.execute(KotlinCompileMojoBase.java:209)
  [ERROR]         at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execute(K2JVMCompileMojo.java:222)
  [ERROR]         at org.jetbrains.kotlin.maven.KotlinTestCompileMojo.execute(KotlinTestCompileMojo.java:84)
  [ERROR]         at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
  [ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
  [ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
  [ERROR]         at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
  [ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
  [ERROR]         at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
  [ERROR]         at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
  [ERROR]         at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
  [ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
  [ERROR]         at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
  [ERROR]         at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
  [ERROR]         at org.apache.maven.cli.MavenCli.execute(MavenCli.java:956)
  [ERROR]         at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
  [ERROR]         at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
  [ERROR]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  [ERROR]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  [ERROR]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  [ERROR]         at java.lang.reflect.Method.invoke(Method.java:498)
  [ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
  [ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
  [ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
  [ERROR]         at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
  [ERROR]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  [ERROR]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  [ERROR]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  [ERROR]         at java.lang.reflect.Method.invoke(Method.java:498)
  [ERROR]         at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
  [ERROR]         at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
  [ERROR]         at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:61)
  [ERROR] Caused by: java.io.FileNotFoundException: P:\projects\contrib\github-neo4j-ogm\neo4j-ogm-tests\neo4j-ogm-integration-tests\target\test-classes\org\neo4j\ogm\kotlin\KotlinMetaDataTest$Kotlin's "implementation by delegation" should yield same result as Java equivalent$1.class (The filename, directory name, or volume label syntax is incorrect)
  [ERROR]         at java.io.FileOutputStream.open0(Native Method)
  [ERROR]         at java.io.FileOutputStream.open(FileOutputStream.java:270)
  [ERROR]         at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
  [ERROR]         at com.intellij.openapi.util.io.FileUtil.writeToFile(FileUtil.java:1057)
  [ERROR]         at com.intellij.openapi.util.io.FileUtil.writeToFile(FileUtil.java:1051)
  [ERROR]         at com.intellij.openapi.util.io.FileUtil.writeToFile(FileUtil.java:1036)
  [ERROR]         at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt.writeAll(outputUtils.kt:32)
  [ERROR]         at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt.writeAllTo(outputUtils.kt:37)
  [ERROR]         at org.jetbrains.kotlin.cli.common.output.OutputUtilsKt.writeAll(outputUtils.kt:41)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.writeOutput(KotlinToJVMBytecodeCompiler.kt:102)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler.access$writeOutput(KotlinToJVMBytecodeCompiler.kt:82)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$createOutputFilesFlushingCallbackIfPossible$1.invoke(KotlinToJVMBytecodeCompiler.kt:111)
  [ERROR]         at org.jetbrains.kotlin.cli.jvm.compiler.KotlinToJVMBytecodeCompiler$createOutputFilesFlushingCallbackIfPossible$1.invoke(KotlinToJVMBytecodeCompiler.kt:82)
  [ERROR]         at org.jetbrains.kotlin.codegen.state.GenerationStateKt$GenerationStateEventCallback$1.invoke(GenerationState.kt:354)
  [ERROR]         at org.jetbrains.kotlin.codegen.state.GenerationStateKt$GenerationStateEventCallback$1.invoke(GenerationState.kt:353)
  [ERROR]         at org.jetbrains.kotlin.codegen.state.GenerationState.afterIndependentPart(GenerationState.kt:310)
  [ERROR]         at org.jetbrains.kotlin.codegen.PackageCodegenImpl.generate(PackageCodegenImpl.java:69)
  [ERROR]         ... 46 more
  ```
</details>

I'm guessing it only applies to Windows, otherwise CI would be failing left and right.

## Related Issue
See https://discuss.kotlinlang.org/t/more-characters-allowed-for-identifiers-than-grammar-specifies-what-is-supported/2359/4. An alternative fix would've been to change `"` to `'`, but I like the method name, so I opted to fix the root cause.
For some (probably historical) reason `.stream()` was used to generate a list of fields to be verified. This is ok, but `Stream.map` is a Java function and there's a Kotlin SAM conversion taking place when it is passed a `{ it.name }` which means that an anonymous local inner class is being created. Local classes have the quirk of including not only the outer class name, but also the method name. Which means that the full `.class` file name includes the quotes.
To alleviate this simply removing the `.stream()` call forces Kotlin to compile against `Iterable<T>.map` which is a Kotlin extension function and is inline so there's no extra class created for the lambda, just a for loop.

## Motivation and Context
I tried to run `mvnw verify` on my computer and got a compilation error in `KotlinMetaDataTest.kt`.

## How Has This Been Tested?
The test compiles and runs green after this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
