### PR TITLE
Use the NodeQueryBuilder for deep nested relationship queries.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/FilteredQueryBuilder.java
@@ -127,61 +127,50 @@ public class FilteredQueryBuilder {
 
     private static StringBuilder constructRelationshipQuery(String type, Iterable<Filter> filters,
         Map<String, Object> properties) {
-        List<Filter> startNodeFilters = new ArrayList<>(); //All filters that apply to the start node
-        List<Filter> endNodeFilters = new ArrayList<>(); //All filters that apply to the end node
-        List<Filter> relationshipFilters = new ArrayList<>(); //All filters that apply to the relationship
-        String startNodeLabel = null;
-        String endNodeLabel = null;
-        boolean noneOperatorEncounteredInStartFilters = false;
-        boolean noneOperatorEncounteredInEndFilters = false;
+
+        // Filters are created in 3 steps: For deep nested filter, the improved version
+        // NodeQueryBuilder is used. For the others the old approach still applies.
+        FiltersAtStartNode deepNestedFilters = new FiltersAtStartNode();
+
+        FiltersAtStartNode outgoingFilters = new FiltersAtStartNode();
+
+        FiltersAtStartNode incomingFilters = new FiltersAtStartNode();
+
+        List<Filter> relationshipFilters = new ArrayList<>();
 
         for (Filter filter : filters) {
             if (filter.isNested() || filter.isDeepNested()) {
-                String startNestedEntityTypeLabel = filter.getNestedEntityTypeLabel();
-                String endNestedEntityTypeLabel = filter.getNestedEntityTypeLabel();
-                Direction relationshipDirection = filter.getRelationshipDirection();
-
                 if (filter.isDeepNested()) {
                     List<Filter.NestedPathSegment> nestedPath = filter.getNestedPath();
+
                     Filter.NestedPathSegment firstNestedPathSegment = nestedPath.get(0);
-                    Filter.NestedPathSegment lastNestedPathSegment = nestedPath.get(nestedPath.size() - 1);
+                    filter.setOwnerEntityType(firstNestedPathSegment.getPropertyType());
 
-                    startNestedEntityTypeLabel = firstNestedPathSegment.getNestedEntityTypeLabel();
-                    endNestedEntityTypeLabel = lastNestedPathSegment.getNestedEntityTypeLabel();
-                    relationshipDirection = firstNestedPathSegment.getRelationshipDirection();
-                }
-
-                if (relationshipDirection == Direction.OUTGOING) {
-                    if (filter.getBooleanOperator().equals(BooleanOperator.NONE)) {
-                        if (noneOperatorEncounteredInStartFilters) {
-                            throw new MissingOperatorException(
-                                "BooleanOperator missing for filter with property name " + filter.getPropertyName());
-                        }
-                        noneOperatorEncounteredInStartFilters = true;
+                    Filter.NestedPathSegment[] newPath = new Filter.NestedPathSegment[nestedPath.size() - 1];
+                    if (nestedPath.size() > 1) {
+                        // The first element will represent the owning entity, so we need to get rid of it.
+                        nestedPath.subList(1, nestedPath.size()).toArray(newPath);
+                        filter.setNestedPath(newPath);
+                    } else {
+                        // The list of deep nested filters need an anchor only for relationships with one
+                        // nested segments.
+                        deepNestedFilters.startNodeLabel = firstNestedPathSegment.getNestedEntityTypeLabel();
                     }
-                    if (startNodeLabel == null) {
-                        startNodeLabel = startNestedEntityTypeLabel;
-                        filter.setBooleanOperator(BooleanOperator.NONE); //the first filter for the start node
-                    }
-                    startNodeFilters.add(filter);
+                    filter.setNestedPath(newPath);
+                    deepNestedFilters.content.add(filter);
                 } else {
-                    if (filter.getBooleanOperator().equals(BooleanOperator.NONE)) {
-                        if (noneOperatorEncounteredInEndFilters) {
-                            throw new MissingOperatorException(
-                                "BooleanOperator missing for filter with property name " + filter.getPropertyName());
-                        }
-                        noneOperatorEncounteredInEndFilters = true;
+                    FiltersAtStartNode target;
+                    Direction relationshipDirection = filter.getRelationshipDirection();
+                    if (relationshipDirection == Direction.OUTGOING) {
+                        target = outgoingFilters;
+                    } else {
+                        target = incomingFilters;
                     }
-                    if (endNodeLabel == null) {
-                        endNodeLabel = endNestedEntityTypeLabel;
-                        filter.setBooleanOperator(BooleanOperator.NONE); //the first filter for the end node
-                    }
-                    endNodeFilters.add(filter);
+                    addFilterToList(target, filter);
                 }
             } else {
                 if (relationshipFilters.size() == 0) {
-                    filter.setBooleanOperator(
-                        BooleanOperator.NONE); //TODO think about the importance of the first filter and stop using this as a condition to test against
+                    filter.setBooleanOperator(BooleanOperator.NONE);
                 } else {
                     if (filter.getBooleanOperator().equals(BooleanOperator.NONE)) {
                         throw new MissingOperatorException(
@@ -193,10 +182,40 @@ public class FilteredQueryBuilder {
         }
 
         StringBuilder query = new StringBuilder();
-        createNodeMatchSubquery(properties, startNodeFilters, startNodeLabel, query, "n");
-        createNodeMatchSubquery(properties, endNodeFilters, endNodeLabel, query, "m");
+        if (!deepNestedFilters.content.isEmpty()) {
+            NodeQueryBuilder nqb = new NodeQueryBuilder(deepNestedFilters.startNodeLabel, deepNestedFilters.content);
+            FilteredQuery filteredQuery = nqb.build();
+            query.append(filteredQuery.statement()).append(" ");
+            properties.putAll(filteredQuery.parameters());
+        }
+        createNodeMatchSubquery(properties, outgoingFilters, query, "n");
+        createNodeMatchSubquery(properties, incomingFilters, query, "m");
         createRelationSubquery(type, properties, relationshipFilters, query);
         return query;
+    }
+
+    static class FiltersAtStartNode {
+
+        String startNodeLabel;
+
+        List<Filter> content = new ArrayList<>();
+    }
+
+    /**
+     * Adds a filter to list, checking if all filters but the first have an operator.
+     *
+     * @param target The target filters
+     * @param filter The filter to add
+     */
+    private static void addFilterToList(FiltersAtStartNode target, Filter filter) {
+        if (filter.getBooleanOperator().equals(BooleanOperator.NONE) && !target.content.isEmpty()) {
+            throw new MissingOperatorException(
+                "BooleanOperator missing for filter with property name " + filter.getPropertyName());
+        }
+        target.content.add(filter);
+        if (target.startNodeLabel == null) {
+            target.startNodeLabel = filter.getNestedEntityTypeLabel();
+        }
     }
 
     private static void createRelationSubquery(String type, Map<String, Object> properties,
@@ -208,9 +227,11 @@ public class FilteredQueryBuilder {
         }
     }
 
-    private static void createNodeMatchSubquery(Map<String, Object> properties, List<Filter> nodeFilters,
-        String nodeLabel, StringBuilder query, String nodeIdentifier) {
-        if (nodeLabel != null) {
+    private static void createNodeMatchSubquery(Map<String, Object> properties, FiltersAtStartNode filtersAtStartNode,
+        StringBuilder query, String nodeIdentifier) {
+        String nodeLabel = filtersAtStartNode.startNodeLabel;
+        List<Filter> nodeFilters = filtersAtStartNode.content;
+        if (!(nodeLabel == null || nodeFilters.isEmpty())) {
             query.append(String.format("MATCH (%s:`%s`) WHERE ", nodeIdentifier, nodeLabel));
             appendFilters(nodeFilters, nodeIdentifier, query, properties);
         }

--- a/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/NodeQueryBuilder.java
@@ -44,7 +44,7 @@ public class NodeQueryBuilder {
     private boolean hasRelationshipMatch = false;
 
     NodeQueryBuilder(String principalLabel, Iterable<Filter> filters) {
-        this.principalClause = new PrincipalNodeMatchClause(principalLabel);
+        this.principalClause = principalLabel == null ? null : new PrincipalNodeMatchClause(principalLabel);
         this.filters = filters;
         this.nestedClauses = new ArrayList<>();
         this.pathClauses = new ArrayList<>();
@@ -67,7 +67,7 @@ public class NodeQueryBuilder {
                 } else if (filter.isDeepNested()) {
                     appendDeepNestedFilter(filter);
                     hasRelationshipMatch = true;
-                } else {
+                } else if (principalClause != null) {
                     //If the filter is not nested, it belongs to the node we're returning
                     principalClause().append(filter);
                 }
@@ -117,7 +117,6 @@ public class NodeQueryBuilder {
             nestedClauses.add(clause);
         }
         pathClauses.add(new NestedPathMatchClause(matchClauseId).append(filter));
-        //nestedClauses.add(clause);
         clause.append(filter);
 
         matchClauseId++;
@@ -140,7 +139,11 @@ public class NodeQueryBuilder {
     }
 
     private StringBuilder toCypher() {
-        StringBuilder stringBuilder = new StringBuilder(principalClause.toCypher());
+        StringBuilder stringBuilder = new StringBuilder();
+
+        if (principalClause != null) {
+            stringBuilder.append(principalClause.toCypher());
+        }
 
         for (MatchClause matchClause : nestedClauses) {
             stringBuilder.append(matchClause.toCypher());

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/Address.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/Address.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh824;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class Address {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String code;
+
+    @Relationship(value = "IS_IN", direction = Relationship.Direction.OUTGOING)
+    private City city;
+
+    public long getId() {
+        return id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public City getCity() {
+        return city;
+    }
+
+    public void setCity(City city) {
+        this.city = city;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/City.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/City.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh824;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class City {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public City() {
+    }
+
+    public City(String name) {
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/GroupMember.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/GroupMember.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh824;
+
+import org.neo4j.ogm.annotation.EndNode;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+import org.neo4j.ogm.annotation.StartNode;
+
+/**
+ * @author Michael J. Simons
+ */
+@RelationshipEntity("GROUP_MEMBER")
+public class GroupMember {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @StartNode
+    private User user;
+
+    @EndNode
+    private UserGroup group;
+
+    public GroupMember() {
+    }
+
+    public GroupMember(User user, UserGroup group) {
+        this.user = user;
+        this.group = group;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public UserGroup getGroup() {
+        return group;
+    }
+
+    public void setGroup(UserGroup group) {
+        this.group = group;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/User.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/User.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh824;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Relationship;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class User {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @Relationship("USER_HAS_ADDRESS")
+    private Address address;
+
+    public User() {
+    }
+
+    public User(String name) {
+        this.name = name;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/UserGroup.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/gh824/UserGroup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.gh824;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+/**
+ * @author Michael J. Simons
+ */
+@NodeEntity
+public class UserGroup {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/relationships/DeepNestQueryingOfRelationshipEntitiesIntegrationTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/relationships/DeepNestQueryingOfRelationshipEntitiesIntegrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.persistence.relationships;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.domain.gh824.Address;
+import org.neo4j.ogm.domain.gh824.City;
+import org.neo4j.ogm.domain.gh824.GroupMember;
+import org.neo4j.ogm.domain.gh824.User;
+import org.neo4j.ogm.domain.gh824.UserGroup;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.TestContainersTestBase;
+
+/**
+ * @author Michael J. Simons
+ */
+public class DeepNestQueryingOfRelationshipEntitiesIntegrationTest extends TestContainersTestBase {
+
+    private static SessionFactory sessionFactory;
+
+    @BeforeClass
+    public static void oneTimeSetUp() {
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.gh824");
+    }
+
+    @Before
+    public void createData() {
+
+        Address a1 = new Address();
+        a1.setCode("0001");
+        Address a2 = new Address();
+        a2.setCode("0002");
+        a2.setCity(new City("Aachen"));
+        User u1 = new User();
+        u1.setAddress(a1);
+        User u2 = new User("Mr. User");
+        u2.setAddress(a1);
+        User u3 = new User();
+        u3.setAddress(a2);
+        UserGroup ug1 = new UserGroup();
+        UserGroup ug2 = new UserGroup();
+        List<GroupMember> members = Arrays
+            .asList(new GroupMember(u1, ug1), new GroupMember(u2, ug2), new GroupMember(u3, ug2));
+
+        Session session = sessionFactory.openSession();
+        members.forEach(session::save);
+    }
+
+    @After
+    public void purgeData() {
+
+        sessionFactory.openSession().purgeDatabase();
+    }
+
+    @Test
+    public void flattenedPathSegmentsShouldWork() {
+
+        Filter playsFilter = new Filter("name", ComparisonOperator.EQUALS, "Mr. User");
+        playsFilter.setOwnerEntityType(GroupMember.class);
+
+        playsFilter.setNestedPath(
+            new Filter.NestedPathSegment("user", User.class)
+        );
+
+        Collection<GroupMember> films = sessionFactory.openSession().loadAll(GroupMember.class, playsFilter);
+        assertThat(films).hasSize(1);
+    }
+
+    @Test
+    public void nPathSegmentsShouldWork() {
+
+        Filter playsFilter = new Filter("code", ComparisonOperator.EQUALS, "0001");
+        playsFilter.setOwnerEntityType(GroupMember.class);
+
+        playsFilter.setNestedPath(
+            new Filter.NestedPathSegment("user", User.class),
+            new Filter.NestedPathSegment("address", Address.class)
+        );
+
+        Collection<GroupMember> films = sessionFactory.openSession().loadAll(GroupMember.class, playsFilter);
+        assertThat(films).hasSize(2);
+    }
+
+    @Test
+    public void nPlus1PathSegmentsShouldWork() {
+
+        Filter playsFilter = new Filter("name", ComparisonOperator.EQUALS, "Aachen");
+        playsFilter.setOwnerEntityType(GroupMember.class);
+
+        playsFilter.setNestedPath(
+            new Filter.NestedPathSegment("user", User.class),
+            new Filter.NestedPathSegment("address", Address.class),
+            new Filter.NestedPathSegment("city", City.class)
+        );
+
+        Collection<GroupMember> films = sessionFactory.openSession().loadAll(GroupMember.class, playsFilter);
+        assertThat(films).hasSize(1);
+    }
+}


### PR DESCRIPTION
This changes the code path for querying nested paths outgoing from relationships to the same path the node centric approach uses.

For direct or simple nested properties, the old path still applies.

This fixes #824.

If you have an idea to remove the separation, I'd be happy if you just push to the branch @meistermeier 