### PR TITLE
GH-869 - Close Driver if verifyConnectivity fails to avoid resource leak

### DIFF
--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
@@ -156,8 +156,8 @@ public class BoltDriver extends AbstractConfigurableDriver {
     private void initializeDriver() {
 
         final String serviceUnavailableMessage = "Could not create driver instance";
+        Driver driver = null;
         try {
-            Driver driver;
             if (credentials != null) {
                 UsernamePasswordCredentials usernameAndPassword = (UsernamePasswordCredentials) this.credentials;
                 AuthToken authToken = AuthTokens
@@ -169,8 +169,13 @@ public class BoltDriver extends AbstractConfigurableDriver {
             }
             driver.verifyConnectivity();
             boltDriver = driver;
+            driver = null; // set null to skip close() in finally
         } catch (ServiceUnavailableException e) {
             throw new ConnectionException(serviceUnavailableMessage, e);
+        } finally {
+            if (driver != null) {
+                driver.close();
+            }
         }
     }
 


### PR DESCRIPTION
This PR provides a test case for GH-869 and intends to fix the resource leak.

## Description

There's basically two ways to approach this:
1. Keep hold of the reference to the `Driver` instance created in `BoltDriver#initializeDriver` and leave it up to users of Neo4j OGM to decide what happens
2. Abandon the reference as before but call `Driver#close()` beforehand to cleanup resources such as threads

Since 2. seems more consistent with the current behavior that's what this PR does. Furthermore the usage of ` finally` is meant to even call `Driver#close()` in the case of other exceptions than the caught `ServiceUnavailableException`.

## How Has This Been Tested?

A test case has been added which previously would have failed. Furthermore, the Spring Boot / Spring Data Neo4j application mentioned in GH-869 has been confirmed to terminate fully if its startup fails due to a database connectivity issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. (:question: Where is it? :blush: :question: )
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
