### PR TITLE
Fix reading of Neo4j literal byte[] arrays.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/result/adapter/BaseAdapter.java
+++ b/api/src/main/java/org/neo4j/ogm/result/adapter/BaseAdapter.java
@@ -18,7 +18,8 @@
  */
 package org.neo4j.ogm.result.adapter;
 
-import java.util.HashMap;
+import static java.util.stream.Collectors.*;
+
 import java.util.Map;
 
 import org.neo4j.ogm.support.CollectionUtils;
@@ -29,16 +30,18 @@ import org.neo4j.ogm.support.CollectionUtils;
  */
 public class BaseAdapter {
 
-    public Map<String, Object> convertArrayPropertiesToIterable(Map<String, Object> properties) {
-        Map<String, Object> props = new HashMap<>();
-        for (String k : properties.keySet()) {
-            Object v = properties.get(k);
-            if (v.getClass().isArray()) {
-                props.put(k, CollectionUtils.iterableOf(v));
-            } else {
-                props.put(k, v);
-            }
+    public Map<String, Object> convertArrayPropertiesToCollection(Map<String, Object> properties) {
+        return properties.entrySet().stream()
+            .collect(toMap(Map.Entry::getKey, BaseAdapter::convertOrReturnSelf));
+    }
+
+    private static Object convertOrReturnSelf(Map.Entry<String, Object> entry) {
+
+        Object entryValue = entry.getValue();
+        if (entryValue != null && entryValue.getClass().isArray()) {
+            return CollectionUtils.materializeIterableIf(CollectionUtils.iterableOf(entryValue));
+        } else {
+            return entryValue;
         }
-        return props;
     }
 }

--- a/api/src/main/java/org/neo4j/ogm/result/adapter/GraphModelAdapter.java
+++ b/api/src/main/java/org/neo4j/ogm/result/adapter/GraphModelAdapter.java
@@ -110,7 +110,7 @@ public abstract class GraphModelAdapter extends BaseAdapter implements ResultAda
         List<String> labels = labels(node);
 
         nodeModel.setLabels(labels.toArray(new String[0]));
-        nodeModel.setProperties(convertArrayPropertiesToIterable(properties(node)));
+        nodeModel.setProperties(convertArrayPropertiesToCollection(properties(node)));
         nodeModel.setGeneratedNode(generatedNode);
 
         graphModel.addNode(nodeModel);
@@ -129,7 +129,7 @@ public abstract class GraphModelAdapter extends BaseAdapter implements ResultAda
         edgeModel.setStartNode(startNodeId(relationship));
         edgeModel.setEndNode(endNodeId(relationship));
 
-        edgeModel.setProperties(convertArrayPropertiesToIterable(properties(relationship)));
+        edgeModel.setProperties(convertArrayPropertiesToCollection(properties(relationship)));
 
         graphModel.addRelationship(edgeModel);
     }

--- a/api/src/main/java/org/neo4j/ogm/result/adapter/RestModelAdapter.java
+++ b/api/src/main/java/org/neo4j/ogm/result/adapter/RestModelAdapter.java
@@ -104,7 +104,7 @@ public abstract class RestModelAdapter extends BaseAdapter
         NodeModel nodeModel = new NodeModel(nodeId(node));
         List<String> labels = labels(node);
         nodeModel.setLabels(labels.toArray(new String[labels.size()]));
-        nodeModel.setProperties(convertArrayPropertiesToIterable(properties(node)));
+        nodeModel.setProperties(convertArrayPropertiesToCollection(properties(node)));
         return nodeModel;
     }
 

--- a/api/src/main/java/org/neo4j/ogm/support/CollectionUtils.java
+++ b/api/src/main/java/org/neo4j/ogm/support/CollectionUtils.java
@@ -18,8 +18,9 @@
  */
 package org.neo4j.ogm.support;
 
-import java.util.Arrays;
+import java.lang.reflect.Array;
 import java.util.Collections;
+import java.util.Iterator;
 
 /**
  * Utilities around collections.
@@ -43,12 +44,34 @@ public final class CollectionUtils {
         } else if (thingToIterable instanceof Iterable) {
             return ((Iterable) thingToIterable);
         } else if (thingToIterable.getClass().isArray()) {
-            return Arrays.asList((Object[]) thingToIterable);
+            return () -> new ArrayIterator(thingToIterable);
         } else {
             return Collections.singletonList(thingToIterable);
         }
     }
 
     private CollectionUtils() {
+    }
+
+    private static class ArrayIterator implements Iterator<Object> {
+        private final Object source;
+        private final int length;
+
+        private int index = 0;
+
+        private ArrayIterator(Object source) {
+            this.source = source;
+            this.length = Array.getLength(source);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index < length;
+        }
+
+        @Override
+        public Object next() {
+            return Array.get(source, index++);
+        }
     }
 }

--- a/api/src/main/java/org/neo4j/ogm/support/CollectionUtils.java
+++ b/api/src/main/java/org/neo4j/ogm/support/CollectionUtils.java
@@ -19,8 +19,11 @@
 package org.neo4j.ogm.support;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Utilities around collections.
@@ -48,6 +51,20 @@ public final class CollectionUtils {
         } else {
             return Collections.singletonList(thingToIterable);
         }
+    }
+
+    /**
+     * @param entryValue A value that is needed as a collection.
+     * @return Returns a collection if {@code entryValue} is iterable but not already a collection.
+     */
+    public static Object materializeIterableIf(Object entryValue) {
+
+        if (entryValue instanceof Iterable && !(entryValue instanceof Collection)) {
+            List hlp = new ArrayList<>();
+            ((Iterable) entryValue).forEach(hlp::add);
+            entryValue = hlp;
+        }
+        return entryValue;
     }
 
     private CollectionUtils() {

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
@@ -95,7 +95,7 @@ public class EntityAccessManager {
             }
         }
 
-        // Array needs a different coercion and special treatment to pproperlyreassign the existing collection
+        // Array needs a different coercion and special treatment to properly reassign the existing collection
         if (parameterType.isArray()) {
 
             Class<?> componentType = parameterType.getComponentType();

--- a/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/reflect/EntityAccessManager.java
@@ -111,7 +111,7 @@ public class EntityAccessManager {
 
         // create the desired type of collection and use it for the merge
         Collection newCollection = createTargetCollection(parameterType,
-            mergeAndCoerce(elementType, (Collection) newValues, currentValues));
+            mergeAndCoerce(elementType, (Iterable) newValues, currentValues));
         if (newCollection != null) {
             return newCollection;
         }

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
@@ -25,11 +25,8 @@ import static org.neo4j.ogm.support.ClassUtils.*;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/MapCompositeConverter.java
@@ -101,7 +101,7 @@ public class MapCompositeConverter implements CompositeAttributeConverter<Map<?,
 
     private void addMapToProperties(Map<?, ?> fieldValue, Map<String, Object> graphProperties, String entryPrefix) {
         for (Map.Entry<?, ?> entry : fieldValue.entrySet()) {
-            Object entryValue = materializeIterableIfNecessary(entry.getValue());
+            Object entryValue = entry.getValue();
             String entryKey = entryPrefix + keyInstanceToString(entry.getKey());
             if (entryValue instanceof Map) {
                 addMapToProperties((Map<?, ?>) entryValue, graphProperties, entryKey + delimiter);
@@ -115,30 +115,6 @@ public class MapCompositeConverter implements CompositeAttributeConverter<Map<?,
                 }
             }
         }
-    }
-
-    /**
-     * When the {@link org.neo4j.ogm.result.adapter.BaseAdapter} created an iterable based on an array, we must
-     * materialize it into a real collection at this point. For normal properties, this is done through the
-     * {@link org.neo4j.ogm.metadata.reflect.EntityAccessManager}, but that doesn't apply here.
-     * <p>
-     * In the end, this is a necessity due to the fact that while {@code AdapterUtils} prior to 3.2.11 returned
-     * a concrete {@link List} for arrays even though they said {@code convertToIterable}.
-     * <p>
-     * The later method has been refactored into {@link org.neo4j.ogm.support.CollectionUtils#iterableOf(Object)} which
-     * actually does what the name says, so we need to adapt here.
-     *
-     * @param entryValue The value that might be an iterable but not a collection
-     * @return A collection if {@code value} had been iterable, the value itself otherwise.
-     */
-    private static Object materializeIterableIfNecessary(Object entryValue) {
-
-        if (entryValue instanceof Iterable && !(entryValue instanceof Collection)) {
-            List hlp = new ArrayList<>();
-            ((Iterable) entryValue).forEach(hlp::add);
-            entryValue = hlp;
-        }
-        return entryValue;
     }
 
     private boolean canCastType(Object value) {

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/NoOpByteArrayConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/NoOpByteArrayConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.typeconversion;
+
+/**
+ * This converter is provided for convenience so that the default conversion of byte arrays ({@literal byte[]}
+ * to Base64 encoded Strings can be turned off. <strong>Be aware that this works only with the embedded or bolt transport!
+ * Neo4j's HTTP endpoint does not support literal byte arrays. In that case, the values will be stored as Base64 encoded string.
+ * Those Strings can be however read into a byte array literal.
+ * </strong>
+ *
+ * @author Michael J. Simons
+ */
+public final class NoOpByteArrayConverter implements AttributeConverter<byte[], byte[]> {
+
+    @Override
+    public byte[] toGraphProperty(byte[] value) {
+        return value;
+    }
+
+    @Override public byte[] toEntityAttribute(byte[] value) {
+        return value;
+    }
+}

--- a/core/src/main/java/org/neo4j/ogm/typeconversion/NoOpWrappedByteArrayConverter.java
+++ b/core/src/main/java/org/neo4j/ogm/typeconversion/NoOpWrappedByteArrayConverter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.typeconversion;
+
+/**
+ * This converter is provided for convenience so that the default conversion of byte arrays ({@literal Byte[]}
+ * to Base64 encoded Strings can be turned off. <strong>Be aware that this works only with the embedded or bolt transport!
+ * Neo4j's HTTP endpoint does not support literal byte arrays. In that case, the values will be stored as Base64 encoded string.
+ * Those Strings can be however read into a byte array literal.
+ * </strong>
+ *
+ * @author Michael J. Simons
+ */
+public final class NoOpWrappedByteArrayConverter implements AttributeConverter<Byte[], byte[]> {
+
+    @Override
+    public byte[] toGraphProperty(Byte[] value) {
+
+        if (value == null) {
+            return null;
+        }
+        byte[] unwrapped = new byte[value.length];
+        for (int i = 0; i < value.length; i++) {
+            unwrapped[i] = value[i];
+        }
+        return unwrapped;
+    }
+
+    @Override
+    public Byte[] toEntityAttribute(byte[] value) {
+
+        if (value == null) {
+            return null;
+        }
+        Byte[] wrapped = new Byte[value.length];
+        for (int i = 0; i < value.length; i++) {
+            wrapped[i] = value[i];
+        }
+        return wrapped;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh791/EntityWithNativeByteArrays.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh791/EntityWithNativeByteArrays.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh791;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.typeconversion.Convert;
+import org.neo4j.ogm.typeconversion.AttributeConverter;
+import org.neo4j.ogm.typeconversion.NoOpByteArrayConverter;
+import org.neo4j.ogm.typeconversion.NoOpWrappedByteArrayConverter;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class EntityWithNativeByteArrays {
+
+    @Id @GeneratedValue Long id;
+
+    @Convert(NoOpByteArrayConverter.class)
+    private byte[] primitive;
+
+    @Convert(NoOpWrappedByteArrayConverter.class)
+    private Byte[] wrapped;
+
+    @Convert(SomeTupleConverter.class)
+    private SomeTuple someTuple;
+
+    public Long getId() {
+        return id;
+    }
+
+    public byte[] getPrimitive() {
+        return primitive;
+    }
+
+    public void setPrimitive(byte[] primitive) {
+        this.primitive = primitive;
+    }
+
+    public Byte[] getWrapped() {
+        return wrapped;
+    }
+
+    public void setWrapped(Byte[] wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    public SomeTuple getSomeTuple() {
+        return someTuple;
+    }
+
+    public void setSomeTuple(SomeTuple someTuple) {
+        this.someTuple = someTuple;
+    }
+
+    public static class SomeTuple {
+
+        private final String value1;
+        private final String value2;
+
+        public SomeTuple(String value1, String value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SomeTuple someTuple = (SomeTuple) o;
+            return value1.equals(someTuple.value1) &&
+                value2.equals(someTuple.value2);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(value1, value2);
+        }
+    }
+
+    public static class SomeTupleConverter implements AttributeConverter<SomeTuple, byte[]> {
+
+        @Override
+        public byte[] toGraphProperty(SomeTuple value) {
+            if (value == null) {
+                return null;
+            }
+            return (value.value1 + "@" + value.value2).getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public SomeTuple toEntityAttribute(byte[] value) {
+            if (value == null) {
+                return null;
+            }
+                System.out.println(new String(value, StandardCharsets.UTF_8));
+            String[] tmp = new String(value, StandardCharsets.UTF_8).split("@");
+
+            return new SomeTuple(tmp[0], tmp[1]);
+        }
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/ArraysMappingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/model/ArraysMappingTest.java
@@ -21,13 +21,19 @@ package org.neo4j.ogm.persistence.model;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.neo4j.ogm.domain.gh791.EntityWithNativeByteArrays;
+import org.neo4j.ogm.domain.gh791.EntityWithNativeByteArrays.SomeTuple;
 import org.neo4j.ogm.domain.social.Individual;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
@@ -40,7 +46,7 @@ public class ArraysMappingTest extends TestContainersTestBase {
 
     @BeforeClass
     public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.social");
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.social", "org.neo4j.ogm.domain.gh791");
     }
 
     @Before
@@ -85,11 +91,88 @@ public class ArraysMappingTest extends TestContainersTestBase {
             emptyMap()).queryResults()).hasSize(1);
 
         session.clear();
-        Iterable<Map<String, Object>> executionResult = session.query("MATCH (i:Individual) RETURN i.primitiveByteArray AS bytes",
-            emptyMap()).queryResults();
+        Iterable<Map<String, Object>> executionResult = session
+            .query("MATCH (i:Individual) RETURN i.primitiveByteArray AS bytes",
+                emptyMap()).queryResults();
         Map<String, Object> result = executionResult.iterator().next();
         assertThat(result.get("bytes")).as("The array wasn't persisted as the correct type")
             .isEqualTo("AQIDBAU="); //Byte arrays are converted to Base64 Strings
+    }
+
+    @Test
+    public void shouldDeserializeByteArrays() {
+
+        long id = (long) session.query(
+            "CREATE (i:Individual {age:42, bankBalance: 23, code:6, primitiveByteArray:'AQIDBAU='}) return id(i) as id",
+            Collections.emptyMap()).queryResults().iterator().next().get("id");
+
+        session.clear();
+
+        Session freshSession = sessionFactory.openSession();
+        Individual loadedIndividual = freshSession.load(Individual.class, id);
+        assertThat(loadedIndividual.getPrimitiveByteArray()).isEqualTo(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    @Test // GH-791
+    public void shouldDeserializeNativeByteArrays() {
+
+        byte[] primitive = { 1, 2, 3, 4, 5 };
+        Byte[] wrapped = { 9, 8, 7, 6, 5 };
+        byte[] helloWorld = { 104, 101, 108, 108, 111, 64, 119, 111, 114, 108, 100 };
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("primitive", primitive);
+        parameters.put("wrapped", wrapped);
+        parameters.put("someTuple", helloWorld);
+        long id = (long) session.query(
+            "CREATE (i:EntityWithNativeByteArrays {primitive: $primitive, wrapped: $wrapped, someTuple: $someTuple}) return id(i) as id",
+            parameters).queryResults().iterator().next()
+            .get("id");
+
+        session.clear();
+
+        Session freshSession = sessionFactory.openSession();
+        EntityWithNativeByteArrays loadedIndividual = freshSession.load(EntityWithNativeByteArrays.class, id);
+        assertThat(loadedIndividual.getPrimitive()).isEqualTo(primitive);
+        assertThat(loadedIndividual.getWrapped()).isEqualTo(wrapped);
+        assertThat(loadedIndividual.getSomeTuple()).isEqualTo(new SomeTuple("hello", "world"));
+    }
+
+    @Test // GH-791
+    public void shouldSerializeNativeByteArrays() {
+
+        byte[] primitive = { 1, 2, 3, 4, 5 };
+        Byte[] wrapped = { 9, 8, 7, 6, 5 };
+        byte[] helloWorld = { 104, 101, 108, 108, 111, 64, 119, 111, 114, 108, 100 };
+
+        EntityWithNativeByteArrays entityWithNativeByteArrays = new EntityWithNativeByteArrays();
+        entityWithNativeByteArrays.setPrimitive(primitive);
+        entityWithNativeByteArrays.setWrapped(wrapped);
+        entityWithNativeByteArrays.setSomeTuple(new SomeTuple("hello", "world"));
+
+        session.save(entityWithNativeByteArrays);
+
+        Map<String, Object> result = session.query(
+            "MATCH (i:EntityWithNativeByteArrays) WHERE id(i) = $id RETURN i.primitive AS primitiveArray, i.wrapped AS wrappedArray, i.someTuple as someTuple",
+            singletonMap("id", entityWithNativeByteArrays.getId())).queryResults().iterator().next();
+
+        byte[] primitiveArray = getBytes(result.get("primitiveArray"));
+        byte[] wrappedArray = getBytes(result.get("wrappedArray"));
+        String someTuple = new String(getBytes(result.get("someTuple")), StandardCharsets.UTF_8);
+
+        assertThat(primitiveArray).isEqualTo(primitive);
+        assertThat(wrappedArray).isEqualTo(wrapped);
+        assertThat(someTuple).isEqualTo("hello@world");
+    }
+
+    private static byte[] getBytes(Object o) {
+        if (o instanceof byte[]) {
+            return (byte[]) o;
+        } else if (o instanceof String) {
+            return Base64.getDecoder().decode((String) o);
+        } else {
+            throw new IllegalArgumentException("Can only retrieve byte from byte[] or String.");
+        }
     }
 
     @Test


### PR DESCRIPTION
We optimized the previous `convertToIterable` (now `iterableOf` in `CollectionUtils` to actually return an iterable. In the case of byte arrays, the `EntityAccessManager` casts that `Iterable` into a collection to coerce it with existing values. That lead to the `ClassCastException` mentioned in #791.

The issue needs several fixes:
- `EntityAccessManager` must only work on `Iterables`
- The `CollectionUtils` must treat an array of primitive types separatly. It cannot be just casted into an `Object[]` array.

This change also introduces two NoOp-Converter (`NoOpByteArrayConverter` and `NoOpWrappedByteArrayConverter`) that allow users to circumenvent the conversion to Base64 arrays.

We can read Base64 encoded into byte[] arrays from HTTP, but not write byte[] arrays over HTTP as the HTTP endpoint doesn’t support byte[] as parameter.

This closes #791.