### PR TITLE
Make consistent use of mayBeReadWrite for deciding to clear the session or not.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -121,7 +121,7 @@ public class ExecuteQueriesDelegate extends SessionDelegate {
 
         validateQuery(cypher, parameters, readOnly);
 
-        if (!readOnly) {
+        if (mayBeReadWrite(cypher)) {
             // While an update query may not return objects, it has enough changes
             // to modify all entities in the context, so we must flush it either way.
             session.clear();


### PR DESCRIPTION
This addresses the following SDN issue: https://jira.spring.io/browse/DATAGRAPH-1407

Basically: The read only indicator of the transaction would overwrite any hint or other means to decide whether it's a rw or ro query.  We cannot use it to decide to clear the session or not in a transaction spanning multiple queries. 

@torstenkuhnhenne Would that still work with you use case? 

Paging @Phoosha here as well.