### PR TITLE
Add String.asParam().

### DIFF
--- a/core/src/main/kotlin/org/neo4j/ogm/utils/Parameters.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/utils/Parameters.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.utils
+
+// A couple of extension methods that escapes $parameterNames inside multiline strings.
+// See ParameterTest.kt for an example how to use them.
+
+inline fun String.asParam() = "\$" + this
+
+infix fun String.Companion.asParam(s: String) = "\$" + s

--- a/core/src/main/kotlin/org/neo4j/ogm/utils/Parameters.kt
+++ b/core/src/main/kotlin/org/neo4j/ogm/utils/Parameters.kt
@@ -21,6 +21,18 @@ package org.neo4j.ogm.utils
 // A couple of extension methods that escapes $parameterNames inside multiline strings.
 // See ParameterTest.kt for an example how to use them.
 
+/**
+ * Extension on [String] returning the string itself prefixed with an escaped `$`.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
 inline fun String.asParam() = "\$" + this
 
+/**
+ * Extension on [String]'s companion object returning the string passed to it prefixed with an escaped `$`.
+ *
+ * @author Michael J. Simons
+ * @since 1.0
+ */
 infix fun String.Companion.asParam(s: String) = "\$" + s

--- a/core/src/test/kotlin/org/neo4j/ogm/utils/ParameterTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/utils/ParameterTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.utils
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+/**
+ * @author Michael J. Simons
+ */
+class ParameterTest {
+
+    @Test
+    fun `named parameters in multiline strings shouldn't be that hard`() {
+
+        """
+            MATCH (n:Something {n.name: ${"someParameter".asParam()}}
+            WHERE n.someProperty = ${String asParam "someOther"}
+        """.trimIndent().apply {
+
+            assertEquals("MATCH (n:Something {n.name: \$someParameter}\nWHERE n.someProperty = \$someOther", this)
+        };
+    }
+}

--- a/core/src/test/kotlin/org/neo4j/ogm/utils/ParametersTest.kt
+++ b/core/src/test/kotlin/org/neo4j/ogm/utils/ParametersTest.kt
@@ -21,11 +21,10 @@ package org.neo4j.ogm.utils
 import org.junit.Test
 import kotlin.test.assertEquals
 
-
 /**
  * @author Michael J. Simons
  */
-class ParameterTest {
+class ParametersTest {
 
     @Test
     fun `named parameters in multiline strings shouldn't be that hard`() {


### PR DESCRIPTION
This allows easier escaping of $parameterNames in Kotlins multiline strings.

I'm gonna add something similar to SDN/RX.