### PR TITLE
Fix cross reference link

### DIFF
--- a/neo4j-ogm-docs/src/main/asciidoc/reference/getting-started.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/getting-started.adoc
@@ -112,7 +112,7 @@ In the `<dependencies>` section of your `pom.xml` add the following:
 </dependency>
 ----
 
-Please also have a look at <<reference:native-property-types:supported-drivers, the native type system>> to take advantage of Neo4j-OGM's support for native temporal and spatial types
+Please also have a look at https://github.com/neo4j/neo4j-ogm/blob/master/neo4j-ogm-docs/src/main/asciidoc/reference/nativetypes.adoc#supported-drivers[the native type system] to take advantage of Neo4j-OGM's support for native temporal and spatial types
 and how to use the modules `neo4j-ogm-bolt-native-types` and `neo4j-ogm-embedded-native-types`.
 
 [[reference:getting-started:dependency-management:gradle]]


### PR DESCRIPTION
I'm using an absolute link because this page is included in https://github.com/neo4j-documentation/developer-guides/blob/publish/modules/ROOT/pages/neo4j-ogm.adoc and published by Antora at https://neo4j.com/developer/neo4j-ogm

Please note that the explicit id is ignored by GitHub and as a result the actual fragment will be #supported-drivers.