### PR TITLE
Add an example for Kotlins inline classes.

### DIFF
--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/pom.xml
@@ -143,6 +143,11 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
             <scope>test</scope>

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/gh822/IdTypes.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/gh822/IdTypes.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh822
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.io.IOException
+import java.io.Serializable
+
+inline class StringID(val value: String) : Serializable
+
+private class StringIDSerializer : StdSerializer<StringID>(StringID::class.java) {
+    @Throws(IOException::class)
+    override fun serialize(s: StringID, jsonGenerator: JsonGenerator,
+                           serializerProvider: SerializerProvider) {
+        jsonGenerator.writeObject(s.value)
+    }
+}
+
+class IdTypesModule : com.fasterxml.jackson.databind.module.SimpleModule() {
+
+    init {
+        addSerializer(StringIDSerializer())
+    }
+}
+
+

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/gh822/User.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/domain/gh822/User.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh822
+
+import org.neo4j.ogm.annotation.Id
+import org.neo4j.ogm.annotation.NodeEntity
+
+@NodeEntity
+data class User(
+        @Id var userId: StringID? = null,
+        val name: String
+)

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/kotlin/org/neo4j/ogm/kotlin/KotlinMetaDataTest.kt
@@ -67,4 +67,13 @@ class KotlinMetaDataTest {
         assertThat(kotlinZoo.getFieldInfo("animals").typeDescriptor).isEqualTo("org.neo4j.ogm.domain.gh696.Animal")
         assertThat(kotlinZoo.getFieldInfo("zookeepers").typeDescriptor).isEqualTo("org.neo4j.ogm.domain.gh696.Zookeeper")
     }
+
+    @Test // GH-822
+    fun `OGM should detect the inlines class underlying value type`() {
+        val metaData = MetaData("org.neo4j.ogm.domain.gh822")
+        val userClassInfo = metaData.classInfo("User")
+
+        assertThat(userClassInfo).isNotNull
+        assertThat(userClassInfo.getFieldInfo("userId").typeDescriptor).isEqualTo("java.lang.String")
+    }
 }


### PR DESCRIPTION
Kotlin provides so called „Inline classes“ (https://kotlinlang.org/docs/reference/inline-classes.html), wrapping standard types into a dedicated type. This makes them a nice fit for IDs etc.

The object mapping process works ootb, the parameter mapping needs some extra work: One has to provide custom serializers for all data classes being used (see `IdTypes`). Those serializers can be registered with a dedicated `SimpleModule`. This module needs to be added to the `ObjectMapper` instance used by OGM to convert parameters:

```
ObjectMapperFactory.objectMapper()
        .registerModule(KotlinModule())
        .registerModule(IdTypesModule())
```

The kotlin jackson module may detect them at some point in the future itself (See https://github.com/FasterXML/jackson-module-kotlin/issues/199), but until than that work is necessary.

This closes #822.