### PR TITLE
Enhance Pre- and PostSave events to include the saved object’s state.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/event/PostSaveEvent.java
+++ b/core/src/main/java/org/neo4j/ogm/session/event/PostSaveEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session.event;
+
+/**
+ * Specialized {@link Event} which is fired before an entity is saved. If the application receives an {@link Event} that
+ * returns {@link }Type#POST_SAVE} from {@link Event#getLifeCycle()}, the event can safely be down casted.
+ *
+ * @author Michael J. Simons
+ * @since 3.2.11
+ */
+public final class PostSaveEvent extends PersistenceEvent {
+
+    private final boolean wasNew;
+
+    public PostSaveEvent(Object affectedObject, boolean wasNew) {
+
+        super(affectedObject, TYPE.POST_SAVE);
+        this.wasNew = wasNew;
+    }
+
+    /**
+     * @return True, if the object was new before it was saved.
+     */
+    public boolean wasNew() {
+        return wasNew;
+    }
+}

--- a/core/src/main/java/org/neo4j/ogm/session/event/PreSaveEvent.java
+++ b/core/src/main/java/org/neo4j/ogm/session/event/PreSaveEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session.event;
+
+/**
+ * Specialized {@link Event} which is fired before an entity is saved. If the application receives an {@link Event} that
+ * returns {@link }Type#PRE_SAVE} from {@link Event#getLifeCycle()}, the event can safely be down casted.
+ *
+ * @author Michael J. Simons
+ * @since 3.2.11
+ */
+public final class PreSaveEvent extends PersistenceEvent {
+
+    private final boolean isNew;
+
+    public PreSaveEvent(Object affectedObject, boolean isNew) {
+
+        super(affectedObject, TYPE.PRE_SAVE);
+        this.isNew = isNew;
+    }
+
+    public boolean isNew() {
+        return isNew;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/EventTestBaseClass.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/EventTestBaseClass.java
@@ -167,13 +167,17 @@ public abstract class EventTestBaseClass extends TestContainersTestBase {
         }
 
         public boolean captured(Object o, Event.TYPE lifecycle) {
+            return get(o, lifecycle) != null;
+        }
+
+        public Event get(Object o, Event.TYPE lifecycle) {
             Event event = new PersistenceEvent(o, lifecycle);
             for (Event captured : eventsCaptured) {
                 if (captured.toString().equals(event.toString())) {
-                    return true;
+                    return captured;
                 }
             }
-            return false;
+            return null;
         }
 
         public int count() {
@@ -186,7 +190,7 @@ public abstract class EventTestBaseClass extends TestContainersTestBase {
     }
 
     @After
-    public void clean() throws IOException {
+    public void clean() {
         session.purgeDatabase();
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/NodeEntityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/NodeEntityTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.neo4j.ogm.domain.filesystem.Document;
 import org.neo4j.ogm.domain.filesystem.Folder;
 import org.neo4j.ogm.session.event.Event;
+import org.neo4j.ogm.session.event.PostSaveEvent;
+import org.neo4j.ogm.session.event.PreSaveEvent;
 
 /**
  * @author vince
@@ -53,8 +55,12 @@ public class NodeEntityTest extends EventTestBaseClass {
 
         assertThat(eventListener.count()).isEqualTo(2);
 
-        assertThat(eventListener.captured(e, Event.TYPE.PRE_SAVE)).isTrue();
-        assertThat(eventListener.captured(e, Event.TYPE.POST_SAVE)).isTrue();
+        Event captured = eventListener.get(e, Event.TYPE.PRE_SAVE);
+        assertThat(captured).isNotNull();
+        assertThat(((PreSaveEvent) captured).isNew()).isTrue();
+        captured = eventListener.get(e, Event.TYPE.POST_SAVE);
+        assertThat(captured).isNotNull();
+        assertThat(((PostSaveEvent) captured).wasNew()).isTrue();
     }
 
     @Test
@@ -65,8 +71,12 @@ public class NodeEntityTest extends EventTestBaseClass {
 
         assertThat(eventListener.count()).isEqualTo(2);
 
-        assertThat(eventListener.captured(a, Event.TYPE.PRE_SAVE)).isTrue();
-        assertThat(eventListener.captured(a, Event.TYPE.POST_SAVE)).isTrue();
+        Event captured = eventListener.get(a, Event.TYPE.PRE_SAVE);
+        assertThat(captured).isNotNull();
+        assertThat(((PreSaveEvent) captured).isNew()).isFalse();
+        captured = eventListener.get(a, Event.TYPE.POST_SAVE);
+        assertThat(captured).isNotNull();
+        assertThat(((PostSaveEvent) captured).wasNew()).isFalse();
     }
 
     @Test

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/RelationshipEntityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/events/RelationshipEntityTest.java
@@ -26,6 +26,8 @@ import java.util.Random;
 import org.junit.Test;
 import org.neo4j.ogm.domain.cineasts.annotated.Knows;
 import org.neo4j.ogm.session.event.Event;
+import org.neo4j.ogm.session.event.PostSaveEvent;
+import org.neo4j.ogm.session.event.PreSaveEvent;
 
 /**
  * @author vince
@@ -83,11 +85,17 @@ public class RelationshipEntityTest extends EventTestBaseClass {
         session.save(bruce);
 
         assertThat(eventListener.captured(knowsBS, Event.TYPE.PRE_SAVE)).isTrue();
+        assertThat(((PreSaveEvent) eventListener.get(knowsBS, Event.TYPE.PRE_SAVE)).isNew()).isTrue();
         assertThat(eventListener.captured(knowsBS, Event.TYPE.POST_SAVE)).isTrue();
+        assertThat(((PostSaveEvent) eventListener.get(knowsBS, Event.TYPE.POST_SAVE)).wasNew()).isTrue();
         assertThat(eventListener.captured(bruce, Event.TYPE.PRE_SAVE)).isTrue();
+        assertThat(((PreSaveEvent) eventListener.get(bruce, Event.TYPE.PRE_SAVE)).isNew()).isFalse();
         assertThat(eventListener.captured(bruce, Event.TYPE.POST_SAVE)).isTrue();
+        assertThat(((PostSaveEvent) eventListener.get(bruce, Event.TYPE.POST_SAVE)).wasNew()).isFalse();
         assertThat(eventListener.captured(stan, Event.TYPE.PRE_SAVE)).isTrue();
+        assertThat(((PreSaveEvent) eventListener.get(stan, Event.TYPE.PRE_SAVE)).isNew()).isFalse();
         assertThat(eventListener.captured(stan, Event.TYPE.POST_SAVE)).isTrue();
+        assertThat(((PostSaveEvent) eventListener.get(stan, Event.TYPE.POST_SAVE)).wasNew()).isFalse();
 
         assertThat(eventListener.count()).isEqualTo(6);
     }


### PR DESCRIPTION
The PreSave event now indicates `isNew` and the PostSave event now indicates `wasNew`. This closes #317.