### PR TITLE
GH-809 - Solve ambiguous class name collision.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/DomainInfo.java
@@ -350,11 +350,24 @@ public class DomainInfo {
             Pattern partialClassNamePattern = Pattern.compile(".+[\\\\.\\$]" + Pattern.quote(k) + "$");
             String matchingKey = null;
             for (String key : infos.keySet()) {
-                if (partialClassNamePattern.matcher(key).matches()) {
+                boolean isCandidate = partialClassNamePattern.matcher(key).matches();
+                if (isCandidate) {
+                    ClassInfo candidate = infos.get(key);
+                    String candidateNeo4jName = candidate.neo4jName() != null ? candidate.neo4jName() : key;
                     if (matchingKey != null) {
-                        throw new MappingException("More than one class has simple name: " + fullOrPartialClassName);
+                        ClassInfo existingMatch = infos.get(matchingKey);
+                        String previousMatchNeo4jName =
+                            existingMatch.neo4jName() != null ? existingMatch.neo4jName() : key;
+
+                        boolean sameLabel = candidateNeo4jName.equals(previousMatchNeo4jName);
+
+                        if (sameLabel) {
+                            throw new MappingException("More than one class has simple name: " + fullOrPartialClassName);
+                        }
                     }
-                    matchingKey = key;
+                    if (matchingKey == null || candidateNeo4jName.equals(fullOrPartialClassName)) {
+                        matchingKey = key;
+                    }
                 }
             }
             return Optional.ofNullable(matchingKey);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh809/package1/TestEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh809/package1/TestEntity.java
@@ -1,0 +1,16 @@
+package org.neo4j.ogm.domain.gh809.package1;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+/**
+ * @author Gerrit Meier
+ */
+public class TestEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh809/package2/TestEntity.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh809/package2/TestEntity.java
@@ -1,0 +1,18 @@
+package org.neo4j.ogm.domain.gh809.package2;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Gerrit Meier
+ */
+@NodeEntity("TestEntity2")
+public class TestEntity {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/DomainInfoTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.neo4j.ogm.domain.gh809.package1.TestEntity;
 
 /**
  * see DATAGRAPH-590 - Metadata resolves to an abstract class for an interface
@@ -35,7 +36,10 @@ public class DomainInfoTest {
 
     @Before
     public void setUp() {
-        domainInfo = DomainInfo.create("org.neo4j.ogm.domain.forum", "org.neo4j.ogm.domain.gh806");
+        domainInfo = DomainInfo.create(
+            "org.neo4j.ogm.domain.forum",
+            "org.neo4j.ogm.domain.gh806",
+            "org.neo4j.ogm.domain.gh809");
     }
 
     @Test
@@ -87,5 +91,11 @@ public class DomainInfoTest {
         ClassInfo classInfo = domainInfo.getClassSimpleName("SilverMembership");
         assertThat(classInfo).isNotNull();
         assertThat(classInfo.interfacesInfo().list()).hasSize(1);
+    }
+
+    @Test
+    public void shouldCorrectlyFindMultipleClassesWithSimpleNameIfAnnotated() {
+        ClassInfo classInfo = domainInfo.getClassSimpleName("TestEntity");
+        assertThat(classInfo.getUnderlyingClass()).isSameAs(TestEntity.class);
     }
 }


### PR DESCRIPTION
If one class is annotated without NodeEntity, the class determination
will fail if there is another class with the same simple name on
the class path.
