### PR TITLE
Prevent OR’ing of filters containing nested paths.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
@@ -29,6 +29,7 @@ import org.neo4j.ogm.exception.core.MissingOperatorException;
 
 /**
  * @author Jasper Blues
+ * @author Michael J. Simons
  */
 public class NodeQueryBuilder {
 
@@ -78,9 +79,6 @@ public class NodeQueryBuilder {
     }
 
     private void appendNestedFilter(Filter filter) {
-        if (filter.getBooleanOperator().equals(BooleanOperator.OR)) {
-            throw new UnsupportedOperationException("OR is not supported for nested properties on an entity");
-        }
         if (filter.isNestedRelationshipEntity()) {
             MatchClause clause = relationshipPropertyClauseFor(filter.getRelationshipType());
             if (clause == null) {
@@ -101,11 +99,9 @@ public class NodeQueryBuilder {
     }
 
     private void appendDeepNestedFilter(Filter filter) {
-        if (filter.getBooleanOperator().equals(BooleanOperator.OR)) {
-            throw new UnsupportedOperationException("OR is not supported for nested properties on an entity");
-        }
         Filter.NestedPathSegment lastPathSegment = filter.getNestedPath().get(filter.getNestedPath().size() - 1);
-        MatchClause clause = new NestedPropertyPathMatchClause(matchClauseId, lastPathSegment.getNestedEntityTypeLabel(), lastPathSegment.isNestedRelationshipEntity());
+        MatchClause clause = new NestedPropertyPathMatchClause(matchClauseId,
+            lastPathSegment.getNestedEntityTypeLabel(), lastPathSegment.isNestedRelationshipEntity());
 
         pathClauses.add(new NestedPathMatchClause(matchClauseId).append(filter));
         nestedClauses.add(clause);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/CineastsIntegrationTest.java
@@ -26,14 +26,19 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.neo4j.ogm.cypher.BooleanOperator;
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.cypher.PropertyValueTransformer;
+import org.neo4j.ogm.cypher.function.FilterFunction;
 import org.neo4j.ogm.domain.cineasts.annotated.Actor;
 import org.neo4j.ogm.domain.cineasts.annotated.Movie;
 import org.neo4j.ogm.domain.cineasts.annotated.Pet;
@@ -44,7 +49,6 @@ import org.neo4j.ogm.domain.cineasts.annotated.Title;
 import org.neo4j.ogm.domain.cineasts.annotated.User;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.session.SessionFactory;
-import org.neo4j.ogm.session.Utils;
 import org.neo4j.ogm.testutil.TestContainersTestBase;
 import org.neo4j.ogm.testutil.TestUtils;
 
@@ -54,6 +58,7 @@ import org.neo4j.ogm.testutil.TestUtils;
  * @author Michal Bachman
  * @author Adam George
  * @author Mark Angrish
+ * @author Michael J. Simons
  */
 public class CineastsIntegrationTest extends TestContainersTestBase {
 
@@ -214,8 +219,8 @@ public class CineastsIntegrationTest extends TestContainersTestBase {
 
         Collection<Rating> ratings = session.loadAll(Rating.class, userNameFilter.and(ratingFilter));
         assertThat(ratings).hasSize(1);
-
     }
+
     @Test
     public void loadRatingByUserNameAndStars() {
         Filter userNameFilter = new Filter("name", ComparisonOperator.EQUALS, "Michal");
@@ -261,10 +266,7 @@ public class CineastsIntegrationTest extends TestContainersTestBase {
         assertThat(vince.getTitles().get(0)).isEqualTo(Title.MR);
     }
 
-    /**
-     * @see DATAGRAPH-614
-     */
-    @Test
+    @Test // DATAGRAPH-614
     public void saveAndRetrieveUserWithDifferentCharset() {
         User user = new User();
         user.setLogin("aki");
@@ -350,11 +352,7 @@ public class CineastsIntegrationTest extends TestContainersTestBase {
         assertThat(user.getNicknames()[1]).isEqualTo("robin");
     }
 
-    /**
-     * @throws MalformedURLException
-     * @see Issue #128
-     */
-    @Test
+    @Test // GH-128
     public void shouldBeAbleToSetNodePropertiesToNull() throws MalformedURLException {
         Movie movie = new Movie("Zootopia", 2016);
         movie.setImdbUrl(new URL("http://www.imdb.com/title/tt2948356/"));
@@ -372,5 +370,84 @@ public class CineastsIntegrationTest extends TestContainersTestBase {
         movie = session.load(Movie.class, movie.getUuid());
         assertThat(movie.getTitle()).isNull();
         assertThat(movie.getImdbUrl()).isNull();
+    }
+
+    @Test
+    public void nestedFilteringMustThrowExceptionWithOrInThePipeline() {
+        // rated by the user who doesn't own Catty or by the user who owns Catty
+        Filter filterA = new Filter("name", ComparisonOperator.EQUALS, "Catty");
+        filterA.setNestedPath(
+            new Filter.NestedPathSegment("ratings", Rating.class),
+            new Filter.NestedPathSegment("user", User.class),
+            new Filter.NestedPathSegment("pets", Pet.class)
+        );
+
+        filterA.setNegated(true);
+
+        Filter alwaysTrueFilter = new Filter(new FilterFunction() {
+
+            private Filter theFilter;
+
+            @Override public Object getValue() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> parameters(UnaryOperator createUniqueParameterName,
+                PropertyValueTransformer valueTransformer) {
+                return Collections.emptyMap();
+            }
+
+            @Override
+            public String expression(String nodeIdentifier, String filteredProperty,
+                UnaryOperator createUniqueParameterName) {
+                return "1 = 1 ";
+            }
+
+        });
+        alwaysTrueFilter.setBooleanOperator(BooleanOperator.OR);
+
+        Filter filterB = new Filter("name", ComparisonOperator.EQUALS, "Catty");
+        filterB.setNestedPath(
+            new Filter.NestedPathSegment("ratings", Rating.class),
+            new Filter.NestedPathSegment("user", User.class),
+            new Filter.NestedPathSegment("pets", Pet.class)
+        );
+        filterB.setBooleanOperator(BooleanOperator.AND);
+        Filters filters = new Filters(filterA, alwaysTrueFilter, filterB);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> session.loadAll(Movie.class, filters))
+            .withMessage("Filters containing nested paths cannot be combined via the logical OR operator.");
+    }
+
+    @Test
+    public void nestedFilteringCanBeTheOneAndOnlyOredFilter() {
+        Filter filterB = new Filter("name", ComparisonOperator.EQUALS, "Catty");
+        filterB.setNestedPath(
+            new Filter.NestedPathSegment("ratings", Rating.class),
+            new Filter.NestedPathSegment("user", User.class),
+            new Filter.NestedPathSegment("pets", Pet.class)
+        );
+        filterB.setBooleanOperator(BooleanOperator.OR);
+        Filters filters = new Filters(filterB);
+        Collection<Movie> films = session.loadAll(Movie.class, filters);
+        assertThat(films).hasSize(2);
+    }
+
+    @Test
+    public void nestedFilteringMustThrowExceptionWithOrInThePipelineForRelationshipEntities() {
+        Filter userNameFilter = new Filter("name", ComparisonOperator.EQUALS, "Michal");
+        userNameFilter.setBooleanOperator(BooleanOperator.OR);
+
+        Filter ratingFilter = new Filter("stars", ComparisonOperator.EQUALS, 5);
+
+        userNameFilter.setNestedPath(
+            new Filter.NestedPathSegment("user", User.class)
+        );
+
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> session.loadAll(Rating.class, userNameFilter.and(ratingFilter)))
+            .withMessage("Filters containing nested paths cannot be combined via the logical OR operator.");
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -538,11 +538,7 @@ public class NodeQueryStatementsTest {
             "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter_0` MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_1` MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-662
-     * //TODO FIXME
-     */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class) // DATAGRAPH-662
     public void testFindByMultipleNestedPropertiesOred() {
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
 
@@ -552,17 +548,12 @@ public class NodeQueryStatementsTest {
         planetParam.setNestedEntityTypeLabel("Planet");
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
-        assertThat(
-            queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 1).getStatement())
-            .isEqualTo(
-                "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter` OPTIONAL MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name` OPTIONAL MATCH (n)-[:`COLLIDES`]->(m0) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+
+        queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 1)
+            .getStatement();
     }
 
-    /**
-     * @see DATAGRAPH-662
-     * //TODO FIXME
-     */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class) // DATAGRAPH-662
     public void testFindByMultipleNestedPropertiesOredDepth0() {
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
 
@@ -573,16 +564,11 @@ public class NodeQueryStatementsTest {
         planetParam.setRelationshipType("COLLIDES");
         planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
 
-        assertThat(
-            queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 0).getStatement())
-            .isEqualTo(
-                "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter` OPTIONAL MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name` OPTIONAL MATCH (n)-[:`COLLIDES`]->(m0) RETURN n");
+        String statement = queryStatements.findByType("Asteroid", new Filters().add(diameterParam).add(planetParam), 0)
+            .getStatement();
     }
 
-    /**
-     * @see DATAGRAPH-632
-     */
-    @Test
+    @Test // DATAGRAPH-632
     public void testFindByNestedREProperty() {
         Filter planetParam = new Filter("totalDestructionProbability", ComparisonOperator.EQUALS, "20");
         planetParam.setNestedPropertyName("collision");
@@ -598,10 +584,7 @@ public class NodeQueryStatementsTest {
                 "WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see OGM-279
-     */
-    @Test
+    @Test // GH-279
     public void testFindByMultipleNestedREProperty() {
         Filter planetParam = new Filter("totalDestructionProbability", ComparisonOperator.EQUALS, "20");
         planetParam.setNestedPropertyName("collision");
@@ -677,11 +660,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-662
-     * //TODO FIXME
-     */
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class) // DATAGRAPH-662
     public void testFindByDifferentNestedPropertiesOred() {
         Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
 
@@ -696,16 +675,11 @@ public class NodeQueryStatementsTest {
         moonParam.setRelationshipType("ORBITS");
         moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
         moonParam.setBooleanOperator(BooleanOperator.OR);
-        assertThat(
-            queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(moonParam), 1).getStatement())
-            .isEqualTo(
-                "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name` OPTIONAL MATCH (m1:`Moon`) WHERE m1.`name` = $`moon_name` OPTIONAL MATCH (n)-[:`COLLIDES`]->(m0) OPTIONAL MATCH (n)<-[:`ORBITS`]-(m1) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+
+        queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(moonParam), 1).getStatement();
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleNestedPropertiesAnded() {
         Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
         planetParam.setNestedPropertyName("collidesWith");


### PR DESCRIPTION
A filter with nested paths will result in several matches chained together. Those matches are nessary to have the nodes holding the properties we want to filter on.

While at first it may seem trivial to think that adding a nested filter with its own match by an OR just doing an OPTIONAL MATCH, this is wrong, as the first part of the OR would need to be marked as OPTIONAL as well.

In the end trying to do so, would create very brittle Cypher statements.

Instead of, this commit improves the current checks into a single place and adds a couple of tests for it.

A query is not created when any of the filters in the chain is nested AND any other is to be chained with OR (when there is actually more than 1 filter).

This closes #796. 