### PR TITLE
GH-787 - Use converter for id based loading.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -100,7 +100,8 @@ public class MappingContext {
         }
 
         // direct match
-        Object node = primaryIndexNodeRegister.get(new LabelPrimaryId(classInfo, id));
+        final LabelPrimaryId key = new LabelPrimaryId(classInfo, id);
+        Object node = primaryIndexNodeRegister.get(key);
         if (node != null) {
             return node;
         }

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadByIdsDelegate.java
@@ -69,7 +69,9 @@ public class LoadByIdsDelegate extends SessionDelegate {
         }
 
         QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
-        PagingAndSortingQuery qry = queryStatements.findAllByType(labelsOrType.get(), ids, depth)
+
+        ClassInfo classInfo = session.metaData().classInfo(type.getName());
+        PagingAndSortingQuery qry = queryStatements.findAllByType(labelsOrType.get(), convertIfNeeded(classInfo, ids), depth)
             .setSortOrder(sortOrder)
             .setPagination(pagination);
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/LoadOneDelegate.java
@@ -79,7 +79,8 @@ public class LoadOneDelegate extends SessionDelegate {
         }
 
         QueryStatements<ID> queryStatements = session.queryStatementsFor(type, depth);
-        PagingAndSortingQuery qry = queryStatements.findOneByType(labelsOrType.get(), id, depth);
+
+        PagingAndSortingQuery qry = queryStatements.findOneByType(labelsOrType.get(), convertIfNeeded(classInfo, id), depth);
 
         GraphModelRequest request = new DefaultGraphModelRequest(qry.getStatement(), qry.getParameters());
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
@@ -19,6 +19,7 @@
 package org.neo4j.ogm.session.delegates;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.neo4j.ogm.annotation.EndNode;
@@ -34,6 +35,7 @@ import org.neo4j.ogm.metadata.AnnotationInfo;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.typeconversion.AttributeConverter;
 import org.neo4j.ogm.utils.RelationshipUtils;
 
 /**
@@ -87,6 +89,25 @@ abstract class SessionDelegate {
 
             }
         }
+    }
+
+    <X extends Object> X convertIfNeeded(ClassInfo classInfo, X id) {
+        if (classInfo.hasPrimaryIndexField() && classInfo.primaryIndexField().hasPropertyConverter()) {
+         return (X) classInfo.primaryIndexField().getPropertyConverter().toGraphProperty(id); // this is fine
+        }
+        return id;
+    }
+
+    <X extends Object> Collection<X> convertIfNeeded(ClassInfo classInfo, Collection<X> ids) {
+        if (classInfo.hasPrimaryIndexField() && classInfo.primaryIndexField().hasPropertyConverter()) {
+            final AttributeConverter propertyConverter = classInfo.primaryIndexField().getPropertyConverter();
+            List<X> convertedIds = new ArrayList<>();
+            for (X id : ids) {
+                convertedIds.add((X) propertyConverter.toGraphProperty(id));
+            }
+            return convertedIds;
+        }
+        return ids;
     }
 
     private void resolveRelationshipType(Filter filter) {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/EntityWithCustomIdConverter.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/EntityWithCustomIdConverter.java
@@ -1,0 +1,24 @@
+package org.neo4j.ogm.domain.gh787;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+
+/**
+ * @author Gerrit Meier
+ */
+@NodeEntity
+public class EntityWithCustomIdConverter {
+
+    @Id
+    @Convert(MyVeryOwnIdTypeConverter.class)
+    private MyVeryOwnIdType key;
+
+    public EntityWithCustomIdConverter(MyVeryOwnIdType key) {
+        this.key = key;
+    }
+
+    public EntityWithCustomIdConverter() {
+
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/MyVeryOwnIdType.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/MyVeryOwnIdType.java
@@ -1,0 +1,36 @@
+package org.neo4j.ogm.domain.gh787;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * @author Gerrit Meier
+ */
+public class MyVeryOwnIdType implements Serializable {
+    private final String value;
+
+    public MyVeryOwnIdType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MyVeryOwnIdType blubb = (MyVeryOwnIdType) o;
+        return value.equals(blubb.value);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/MyVeryOwnIdTypeConverter.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh787/MyVeryOwnIdTypeConverter.java
@@ -1,0 +1,17 @@
+package org.neo4j.ogm.domain.gh787;
+
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+
+/**
+ * @author Gerrit Meier
+ */
+public class MyVeryOwnIdTypeConverter implements AttributeConverter<MyVeryOwnIdType, String> {
+
+    public String toGraphProperty(MyVeryOwnIdType id) {
+        return id.getValue();
+    }
+
+    public MyVeryOwnIdType toEntityAttribute(String value) {
+        return new MyVeryOwnIdType(value);
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/LoadCapabilityTest.java
@@ -37,6 +37,8 @@ import org.neo4j.ogm.domain.education.DomainObject;
 import org.neo4j.ogm.domain.education.School;
 import org.neo4j.ogm.domain.education.Student;
 import org.neo4j.ogm.domain.gh368.User;
+import org.neo4j.ogm.domain.gh787.EntityWithCustomIdConverter;
+import org.neo4j.ogm.domain.gh787.MyVeryOwnIdType;
 import org.neo4j.ogm.domain.music.Album;
 import org.neo4j.ogm.domain.music.Artist;
 import org.neo4j.ogm.domain.music.Recording;
@@ -741,5 +743,31 @@ public class LoadCapabilityTest extends TestContainersTestBase {
         assertThat(allUsers)
             .extracting(User::getFirstName)
             .containsExactly("Anna", "Bob", "Charlie");
+    }
+
+    @Test // GH-787
+    public void shouldLoadSingleEntityWithCustomId() {
+        SessionFactory sf = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh787");
+        Session sessionForIdConverter = sf.openSession();
+
+        MyVeryOwnIdType id = new MyVeryOwnIdType("1234");
+        sessionForIdConverter.save(new EntityWithCustomIdConverter(id));
+
+        sessionForIdConverter.clear();
+
+        assertThat(sessionForIdConverter.load(EntityWithCustomIdConverter.class, id)).isNotNull();
+    }
+
+    @Test // GH-787
+    public void shouldLoadMultipleEntitiesWithCustomId() {
+        SessionFactory sf = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh787");
+        Session sessionForIdConverter = sf.openSession();
+
+        MyVeryOwnIdType id = new MyVeryOwnIdType("1234");
+        sessionForIdConverter.save(new EntityWithCustomIdConverter(id));
+
+        sessionForIdConverter.clear();
+
+        assertThat(sessionForIdConverter.loadAll(EntityWithCustomIdConverter.class, Collections.singleton(id))).hasSize(1);
     }
 }


### PR DESCRIPTION
Call the `AttributeConverter` when querying for types with custom ids.

Because there cannot be one central place to call the conversion upfront, we need to do it for `load` and `loadAll` separately.

Closes GH-787