### PR TITLE
Add shims for GraalVM native image.

### DIFF
--- a/core/src/main/resources/META-INF/native-image/org.neo4j/neo4j-ogm-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/org.neo4j/neo4j-ogm-core/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflection-config.json

--- a/core/src/main/resources/META-INF/native-image/org.neo4j/neo4j-ogm-core/reflection-config.json
+++ b/core/src/main/resources/META-INF/native-image/org.neo4j/neo4j-ogm-core/reflection-config.json
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "org.neo4j.ogm.annotation.typeconversion.Convert",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.typeconversion.DateLong",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.typeconversion.DateString",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.typeconversion.EnumString",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.typeconversion.NumberString",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.CompositeIndex",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.CompositeIndexes",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.EndNode",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.GeneratedValue",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Id",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Index",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Labels",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.NodeEntity",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.PostLoad",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Properties",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Property",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Relationship",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.RelationshipEntity",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Required",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.StartNode",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Transient",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.ValueFor",
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "org.neo4j.ogm.annotation.Version",
+    "allDeclaredMethods": true
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,11 @@
                 <targetPath>META-INF/services</targetPath>
             </resource>
 
+            <resource>
+                <directory>src/main/resources/META-INF/native-image</directory>
+                <targetPath>META-INF/native-image</targetPath>
+            </resource>
+
         </resources>
         <testResources>
             <testResource>


### PR DESCRIPTION
This adds a reflection-config.json for GraalVM native image that registers all applicable annotations to be included in the native image.
It also makes the DomainInfo look for an index file containing the annotated entities as ClassGraph won’t find them via the SubstrateVM class loader.