### PR TITLE
GH-849 Cache collection of FieldInfo for relationship fields

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -542,26 +542,25 @@ public class ClassInfo {
         return relationshipFields;
     }
 
-    @SuppressWarnings("HiddenField")
     private synchronized void initRelationshipFields() {
         if (relationshipFields != null) {
             return;
         }
 
         FieldInfo optionalIdentityField = identityFieldOrNull();
-        Set<FieldInfo> relationshipFields = new HashSet<>();
+        Set<FieldInfo> identifiedRelationshipFields = new HashSet<>();
         for (FieldInfo fieldInfo : fieldsInfo().fields()) {
-            if (fieldInfo != optionalIdentityField) {
-                if (!fieldInfo.getAnnotations().has(Relationship.class)) {
-                    if (!fieldInfo.persistableAsProperty()) {
-                        relationshipFields.add(fieldInfo);
-                    }
-                } else {
-                    relationshipFields.add(fieldInfo);
-                }
+            if (fieldInfo == optionalIdentityField) {
+                continue;
+            }
+
+            if (fieldInfo.getAnnotations().has(Relationship.class)) {
+                identifiedRelationshipFields.add(fieldInfo);
+            } else if (!fieldInfo.persistableAsProperty()) {
+                identifiedRelationshipFields.add(fieldInfo);
             }
         }
-        this.relationshipFields = relationshipFields;
+        this.relationshipFields = Collections.unmodifiableSet(identifiedRelationshipFields);
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/ClassInfo.java
@@ -62,6 +62,7 @@ import org.slf4j.LoggerFactory;
  * @author Luanne Misquitta
  * @author Mark Angrish
  * @author Michael J. Simons
+ * @author Torsten Kuhnhenne
  */
 public class ClassInfo {
 
@@ -105,6 +106,7 @@ public class ClassInfo {
     private volatile boolean isPostLoadMethodMapped = false;
     private volatile MethodInfo postLoadMethod;
     private volatile Collection<String> staticLabels;
+    private volatile Set<FieldInfo> relationshipFields;
     private boolean primaryIndexFieldChecked = false;
     private final Class<?> cls;
     private Class<? extends IdStrategy> idStrategyClass;
@@ -534,6 +536,17 @@ public class ClassInfo {
      * @return A Collection of FieldInfo objects describing the classInfo's relationship fields
      */
     public Collection<FieldInfo> relationshipFields() {
+        if (relationshipFields == null) {
+            initRelationshipFields();
+        }
+        return relationshipFields;
+    }
+
+    @SuppressWarnings("HiddenField")
+    private synchronized void initRelationshipFields() {
+        if (relationshipFields != null) {
+            return;
+        }
 
         FieldInfo optionalIdentityField = identityFieldOrNull();
         Set<FieldInfo> relationshipFields = new HashSet<>();
@@ -548,7 +561,7 @@ public class ClassInfo {
                 }
             }
         }
-        return relationshipFields;
+        this.relationshipFields = relationshipFields;
     }
 
     /**


### PR DESCRIPTION
Cache the collection of FieldInfos for the relationshop fields as it is already done for the property fields.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Caches the collection for FieldInfos for better performance when reading entities with `@Relationship` annotations from the database. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#849 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This changes leads to a better performance when reading linked data from the database and mapping it to an entity model that uses `@Relationship` annotations

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests and also tested it in our software.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
