### PR TITLE
GH-831 - Avoid early population of externally generated ID fields.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
+++ b/core/src/main/java/org/neo4j/ogm/context/LabelPrimaryId.java
@@ -18,8 +18,6 @@
  */
 package org.neo4j.ogm.context;
 
-import static java.util.Objects.*;
-
 import java.util.Objects;
 
 import org.neo4j.ogm.metadata.ClassInfo;
@@ -33,6 +31,7 @@ import org.neo4j.ogm.metadata.ClassInfo;
  * @author Frantisek Hartman
  * @author Jonathan D'Orleans
  * @author Gerrit Meier
+ * @author Michael J. Simons
  */
 class LabelPrimaryId {
 
@@ -45,9 +44,16 @@ class LabelPrimaryId {
      * @param classInfo class info containing the primary id
      * @param id        the value of the id
      */
-    LabelPrimaryId(ClassInfo classInfo, Object id) {
+    static LabelPrimaryId of(ClassInfo classInfo, Object id) {
+
+        Objects.requireNonNull(classInfo);
+        Objects.requireNonNull(id);
+        return new LabelPrimaryId(classInfo, id);
+    }
+
+    private LabelPrimaryId(ClassInfo classInfo, Object id) {
         this.label = classInfo.neo4jName();
-        this.id = requireNonNull(id);
+        this.id = id;
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappingContext.java
@@ -101,7 +101,7 @@ public class MappingContext {
         }
 
         // direct match
-        final LabelPrimaryId key = new LabelPrimaryId(classInfo, id);
+        final LabelPrimaryId key = LabelPrimaryId.of(classInfo, id);
         Object node = primaryIndexNodeRegister.get(key);
         if (node != null) {
             return node;
@@ -113,7 +113,7 @@ public class MappingContext {
 
             ClassInfo subClassInfo = queue.poll();
 
-            node = primaryIndexNodeRegister.get(new LabelPrimaryId(subClassInfo, id));
+            node = primaryIndexNodeRegister.get(LabelPrimaryId.of(subClassInfo, id));
             if (node != null) {
                 return node;
             }
@@ -150,7 +150,7 @@ public class MappingContext {
             nodeEntityRegister.put(id, entity);
             final Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(entity);
             if (primaryIndexValue != null) {
-                LabelPrimaryId key = new LabelPrimaryId(classInfo, primaryIndexValue);
+                LabelPrimaryId key = LabelPrimaryId.of(classInfo, primaryIndexValue);
                 primaryIndexNodeRegister.putIfAbsent(key, entity);
                 primaryIdToNativeId.put(key, id);
             }
@@ -176,7 +176,7 @@ public class MappingContext {
             final ClassInfo classInfo = metaData.classInfo(entity);
             final Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(entity);
             if (primaryIndexValue != null) {
-                primaryIndexNodeRegister.remove(new LabelPrimaryId(classInfo, primaryIndexValue));
+                primaryIndexNodeRegister.remove(LabelPrimaryId.of(classInfo, primaryIndexValue));
             }
 
             if (deregisterDependentRelationshipEntity) {
@@ -191,7 +191,7 @@ public class MappingContext {
         ClassInfo classInfo = metaData.classInfo(entity);
         if (classInfo.hasPrimaryIndexField()) {
             final Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(entity);
-            LabelPrimaryId key = new LabelPrimaryId(classInfo, primaryIndexValue);
+            LabelPrimaryId key = LabelPrimaryId.of(classInfo, primaryIndexValue);
             primaryIdToNativeId.put(key, identity);
         }
 
@@ -204,7 +204,7 @@ public class MappingContext {
         ClassInfo classInfo = metaData.classInfo(entity);
         if (classInfo.hasPrimaryIndexField()) {
             final Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(entity);
-            LabelPrimaryId labelPrimaryId = new LabelPrimaryId(classInfo, primaryIndexValue);
+            LabelPrimaryId labelPrimaryId = LabelPrimaryId.of(classInfo, primaryIndexValue);
             primaryIdToRelationship.remove(labelPrimaryId);
             primaryIdToNativeId.remove(labelPrimaryId);
         }
@@ -291,7 +291,7 @@ public class MappingContext {
      * @return relationship entity
      */
     public Object getRelationshipEntityById(ClassInfo classInfo, Object id) {
-        return primaryIdToRelationship.get(new LabelPrimaryId(classInfo, id));
+        return primaryIdToRelationship.get(LabelPrimaryId.of(classInfo, id));
     }
 
     public Object addRelationshipEntity(Object relationshipEntity, Long id) {
@@ -303,8 +303,9 @@ public class MappingContext {
             ClassInfo classInfo = metaData.classInfo(relationshipEntity);
             if (classInfo.hasPrimaryIndexField()) {
                 final Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(relationshipEntity);
-                primaryIdToRelationship.put(new LabelPrimaryId(classInfo, primaryIndexValue), relationshipEntity);
-                primaryIdToNativeId.put(new LabelPrimaryId(classInfo, primaryIndexValue), id);
+                LabelPrimaryId labelPrimaryId = LabelPrimaryId.of(classInfo, primaryIndexValue);
+                primaryIdToRelationship.put(labelPrimaryId, relationshipEntity);
+                primaryIdToNativeId.put(labelPrimaryId, id);
             }
         }
         return relationshipEntity;
@@ -522,7 +523,7 @@ public class MappingContext {
         } else {
             Object primaryIndexValue = classInfo.readPrimaryIndexValueOf(entity);
             return Optional.ofNullable(primaryIndexValue)
-                .map(v -> primaryIdToNativeId.get(new LabelPrimaryId(classInfo, v)));
+                .map(v -> primaryIdToNativeId.get(LabelPrimaryId.of(classInfo, v)));
         }
     }
 
@@ -543,7 +544,7 @@ public class MappingContext {
                 throw new MappingException("Field with primary id is null for entity " + entity);
             }
 
-            LabelPrimaryId key = new LabelPrimaryId(classInfo, primaryIndexValue);
+            LabelPrimaryId key = LabelPrimaryId.of(classInfo, primaryIndexValue);
             Long graphId = primaryIdToNativeId.get(key);
             if (graphId == null) {
                 graphId = EntityUtils.nextRef();

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import org.neo4j.ogm.context.MappingContext;

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SaveEventDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SaveEventDelegate.java
@@ -18,15 +18,7 @@
  */
 package org.neo4j.ogm.session.delegates;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.context.MappedRelationship;
@@ -107,7 +99,7 @@ final class SaveEventDelegate extends SessionDelegate {
 
     private void firePreSave(Object object) {
 
-        boolean isNew = session.context().nativeId(object) < 0;
+        boolean isNew = !session.context().optionalNativeId(object).isPresent();
         this.session.notifyListeners(new PreSaveEvent(object, isNew));
         this.preSaved.put(object, isNew);
     }
@@ -164,7 +156,7 @@ final class SaveEventDelegate extends SessionDelegate {
 
     // registers this object as visited and returns true if it was not previously visited, false otherwise
     private boolean visit(Object object) {
-        return this.visited.add(session.context().nativeId(object));
+        return this.visited.add(object);
     }
 
     // returns true if the object in question is dirty (has changed)

--- a/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
+++ b/core/src/main/java/org/neo4j/ogm/session/request/RequestExecutor.java
@@ -202,11 +202,12 @@ public class RequestExecutor {
             if (!(obj instanceof TransientRelationship)) {
                 ClassInfo classInfo = session.metaData().classInfo(obj);
                 if (!classInfo.isRelationshipEntity()) {
-                    Long id = session.context().nativeId(obj);
-                    if (id >= 0) {
-                        LOGGER.debug("updating existing node id: {}, {}", id, obj);
-                        registerEntity(session.context(), classInfo, id, obj);
-                    }
+                    session.context().optionalNativeId(obj)
+                        .filter(id -> id >= 0)
+                        .ifPresent(id -> {
+                            LOGGER.debug("updating existing node id: {}, {}", id, obj);
+                            registerEntity(session.context(), classInfo, id, obj);
+                        });
                 }
             }
         }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/context/MappingContextTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/context/MappingContextTest.java
@@ -238,7 +238,7 @@ public class MappingContextTest {
     private boolean containsNativeId(ClassInfo classInfo, Object id) {
         try {
             return ((Map) PRIMARY_ID_TO_NATIVE_ID_ACCESSOR.get(this.mappingContext))
-                .containsKey(new LabelPrimaryId(classInfo, id));
+                .containsKey(LabelPrimaryId.of(classInfo, id));
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This introduces `optionalNativeId` on the mapping context that does not trigger any id generating strategies in contrast tp `nativeId`. This method is than used especially in the eventing system so that firing a pre-save event contains the correct `isNew`state.

Furthrmore it is now used in checking dirtiness and in the delete events, so that those don’t modify the object states without any added benefit.