### PR TITLE
Improve nested filtering.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
@@ -63,17 +63,15 @@ public class FilteredQueryBuilder {
                         return filter.isNestedRelationshipEntity() ?
                             filter.getRelationshipType() :
                             filter.getNestedEntityTypeLabel();
-                    } else if (filter.isDeepNested()) {
-                        return filter.getNestedPath().get(filter.getNestedPath().size() - 1).getNestedEntityTypeLabel();
                     } else {
-                        throw new RuntimeException("¯\\_(ツ)_/¯");
+                        return filter.getNestedPath().get(filter.getNestedPath().size() - 1).getNestedEntityTypeLabel();
                     }
                 },
                 TreeMap::new,
                 Collectors.toList()
             ));
 
-        Predicate<Filter> hasBooleanOperator = filter -> BooleanOperator.OR == filter.getBooleanOperator();
+        Predicate<Filter> hasOrOperator = filter -> BooleanOperator.OR == filter.getBooleanOperator();
         boolean throwException = false;
 
         if (other.isEmpty()) {
@@ -81,15 +79,15 @@ public class FilteredQueryBuilder {
             if (groupedFilters.size() > 1) {
                 throwException = groupedFilters
                     .values().stream()
-                    .anyMatch(l -> hasBooleanOperator.test(l.get(0)));
+                    .anyMatch(l -> hasOrOperator.test(l.get(0)));
             }
         } else if (!groupedFilters.isEmpty()) {
             // Otherwise we have to have a look whether there's at least one nested filter that is support to be or'ed with
-            // other filters.
-            throwException = other.stream().anyMatch(hasBooleanOperator)
+            // other filters.Wi
+            throwException = other.stream().anyMatch(hasOrOperator)
                 || groupedFilters.values().stream()
                 .map(groupedFilter -> groupedFilter.get(0))
-                .anyMatch(hasBooleanOperator);
+                .anyMatch(hasOrOperator);
         }
 
         if (throwException) {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh791/EntityWithNativeByteArrays.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh791/EntityWithNativeByteArrays.java
@@ -118,7 +118,7 @@ public class EntityWithNativeByteArrays {
             if (value == null) {
                 return null;
             }
-                System.out.println(new String(value, StandardCharsets.UTF_8));
+
             String[] tmp = new String(value, StandardCharsets.UTF_8).split("@");
 
             return new SomeTuple(tmp[0], tmp[1]);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/session/request/strategy/impl/NodeQueryStatementsTest.java
@@ -57,13 +57,13 @@ public class NodeQueryStatementsTest {
         new PathNodeLoadClauseBuilder());
 
     @Test
-    public void testFindOne() throws Exception {
+    public void testFindOne() {
         assertThat(queryStatements.findOne(0L, 2).getStatement())
             .isEqualTo("MATCH (n) WHERE ID(n) = $id WITH n MATCH p=(n)-[*0..2]-(m) RETURN p");
     }
 
     @Test
-    public void testFindOnePrimaryIndex() throws Exception {
+    public void testFindOnePrimaryIndex() {
         PagingAndSortingQuery query = primaryQueryStatements.findOne("test-uuid", 2);
         assertThat(query.getStatement())
             .isEqualTo("MATCH (n) WHERE n.`uuid` = $id WITH n MATCH p=(n)-[*0..2]-(m) RETURN p");
@@ -71,7 +71,7 @@ public class NodeQueryStatementsTest {
     }
 
     @Test
-    public void testFindOneByType() throws Exception {
+    public void testFindOneByType() {
         PagingAndSortingQuery query = queryStatements.findOneByType("Orbit", 0L, 2);
         assertThat(query.getStatement())
             .isEqualTo("MATCH (n:`Orbit`) WHERE ID(n) = $id WITH n MATCH p=(n)-[*0..2]-(m) RETURN p");
@@ -85,7 +85,7 @@ public class NodeQueryStatementsTest {
     }
 
     @Test
-    public void testFindOneByTypePrimaryIndex() throws Exception {
+    public void testFindOneByTypePrimaryIndex() {
         PagingAndSortingQuery query = primaryQueryStatements.findOneByType("Orbit", "test-uuid", 2);
 
         assertThat(query.getStatement())
@@ -94,7 +94,7 @@ public class NodeQueryStatementsTest {
     }
 
     @Test
-    public void testFindOneByTypePrimaryIndexInfiniteDepth() throws Exception {
+    public void testFindOneByTypePrimaryIndexInfiniteDepth() {
         PagingAndSortingQuery query = primaryQueryStatements.findOneByType("Orbit", "test-uuid", -1);
 
         assertThat(query.getStatement())
@@ -103,7 +103,7 @@ public class NodeQueryStatementsTest {
     }
 
     @Test
-    public void testFindByLabel() throws Exception {
+    public void testFindByLabel() {
         String statement = queryStatements.findByType("Orbit", 3).getStatement();
         assertThat(statement).isEqualTo("MATCH (n:`Orbit`) WITH n MATCH p=(n)-[*0..3]-(m) RETURN p");
     }
@@ -190,30 +190,26 @@ public class NodeQueryStatementsTest {
     }
 
     @Test
-    public void testFindOneZeroDepthPrimaryIndex() throws Exception {
+    public void testFindOneZeroDepthPrimaryIndex() {
         PagingAndSortingQuery query = primaryQueryStatements.findOne("test-uuid", 0);
 
         assertThat(query.getStatement()).isEqualTo("MATCH (n) WHERE n.`uuid` = $id WITH n RETURN n");
     }
 
     @Test
-    public void testFindByLabelZeroDepth() throws Exception {
+    public void testFindByLabelZeroDepth() {
         assertThat(queryStatements.findByType("Orbit", 0).getStatement())
             .isEqualTo("MATCH (n:`Orbit`) WITH n RETURN n");
     }
 
     @Test
-    public void testFindByPropertyZeroDepth() throws Exception {
+    public void testFindByPropertyZeroDepth() {
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(new Filter("diameter", EQUALS, 60.2)), 0)
             .getStatement()).isEqualTo("MATCH (n:`Asteroid`) WHERE n.`diameter` = $`diameter_0` WITH n RETURN n");
     }
 
-    @Test
-    /**
-     * @see DATAGRAPH-781
-     * @throws Exception
-     */
-    public void testFindByPropertyWithInfiniteValue() throws Exception {
+    @Test // DATAGRAPH-781
+    public void testFindByPropertyWithInfiniteValue() {
         PagingAndSortingQuery pagingAndSortingQuery = queryStatements
             .findByType("Asteroid", new Filters().add(new Filter("albedo", ComparisonOperator.EQUALS, -12.2)), 0);
 
@@ -222,86 +218,55 @@ public class NodeQueryStatementsTest {
         assertThat((double) pagingAndSortingQuery.getParameters().get("albedo_0")).isEqualTo(-12.2, within(0.005));
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-589
-     */
-    @Test
-    public void testFindByLabelWithIllegalCharacters() throws Exception {
+    @Test // DATAGRAPH-589
+    public void testFindByLabelWithIllegalCharacters() {
         assertThat(queryStatements.findByType("l'artiste", 3).getStatement())
             .isEqualTo("MATCH (n:`l'artiste`) WITH n MATCH p=(n)-[*0..3]-(m) RETURN p");
     }
 
-    /**
-     * @see DATAGRAPH-595
-     */
-    @Test
-    public void testFindOneInfiniteDepth() throws Exception {
+    @Test // DATAGRAPH-595
+    public void testFindOneInfiniteDepth() {
         assertThat(queryStatements.findOne(0L, -1).getStatement())
             .isEqualTo("MATCH (n) WHERE ID(n) = $id WITH n MATCH p=(n)-[*0..]-(m) RETURN p");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-595
-     */
-    @Test
-    public void testFindByLabelInfiniteDepth() throws Exception {
+    @Test // DATAGRAPH-595
+    public void testFindByLabelInfiniteDepth() {
         assertThat(queryStatements.findByType("Orbit", -1).getStatement())
             .isEqualTo("MATCH (n:`Orbit`) WITH n MATCH p=(n)-[*0..]-(m) RETURN p");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-595
-     */
-    @Test
-    public void testFindByPropertyInfiniteDepth() throws Exception {
+    @Test // DATAGRAPH-595
+    public void testFindByPropertyInfiniteDepth() {
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(new Filter("diameter", EQUALS, 60.2)), -1)
             .getStatement()).isEqualTo(
             "MATCH (n:`Asteroid`) WHERE n.`diameter` = $`diameter_0` WITH n MATCH p=(n)-[*0..]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-631
-     */
-    @Test
-    public void testFindByPropertyWithIllegalCharacters() throws Exception {
+    @Test // DATAGRAPH-631
+    public void testFindByPropertyWithIllegalCharacters() {
         assertThat(queryStatements
             .findByType("Studio", new Filters().add(new Filter("studio-name", EQUALS, "Abbey Road Studios")), 3)
             .getStatement()).isEqualTo(
             "MATCH (n:`Studio`) WHERE n.`studio-name` = $`studio-name_0` WITH n MATCH p=(n)-[*0..3]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-629
-     */
-    @Test
-    public void testFindByPropertyGreaterThan() throws Exception {
+    @Test // DATAGRAPH-629
+    public void testFindByPropertyGreaterThan() {
         Filter parameter = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(parameter), 4).getStatement()).isEqualTo(
             "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter_0` WITH n MATCH p=(n)-[*0..4]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-904
-     */
-    @Test
-    public void testFindByPropertyGreaterThanEqual() throws Exception {
+    @Test // DATAGRAPH-904
+    public void testFindByPropertyGreaterThanEqual() {
         Filter parameter = new Filter("diameter", ComparisonOperator.GREATER_THAN_EQUAL, 60);
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(parameter), 4).getStatement()).isEqualTo(
             "MATCH (n:`Asteroid`) WHERE n.`diameter` >= $`diameter_0` WITH n MATCH p=(n)-[*0..4]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-629
-     */
-    @Test
-    public void testFindByPropertyLessThan() throws Exception {
+    @Test // DATAGRAPH-629
+    public void testFindByPropertyLessThan() {
         Filter parameter = new Filter("diameter", ComparisonOperator.LESS_THAN, 60);
         assertThat(queryStatements.findByType("Asteroid",
             new Filters().add(parameter), 4).getStatement())
@@ -309,12 +274,8 @@ public class NodeQueryStatementsTest {
                 "WITH n MATCH p=(n)-[*0..4]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @throws Exception
-     * @see DATAGRAPH-904
-     */
-    @Test
-    public void testFindByPropertyLessThanEqual() throws Exception {
+    @Test // DATAGRAPH-904
+    public void testFindByPropertyLessThanEqual() {
         Filter parameter = new Filter("diameter", ComparisonOperator.LESS_THAN_EQUAL, 60);
         assertThat(queryStatements.findByType("Asteroid",
             new Filters().add(parameter), 4).getStatement())
@@ -322,22 +283,11 @@ public class NodeQueryStatementsTest {
                 "WITH n MATCH p=(n)-[*0..4]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-445
-     */
-    @Test
+    @Test // DATAGRAPH-445
     public void testFindByChainedAndedProperties() {
-        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
-        planetParam.setNestedPropertyName("collidesWith");
-        planetParam.setNestedEntityTypeLabel("Planet");
-        planetParam.setRelationshipType("COLLIDES");
-        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        Filter planetParam = collidesWithEarthFilter();
 
-        Filter moonParam = new Filter("name", ComparisonOperator.EQUALS, "Moon");
-        moonParam.setNestedPropertyName("moon");
-        moonParam.setNestedEntityTypeLabel("Moon");
-        moonParam.setRelationshipType("ORBITS");
-        moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
+        Filter moonParam = orbitsMoonFilter();
 
         assertThat(queryStatements.findByType("Asteroid",
             new Filters().add(planetParam).and(moonParam), 1).getStatement())
@@ -346,10 +296,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-445
-     */
-    @Test
+    @Test // DATAGRAPH-445
     public void testFindByChainedOredProperties() {
         Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
 
@@ -361,10 +308,7 @@ public class NodeQueryStatementsTest {
                 "OR n.`name` = $`name_1` WITH n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleAndPropertiesLessThan() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         Filter diameterParam = new Filter("diameter", ComparisonOperator.LESS_THAN, 60);
@@ -375,10 +319,7 @@ public class NodeQueryStatementsTest {
                 "WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleAndPropertiesGreaterThan() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
@@ -389,10 +330,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`name` = $`name_0` AND n.`diameter` > $`diameter_1` WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleAndPropertiesGreaterThanWithDifferentOrder() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         nameParam.setBooleanOperator(BooleanOperator.AND);
@@ -403,10 +341,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter_0` AND n.`name` = $`name_1` WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleOrPropertiesGreaterThan() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
@@ -417,10 +352,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`name` = $`name_0` OR n.`diameter` > $`diameter_1` WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleOrPropertiesLessThan() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         Filter diameterParam = new Filter("diameter", ComparisonOperator.LESS_THAN, 60);
@@ -431,10 +363,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`name` = $`name_0` OR n.`diameter` < $`diameter_1` WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleOrPropertiesGreaterThanWithDifferentOrder() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         nameParam.setBooleanOperator(BooleanOperator.OR);
@@ -445,24 +374,14 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter_0` OR n.`name` = $`name_1` WITH n MATCH p=(n)-[*0..2]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByNestedPropertyOutgoing() {
-        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
-        planetParam.setNestedPropertyName("collidesWith");
-        planetParam.setNestedEntityTypeLabel("Planet");
-        planetParam.setRelationshipType("COLLIDES");
-        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        Filter planetParam = collidesWithEarthFilter();
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam), 1).getStatement()).isEqualTo(
             "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_0` MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-904
-     */
-    @Test
+    @Test // DATAGRAPH-904
     public void testFindByNestedPropertySameEntityType() {
         Filter filter = new Filter("name", ComparisonOperator.EQUALS, "Vesta");
         filter.setNestedPropertyName("collidesWith");
@@ -473,10 +392,7 @@ public class NodeQueryStatementsTest {
             "MATCH (n:`Asteroid`) MATCH (m0:`Asteroid`) WHERE m0.`name` = $`collidesWith_name_0` MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByNestedPropertyIncoming() {
         Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
         planetParam.setNestedPropertyName("collidesWith");
@@ -487,10 +403,7 @@ public class NodeQueryStatementsTest {
             "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_0` MATCH (n)<-[:`COLLIDES`]-(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByNestedPropertyUndirected() {
         Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
         planetParam.setNestedPropertyName("collidesWith");
@@ -501,10 +414,7 @@ public class NodeQueryStatementsTest {
             "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_0` MATCH (n)-[:`COLLIDES`]-(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleNestedProperties() {
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
 
@@ -520,10 +430,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) WHERE n.`diameter` > $`diameter_0` MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_1` MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByMultipleNestedPropertiesInfiniteDepth() {
         Filter diameterParam = new Filter("diameter", ComparisonOperator.GREATER_THAN, 60);
 
@@ -610,10 +517,7 @@ public class NodeQueryStatementsTest {
                 "MATCH (n)<-[r1:`MONITORED_BY`]-(m1) WHERE r1.`signalStrength` >= $`monitoringSatellites_signalStrength_1` WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-632
-     */
-    @Test
+    @Test // DATAGRAPH-632
     public void testFindByNestedBaseAndREProperty() {
         Filter planetParam = new Filter("totalDestructionProbability", ComparisonOperator.EQUALS, "20");
         planetParam.setNestedPropertyName("collision");
@@ -623,11 +527,7 @@ public class NodeQueryStatementsTest {
         planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
         planetParam.setNestedRelationshipEntity(true);
 
-        Filter moonParam = new Filter("name", ComparisonOperator.EQUALS, "Moon");
-        moonParam.setNestedPropertyName("moon");
-        moonParam.setNestedEntityTypeLabel("Moon");
-        moonParam.setRelationshipType("ORBITS");
-        moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
+        Filter moonParam = orbitsMoonFilter();
         moonParam.setBooleanOperator(BooleanOperator.AND);
 
         assertThat(queryStatements.findByType("Asteroid", new Filters().add(planetParam, moonParam), 1).getStatement())
@@ -636,22 +536,11 @@ public class NodeQueryStatementsTest {
                 "MATCH (m1:`Moon`) WHERE m1.`name` = $`moon_name_1` MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see DATAGRAPH-629
-     */
-    @Test
+    @Test // DATAGRAPH-629
     public void testFindByDifferentNestedPropertiesAnded() {
-        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
-        planetParam.setNestedPropertyName("collidesWith");
-        planetParam.setNestedEntityTypeLabel("Planet");
-        planetParam.setRelationshipType("COLLIDES");
-        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        Filter planetParam = collidesWithEarthFilter();
 
-        Filter moonParam = new Filter("name", ComparisonOperator.EQUALS, "Moon");
-        moonParam.setNestedPropertyName("moon");
-        moonParam.setNestedEntityTypeLabel("Moon");
-        moonParam.setRelationshipType("ORBITS");
-        moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
+        Filter moonParam = orbitsMoonFilter();
         moonParam.setBooleanOperator(BooleanOperator.AND);
         assertThat(queryStatements.findByType("Asteroid",
             new Filters().add(planetParam).add(moonParam), 1).getStatement())
@@ -660,20 +549,77 @@ public class NodeQueryStatementsTest {
                 "MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
+    // Would be something like findByMoonSomethingAndFindByPlanetXOrFindByPlanetY
+    @Test
+    public void testFindByNestedPropertiesOnTheSameEntityOredNotFollowingEachOtherDirectly() {
+        Filter planetParam = collidesWithEarthFilter();
+
+        Filter planetParam2 = collidesWithMarsFilter();
+        planetParam2.setBooleanOperator(BooleanOperator.OR);
+
+        Filter moonParam = orbitsMoonFilter();
+        moonParam.setBooleanOperator(BooleanOperator.AND);
+        assertThat(queryStatements.findByType("Asteroid",
+            new Filters().add(planetParam).add(moonParam).add(planetParam2), 1).getStatement())
+            .isEqualTo(
+                "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_0` OR m0.`name` = $`collidesWith_name_2` "
+                    +
+                    "MATCH (m1:`Moon`) WHERE m1.`name` = $`moon_name_1` MATCH (n)-[:`COLLIDES`]->(m0) " +
+                    "MATCH (n)<-[:`ORBITS`]-(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+    }
+
+    // Would be something like findByMoonSomethingAndFindByPlanetXOrFindByPlanetY
+    @Test
+    public void testFindByNestedPropertiesOnTheSameEntityOred() {
+        Filter planetParam = collidesWithEarthFilter();
+        planetParam.setBooleanOperator(BooleanOperator.AND);
+
+        Filter planetParam2 = collidesWithMarsFilter();
+        planetParam2.setBooleanOperator(BooleanOperator.OR);
+
+        Filter moonParam = orbitsMoonFilter();
+
+        assertThat(queryStatements.findByType("Asteroid",
+            new Filters().add(moonParam).add(planetParam).add(planetParam2), 1).getStatement())
+            .isEqualTo("MATCH (n:`Asteroid`) MATCH (m0:`Moon`) WHERE m0.`name` = $`moon_name_0` " +
+                "MATCH (m1:`Planet`) WHERE m1.`name` = $`collidesWith_name_1` OR m1.`name` = $`collidesWith_name_2` " +
+                "MATCH (n)<-[:`ORBITS`]-(m0) MATCH (n)-[:`COLLIDES`]->(m1) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
+    }
+
+    // Would be something like findByMoonSomethingORFindByPlanetXOrFindByPlanetY
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFindByNestedPropertiesOnTheSameEntityOredWithAnotherFilter() {
+        Filter planetParam = collidesWithEarthFilter();
+        planetParam.setBooleanOperator(BooleanOperator.OR);
+
+        Filter planetParam2 = collidesWithMarsFilter();
+        planetParam2.setBooleanOperator(BooleanOperator.OR);
+
+        Filter moonParam = orbitsMoonFilter();
+
+        queryStatements.findByType("Asteroid",
+            new Filters().add(moonParam).add(planetParam).add(planetParam2), 1).getStatement();
+    }
+
+    // Would be something like findByMoonSomethingORFindByPlanetXOrFindByPlanetY
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFindByNestedPropertiesOnTheSameEntityOredNotFollowingEachOtherDirectlyWithAnotherFilter() {
+        Filter planetParam = collidesWithEarthFilter();
+
+        Filter planetParam2 = collidesWithMarsFilter();
+        planetParam2.setBooleanOperator(BooleanOperator.OR);
+
+        Filter moonParam = orbitsMoonFilter();
+        moonParam.setBooleanOperator(BooleanOperator.OR);
+        queryStatements.findByType("Asteroid",
+            new Filters().add(planetParam).add(moonParam).add(planetParam2), 1).getStatement();
+    }
+
     @Test(expected = UnsupportedOperationException.class) // DATAGRAPH-662
     public void testFindByDifferentNestedPropertiesOred() {
-        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
+        Filter planetParam = collidesWithEarthFilter();
 
-        planetParam.setNestedPropertyName("collidesWith");
-        planetParam.setNestedEntityTypeLabel("Planet");
-        planetParam.setRelationshipType("COLLIDES");
-        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
-
-        Filter moonParam = new Filter("name", ComparisonOperator.EQUALS, "Moon");
-        moonParam.setNestedPropertyName("moon");
-        moonParam.setNestedEntityTypeLabel("Moon");
-        moonParam.setRelationshipType("ORBITS");
-        moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
+        Filter moonParam = orbitsMoonFilter();
         moonParam.setBooleanOperator(BooleanOperator.OR);
 
         queryStatements.findByType("Asteroid", new Filters().add(planetParam).add(moonParam), 1).getStatement();
@@ -681,11 +627,7 @@ public class NodeQueryStatementsTest {
 
     @Test // DATAGRAPH-629
     public void testFindByMultipleNestedPropertiesAnded() {
-        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
-        planetParam.setNestedPropertyName("collidesWith");
-        planetParam.setNestedEntityTypeLabel("Planet");
-        planetParam.setRelationshipType("COLLIDES");
-        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        Filter planetParam = collidesWithEarthFilter();
 
         Filter moonParam = new Filter("size", ComparisonOperator.EQUALS, "5");
         moonParam.setNestedPropertyName("collidesWith");
@@ -699,13 +641,37 @@ public class NodeQueryStatementsTest {
                 "MATCH (n:`Asteroid`) MATCH (m0:`Planet`) WHERE m0.`name` = $`collidesWith_name_0` AND m0.`size` = $`collidesWith_size_1` MATCH (n)-[:`COLLIDES`]->(m0) WITH DISTINCT n MATCH p=(n)-[*0..1]-(m) RETURN p, ID(n)");
     }
 
-    /**
-     * @see Issue 73
-     */
-    @Test(expected = MissingOperatorException.class)
+    @Test(expected = MissingOperatorException.class) // GH-73
     public void testFindByMultipleAndPropertiesWithMissingBooleanOperator() {
         Filter nameParam = new Filter("name", ComparisonOperator.EQUALS, "AST-1");
         Filter diameterParam = new Filter("diameter", ComparisonOperator.LESS_THAN, 60);
         queryStatements.findByType("Asteroid", new Filters().add(nameParam).add(diameterParam), 2).getStatement();
+    }
+
+    private static Filter collidesWithEarthFilter() {
+        Filter planetParam = new Filter("name", ComparisonOperator.EQUALS, "Earth");
+        planetParam.setNestedPropertyName("collidesWith");
+        planetParam.setNestedEntityTypeLabel("Planet");
+        planetParam.setRelationshipType("COLLIDES");
+        planetParam.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        return planetParam;
+    }
+
+    private static Filter orbitsMoonFilter() {
+        Filter moonParam = new Filter("name", ComparisonOperator.EQUALS, "Moon");
+        moonParam.setNestedPropertyName("moon");
+        moonParam.setNestedEntityTypeLabel("Moon");
+        moonParam.setRelationshipType("ORBITS");
+        moonParam.setRelationshipDirection(Relationship.Direction.INCOMING);
+        return moonParam;
+    }
+
+    private static Filter collidesWithMarsFilter() {
+        Filter planetParam2 = new Filter("name", ComparisonOperator.EQUALS, "Mars");
+        planetParam2.setNestedPropertyName("collidesWith");
+        planetParam2.setNestedEntityTypeLabel("Planet");
+        planetParam2.setRelationshipType("COLLIDES");
+        planetParam2.setRelationshipDirection(Relationship.Direction.OUTGOING);
+        return planetParam2;
     }
 }


### PR DESCRIPTION
This change allows having OR’s in nested filters targeting the same entity. Thus, the entity itself works as a logical group and can itself by combined with filters on other properties with AND.

A combination of filters with OR containing one nested filter is still not allowed.

This commit makes the `NodeQueryBuilder` collapse deeply nested filters the same way as it does with normal ones.