### PR TITLE
GH-836 - Ignore duplicates in constraint definitions.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
@@ -72,7 +72,7 @@ public class AutoIndexManager {
     private final String dumpDir;
     private final String dumpFilename;
 
-    private final List<AutoIndex> indexes;
+    private final Set<AutoIndex> indexes;
 
     private final Neo4jSession session;
     private DatabaseInformation databaseInfo;
@@ -144,12 +144,12 @@ public class AutoIndexManager {
 
         if (!copyOfIndexes.isEmpty()) {
 
-            String missingIndexes = "[";
+            StringBuilder missingIndexes = new StringBuilder("[");
 
             for (AutoIndex s : copyOfIndexes) {
-                missingIndexes += s.getDescription() + ", ";
+                missingIndexes.append(s.getDescription()).append(", ");
             }
-            missingIndexes += "]";
+            missingIndexes.append("]");
             throw new MissingIndexException(
                 "Validation of Constraints and Indexes failed. Could not find the following : " + missingIndexes);
         }
@@ -253,10 +253,10 @@ public class AutoIndexManager {
         session.doInTransaction(() -> session.requestHandler().execute(request).close(), READ_WRITE);
     }
 
-    private static List<AutoIndex> initialiseAutoIndex(MetaData metaData) {
+    private static Set<AutoIndex> initialiseAutoIndex(MetaData metaData) {
 
         LOGGER.debug("Building Index Metadata.");
-        List<AutoIndex> indexMetadata = new ArrayList<>();
+        Set<AutoIndex> indexMetadata = new HashSet<>();
         for (ClassInfo classInfo : metaData.persistentEntities()) {
 
             final String owningType = classInfo.neo4jName();

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/autoindex/BaseAutoIndexManagerTestClass.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/autoindex/BaseAutoIndexManagerTestClass.java
@@ -29,8 +29,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -91,9 +93,9 @@ public abstract class BaseAutoIndexManagerTestClass extends TestContainersTestBa
 
     protected SessionFactory sessionFactory;
 
-    BaseAutoIndexManagerTestClass(String[] expectedIndexDefinitions, Class<?>... packages) {
+    BaseAutoIndexManagerTestClass(String[] expectedIndexDefinitions, Class<?>... classes) {
         sessionFactory = new SessionFactory(getDriver(),
-            Arrays.stream(packages).map(Class::getName).toArray(String[]::new));
+            Arrays.stream(classes).map(Class::getName).toArray(String[]::new));
         this.expectedIndexDefinitions = expectedIndexDefinitions;
         this.expectedNumberOfAdditionalIndexes = supportsFulltextIndex() ? 2 : 0;
     }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/autoindex/DuplicatedConstraintAutoIndexManagerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/autoindex/DuplicatedConstraintAutoIndexManagerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.autoindex;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.neo4j.ogm.domain.autoindex.RelationshipEntityWithSameType1;
+import org.neo4j.ogm.domain.autoindex.RelationshipEntityWithSameType2;
+
+/**
+ * @author Gerrit Meier
+ */
+public class DuplicatedConstraintAutoIndexManagerTest extends BaseAutoIndexManagerTestClass {
+
+    private static final String INDEX = "INDEX ON :`SAME_TYPE`(`id`)";
+    private static final String CONSTRAINT = "CONSTRAINT ON (`same_type`:`SAME_TYPE`) ASSERT `same_type`.`id` IS UNIQUE";
+
+    public DuplicatedConstraintAutoIndexManagerTest() {
+        super(new String[] { CONSTRAINT }, RelationshipEntityWithSameType1.class, RelationshipEntityWithSameType2.class);
+    }
+
+    @Override
+    protected void additionalTearDown() {
+        executeDrop(CONSTRAINT);
+        executeDrop(INDEX);
+    }
+
+    @Test
+    public void shouldNotFailOnDuplicatedConstraint() {
+
+        runAutoIndex("update");
+
+        executeForIndexes(indexes -> assertThat(indexes).hasSize(expectedNumberOfAdditionalIndexes));
+        executeForConstraints(constraints -> assertThat(constraints).hasSize(1));
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/autoindex/RelationshipEntityWithSameType1.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/autoindex/RelationshipEntityWithSameType1.java
@@ -1,0 +1,14 @@
+package org.neo4j.ogm.domain.autoindex;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+
+/**
+ * @author Gerrit Meier
+ */
+@RelationshipEntity(type = "SAME_TYPE")
+public class RelationshipEntityWithSameType1 {
+
+    @Id
+    private Long id;
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/autoindex/RelationshipEntityWithSameType2.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/autoindex/RelationshipEntityWithSameType2.java
@@ -1,0 +1,14 @@
+package org.neo4j.ogm.domain.autoindex;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.RelationshipEntity;
+
+/**
+ * @author Gerrit Meier
+ */
+@RelationshipEntity(type = "SAME_TYPE")
+public class RelationshipEntityWithSameType2 {
+
+    @Id
+    private Long id;
+}


### PR DESCRIPTION
This will fix the handling of multiple defines, e.g. coming from multiple
relationship entities, constraints with the same type and field.