### PR TITLE
hotfix: null pointer if a NODE index is present in db (full-text search)

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndex.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndex.java
@@ -304,7 +304,7 @@ class AutoIndex {
                 return empty();
             }
 
-            pattern = compile("INDEX ON :(?<label>.*)\\((?<property>.*)\\)");
+            pattern = compile("INDEX ON (NODE)?:(?<label>.*)\\((?<property>.*)\\)");
             matcher = pattern.matcher(description);
             if (matcher.matches()) {
                 String label = matcher.group("label");


### PR DESCRIPTION
Edit of regex pattern due to NullPointerException in case of existing NODE index on db

## Description
When on db is present a node index created with following command 
`CALL db.index.fulltext.createNodeIndex("indexName",["LABEL1","LABEL2"],["prop1","prop2"])`
cause a NullPointerException when parse the index description [in this example the description become something like `INDEX ON NODE:LABEL1, LABEL2(prop1,prop2)`]

## Motivation and Context
Crash when a Node index is present

## How Has This Been Tested?
Tested locally on a db with a NODE index

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
