### PR TITLE
GH-883 - Cache hash code for object

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  * @author Luanne Misquitta
  * @author Andreas Berger
  * @author Michael J. Simons
+ * @author Torsten Kuhnhenne
  */
 public class MappedRelationship implements Mappable {
 
@@ -40,6 +41,7 @@ public class MappedRelationship implements Mappable {
     private final Long relationshipId;
     private final Class startNodeType;
     private final Class endNodeType;
+    private int hash = 0;
 
     public MappedRelationship(long startNodeId, String relationshipType, long endNodeId, Long relationshipId,
         Class startNodeType, Class endNodeType) {
@@ -94,7 +96,10 @@ public class MappedRelationship implements Mappable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(startNodeId, relationshipType, endNodeId, relationshipId);
+        if (hash == 0) {
+            hash = Objects.hash(startNodeId, relationshipType, endNodeId, relationshipId);
+        }
+        return hash;
     }
 
     public String toString() {

--- a/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
+++ b/core/src/main/java/org/neo4j/ogm/context/MappedRelationship.java
@@ -41,7 +41,7 @@ public class MappedRelationship implements Mappable {
     private final Long relationshipId;
     private final Class startNodeType;
     private final Class endNodeType;
-    private int hash = 0;
+    private final int hash;
 
     public MappedRelationship(long startNodeId, String relationshipType, long endNodeId, Long relationshipId,
         Class startNodeType, Class endNodeType) {
@@ -51,6 +51,7 @@ public class MappedRelationship implements Mappable {
         this.relationshipId = relationshipId;
         this.startNodeType = startNodeType;
         this.endNodeType = endNodeType;
+        this.hash = Objects.hash(startNodeId, relationshipType, endNodeId, relationshipId);
     }
 
     public long getStartNodeId() {
@@ -96,9 +97,6 @@ public class MappedRelationship implements Mappable {
 
     @Override
     public int hashCode() {
-        if (hash == 0) {
-            hash = Objects.hash(startNodeId, relationshipType, endNodeId, relationshipId);
-        }
         return hash;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Caches the hash code to reduce garbage created by outboxing long properties and also the value is only calculated once per object and not every time it is added to an HashSet

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #833 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Outboxing of `long` properties creates a lot of garbage when you have a lot `MappedRelationship` objects added to the current `CypherContext` because the hash code is calculated multiple times.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run all tests except the integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
