### PR TITLE
Improve handling of unknown generic types.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
@@ -150,7 +150,10 @@ public class SingleUseEntityMapper {
             boolean targetIsCollection = isCollectionLike.test(effectiveFieldType);
 
             Object value = property.getValue();
-            // In case we haven determined a collection from the the field but the field is generic
+
+            // In case we have not been able to determine a collection type from the the field
+            // but the field is generic and we received something collection like we treat
+            // the field as a collection anyway.
             if (!targetIsCollection && GenericUtils.isGenericField(writer.getField())
                 && value != null && isCollectionLike.test(value.getClass())) {
                 targetIsCollection = true;

--- a/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
+++ b/core/src/main/java/org/neo4j/ogm/context/SingleUseEntityMapper.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 import org.neo4j.ogm.exception.core.MappingException;
 import org.neo4j.ogm.metadata.ClassInfo;
@@ -33,6 +34,7 @@ import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.metadata.MetaData;
 import org.neo4j.ogm.metadata.reflect.EntityAccessManager;
 import org.neo4j.ogm.metadata.reflect.EntityFactory;
+import org.neo4j.ogm.metadata.reflect.GenericUtils;
 import org.neo4j.ogm.model.RowModel;
 import org.neo4j.ogm.session.EntityInstantiator;
 import org.neo4j.ogm.support.ClassUtils;
@@ -144,9 +146,16 @@ public class SingleUseEntityMapper {
                 elementType = DescriptorMappings.getType(writer.getTypeDescriptor());
             }
 
-            boolean targetIsCollection = effectiveFieldType.isArray() || Iterable.class.isAssignableFrom(effectiveFieldType);
+            Predicate<Class<?>> isCollectionLike = c -> c != null && c.isArray() || Iterable.class.isAssignableFrom(c);
+            boolean targetIsCollection = isCollectionLike.test(effectiveFieldType);
 
             Object value = property.getValue();
+            // In case we haven determined a collection from the the field but the field is generic
+            if (!targetIsCollection && GenericUtils.isGenericField(writer.getField())
+                && value != null && isCollectionLike.test(value.getClass())) {
+                targetIsCollection = true;
+            }
+
             if (metadata.classInfo(elementType) != null) {
                 value = mapKnownEntityType(elementType, key, value, targetIsCollection);
             }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/GenericQueryResultWrapper.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh551/GenericQueryResultWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh551;
+
+/**
+ * @param <T>
+ * @author Michael J. Simons
+ */
+public class GenericQueryResultWrapper<T> {
+
+    T result;
+
+    public T getResult() {
+        return result;
+    }
+
+    public void setResult(T result) {
+        this.result = result;
+    }
+}


### PR DESCRIPTION
This improves the `SingleUseEntityMapper` to check the returned value for being something like a collection in case we couldn’t determine the generics of a wrapper class. In case the of Collections, this allows for a correct assigment.

Generic arrays are not detectable with that approach.

So something like

```
public class GenericQueryResultWrapper<T> {

    T result;
}
```

will work for `T` being a known entity type or a collection thereof, but not for an array of known entities.