### PR TITLE
Fix Session.load/queryForObject nullability

### DIFF
--- a/core/src/main/kotlin/org/neo4j/ogm/session/SessionExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/session/SessionExtensions.kt
@@ -66,7 +66,7 @@ inline fun <reified T : Any> Session.loadAll(
 /**
  * Extension for [Session.load] leveraging reified type parameters.
  */
-inline fun <reified T : Any> Session.load(id: Serializable, depth: Int = 1): T =
+inline fun <reified T : Any> Session.load(id: Serializable, depth: Int = 1): T? =
         load(T::class.java, id, depth)
 
 /**
@@ -87,7 +87,7 @@ inline fun <reified T : Any> Session.delete(filters : Iterable<Filter>, listResu
 inline fun <reified T : Any> Session.queryForObject(
         cypher: String,
         parameters: Map<String, Any> = emptyMap()
-): T = queryForObject(T::class.java, cypher, parameters)
+): T? = queryForObject(T::class.java, cypher, parameters)
 
 /**
  * Extension for [Session.query] leveraging reified type parameters.

--- a/core/src/main/kotlin/org/neo4j/ogm/session/SessionFactoryExtensions.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/session/SessionFactoryExtensions.kt
@@ -21,4 +21,4 @@ package org.neo4j.ogm.session
 /**
  * Extension for [SessionFactory.unwrap] leveraging reified type parameters.
  */
-inline fun <reified T : Any> SessionFactory.unwrap(): T = unwrap(T::class.java)
+inline fun <reified T : Any> SessionFactory.unwrap(): T? = unwrap(T::class.java)

--- a/core/src/test/kotlin/org/neo4j/ogm/session/SessionExtensionsTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/session/SessionExtensionsTest.kt
@@ -18,8 +18,10 @@
  */
 package org.neo4j.ogm.session
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.neo4j.ogm.cypher.Filter
 import org.neo4j.ogm.cypher.Filters
@@ -78,6 +80,16 @@ class SessionExtensionsTest {
     }
 
     @Test
+    fun `load(id) extension should call its Java counterpart and allow null to be returned`() {
+        every { session.load(any<Class<*>>(), any<Long>(), any()) } returns(null)
+
+        val result = session.load<SomeEntity>(23L)
+
+        verify(exactly = 1) { session.load(SomeEntity::class.java, 23L, 1) }
+        assertNull(result)
+    }
+
+    @Test
     fun `deleteAll extension should call its Java counterpart`() {
 
         session.deleteAll<SomeEntity>()
@@ -101,6 +113,17 @@ class SessionExtensionsTest {
         session.queryForObject<SomeEntity>(cypher)
 
         verify(exactly = 1) { session.queryForObject(SomeEntity::class.java, cypher, emptyMap<String, Any>()) }
+    }
+
+    @Test
+    fun `queryForObject extension should call its Java counterpart and allow null to be returned`() {
+        every { session.queryForObject(any<Class<*>>(), any(), any()) } returns(null)
+
+        val cypher = "MATCH (n:SomeEntity) RETURN n LIMIT 1"
+        val result = session.queryForObject<SomeEntity>(cypher)
+
+        verify(exactly = 1) { session.queryForObject(SomeEntity::class.java, cypher, emptyMap<String, Any>()) }
+        assertNull(result)
     }
 
     @Test

--- a/core/src/test/kotlin/org/neo4j/ogm/session/SessionFactoryExtensionsTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/session/SessionFactoryExtensionsTest.kt
@@ -18,10 +18,12 @@
  */
 package org.neo4j.ogm.session
 
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
 import org.neo4j.ogm.driver.Driver
+import kotlin.test.assertNotNull
 
 /**
  * @author Michael J. Simons
@@ -29,12 +31,15 @@ import org.neo4j.ogm.driver.Driver
 class SessionFactoryExtensionsTest {
 
     val sessionFactory = mockk<SessionFactory>(relaxed = true)
+    val driver = mockk<Driver>()
 
     @Test
     fun `unwrap extension should call its Java counterpart`() {
 
-        sessionFactory.unwrap<Driver>()
+        every { sessionFactory.unwrap<Driver>()} returns driver
+        val driver = sessionFactory.unwrap<Driver>()!!
 
+        assertNotNull(driver)
         verify(exactly = 1) { sessionFactory.unwrap(Driver::class.java) }
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
@@ -39,6 +39,7 @@ import org.neo4j.ogm.domain.gh696.Lion
 import org.neo4j.ogm.domain.gh696.Zebra
 import org.neo4j.ogm.domain.gh696.ZooKotlin
 import org.neo4j.ogm.session.*
+import kotlin.test.assertNotNull
 
 /**
  * @author Michael J. Simons
@@ -103,15 +104,16 @@ class KotlinInteropTest {
     @Test
     fun basicMappingShouldWork() {
 
-        var myNode = MyNode(name = "Node1", description = "A node", otherNodes = listOf(OtherNode(name = "o1"), OtherNode(name = "o2")))
-            sessionFactory.openSession().save(myNode)
+        val myNode = MyNode(name = "Node1", description = "A node", otherNodes = listOf(OtherNode(name = "o1"), OtherNode(name = "o2")))
+        sessionFactory.openSession().save(myNode)
 
-        myNode = sessionFactory.openSession().load(myNode.dbId!!)
-            assertThat(myNode.name).isEqualTo("Node1")
-            assertThat(myNode.description).isEqualTo("A node")
-            assertThat(myNode.otherNodes)
-                    .hasSize(2)
-                    .extracting("name").containsExactlyInAnyOrder("o1", "o2")
+        val loadedNode: MyNode? = sessionFactory.openSession().load(myNode.dbId!!)
+        assertNotNull(loadedNode)
+        assertThat(loadedNode.name).isEqualTo("Node1")
+        assertThat(loadedNode.description).isEqualTo("A node")
+        assertThat(loadedNode.otherNodes)
+                .hasSize(2)
+                .extracting("name").containsExactlyInAnyOrder("o1", "o2")
 
         driver.session().use {
             val resultList = it.run("MATCH (n:MyNode) WHERE id(n) = \$id RETURN n", Values.parameters("id", myNode.dbId)).list()
@@ -200,7 +202,8 @@ class KotlinInteropTest {
     @Test
     fun `queryForObject should work`() {
 
-        val farin : MyNode = sessionFactory.openSession().queryForObject("MATCH (n:MyNode {name: \$name}) RETURN n", mapOf(Pair("name", "Farin")))
+        val farin : MyNode? = sessionFactory.openSession().queryForObject("MATCH (n:MyNode {name: \$name}) RETURN n", mapOf(Pair("name", "Farin")))
+        assertNotNull(farin)
         assertThat(farin.name).isEqualTo("Farin")
     }
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
@@ -43,6 +43,7 @@ import kotlin.test.assertNotNull
 
 /**
  * @author Michael J. Simons
+ * @author Róbert Papp
  */
 class KotlinInteropTest {
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinInteropTest.kt
@@ -79,7 +79,7 @@ class KotlinInteropTest {
         }
     }
 
-    val names = listOf("Brian", "Roger", "John", "Freddie", "Farin", "Rod", "Bela")
+    private val names = listOf("Brian", "Roger", "John", "Freddie", "Farin", "Rod", "Bela")
 
     @Before
     fun prepareData() {
@@ -131,10 +131,10 @@ class KotlinInteropTest {
         val nodes = sessionFactory.openSession().loadAll<KotlinAImpl>()
         assertThat(nodes.map { it.baseName }).containsExactly("someValue")
 
-        sessionFactory.openSession().save(KotlinAImpl());
+        sessionFactory.openSession().save(KotlinAImpl())
 
         driver.session().use {
-            val resultList = it.run("MATCH (n:A:Base) RETURN count(n) as n ").single()["n"].asLong();
+            val resultList = it.run("MATCH (n:A:Base) RETURN count(n) as n ").single()["n"].asLong()
             assertThat(resultList).isEqualTo(2L)
         }
     }
@@ -145,7 +145,7 @@ class KotlinInteropTest {
         val nodes = sessionFactory.openSession().loadAll<ZooKotlin>()
         assertThat(nodes).hasSize(1)
         assertThat(nodes.first().animals).hasSize(2)
-        assertThat(nodes.first().animals!!.map { it::class.java }).containsExactlyInAnyOrder(Lion::class.java, Zebra::class.java);
+        assertThat(nodes.first().animals!!.map { it::class.java }).containsExactlyInAnyOrder(Lion::class.java, Zebra::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Description
Add tests and fix nullability for these methods that can and will return null.

## Related Issue
See first commit for failing tests for repro.

## Motivation and Context
The mentioned method explicitly declare nullability, but they're restricted in the Kotlin extension functions.

https://github.com/neo4j/neo4j-ogm/blob/0fafd9b0da25fb1571ed84b80083e0bdd8acae19/core/src/main/java/org/neo4j/ogm/session/Session.java#L489-L494

https://github.com/neo4j/neo4j-ogm/blob/0fafd9b0da25fb1571ed84b80083e0bdd8acae19/core/src/main/java/org/neo4j/ogm/session/Session.java#L496-L501

https://github.com/neo4j/neo4j-ogm/blob/0fafd9b0da25fb1571ed84b80083e0bdd8acae19/core/src/main/java/org/neo4j/ogm/session/Session.java#L609-L613

This causes a problem when used like this:
```kotlin
import org.neo4j.ogm.session.queryForObject

class UserService(
	private val session: Session
) {

	fun find(id: String): User =
		session.queryForObject(
			"""
			MATCH (u:User{id:{id}})
			RETURN u AS user
			""",
			mapOf(
				"id" to id
			)
		)
}
```
Notice that because `queryForObject` declared a non-null return type, I can too. But when I call `find` with a wrong ID, it'll blow up with:
> `java.lang.IllegalStateException`: `queryForObject(T::class.java, cypher, parameters)` must not be `null`

This means that a simple inline utility function changes behavior of the method on the interface.

Note that `T` is restricted to non-null (`: Any`) in generics. Adding `T?` as return value is explicitly making this nullable, which it should be. Alternatively changing to `<T: Any?>` would work too, but it's not safe as seen here:
![image](https://user-images.githubusercontent.com/2906988/74989429-34dcaa80-5438-11ea-8f5a-1dbccf982be5.png)
notice how specifying the type argument for the function (explicit or inferred doesn't matter), we're telling Kotlin one thing, but receiving another. See how a non-null inferred `result` is actually passing an `assertNull` test?! 😨 If it was actually using that variable, it would blow up with NPE.

The big problem here is that in Kotlin a change like this is like changing from an interface to a concrete type in Java. It's going to break practically everyone who used this method. The fix is easy though: either `!!` if they're sure the value they're querying is there, or add a null check (`if`/`?.`/`?: fallback`/`?: return`/`?: error()`) to signal appropriately for their project.

## How Has This Been Tested?
Added unit tests.
TODO: should I add an integration test too for not found value being null?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
**It is a breaking change because every time someone used this function they assumed non-null, see context above.**

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
**As in: a big warning in Changelog and release notes.**
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
