### PR TITLE
Add an extension API for custom transaction managers.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
@@ -130,9 +130,7 @@ public abstract class AbstractTransaction implements Transaction {
     @Override
     public final boolean canRollback() {
 
-        return (status == Transaction.Status.ROLLBACK_PENDING
-            || status == Transaction.Status.COMMIT_PENDING
-            || status == Transaction.Status.OPEN || status == Transaction.Status.PENDING);
+        return Transaction.super.canRollback();
     }
 
     /**

--- a/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/AbstractTransaction.java
@@ -19,9 +19,9 @@
 package org.neo4j.ogm.transaction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 
 import org.neo4j.ogm.exception.TransactionException;
 import org.slf4j.Logger;
@@ -67,10 +67,9 @@ public abstract class AbstractTransaction implements Transaction {
 
         // is this the root transaction ?
         if (extensions == 0) {
-            transactionManager.close(this, newObjectNotifier -> {
+            transactionManager.close(this, transactionClosedListener -> {
                 rollback0();
-                Consumer<Object> handler = object -> newObjectNotifier.onStatusChanged(Status.ROLLEDBACK, object);
-                registeredNew.forEach(handler);
+                transactionClosedListener.onTransactionClosed(Status.ROLLEDBACK, Collections.unmodifiableList(this.registeredNew));
                 registeredNew.clear();
                 status = Status.ROLLEDBACK;
                 logger.debug("Thread {}: Rolled back", Thread.currentThread().getId());
@@ -97,10 +96,9 @@ public abstract class AbstractTransaction implements Transaction {
 
         try {
             if (extensions == 0) {
-                transactionManager.close(this, newObjectNotifier -> {
+                transactionManager.close(this, transactionClosedLitener -> {
                     commit0();
-                    Consumer<Object> handler = object -> newObjectNotifier.onStatusChanged(Status.COMMITTED, object);
-                    registeredNew.forEach(handler);
+                    transactionClosedLitener.onTransactionClosed(Status.COMMITTED, Collections.unmodifiableList(this.registeredNew));
                     registeredNew.clear();
                     status = Status.COMMITTED;
                     logger.debug("Thread {}: Committed", Thread.currentThread().getId());

--- a/api/src/main/java/org/neo4j/ogm/transaction/Transaction.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/Transaction.java
@@ -45,7 +45,12 @@ public interface Transaction extends AutoCloseable {
      *
      * @return true if this transaction can be rolled back
      */
-    boolean canRollback();
+    default boolean canRollback() {
+        var status = status();
+        return (status == Transaction.Status.ROLLBACK_PENDING
+            || status == Transaction.Status.COMMIT_PENDING
+            || status == Transaction.Status.OPEN || status == Transaction.Status.PENDING);
+    }
 
     /**
      * return the status of the current transaction

--- a/api/src/main/java/org/neo4j/ogm/transaction/Transaction.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/Transaction.java
@@ -41,6 +41,13 @@ public interface Transaction extends AutoCloseable {
     boolean canCommit();
 
     /**
+     * If this transaction can be rolled back.
+     *
+     * @return true if this transaction can be rolled back
+     */
+    boolean canRollback();
+
+    /**
      * return the status of the current transaction
      *
      * @return the Status value associated with the current transaction

--- a/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.ogm.transaction;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -50,13 +51,15 @@ public interface TransactionManager {
      * choose to call this or not depending on what actually did cause the closing of a transaction.
      */
     @FunctionalInterface
-    interface NewObjectNotifier {
+    interface TransactionClosedListener {
         /**
          * Indicate a commit event per entity
-         * @param newsStatus the new status
-         * @param entity The newly registered entity
+         *
+         * @param newsStatus         the new status
+         * @param entitiesRegistered A list of entities registered in the transaction being closed. A handler might
+         *                           choose to clean up their state.
          */
-        void onStatusChanged(Transaction.Status newsStatus, Object entity);
+        void onTransactionClosed(Transaction.Status newsStatus, List<Object> entitiesRegistered);
     }
 
     /**
@@ -67,7 +70,7 @@ public interface TransactionManager {
      * @param transaction The transaction to be closed
      * @param callback A callback to be executed prior to detaching the transaction from the thread.
      */
-    void close(Transaction transaction, Consumer<NewObjectNotifier> callback);
+    void close(Transaction transaction, Consumer<TransactionClosedListener> callback);
 
     /**
      * Returns the current transaction for this thread, or null if none exists

--- a/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
+++ b/api/src/main/java/org/neo4j/ogm/transaction/TransactionManager.java
@@ -18,6 +18,8 @@
  */
 package org.neo4j.ogm.transaction;
 
+import java.util.function.Consumer;
+
 /**
  * @author Vince Bickers
  * @author Mark Angrish
@@ -43,28 +45,29 @@ public interface TransactionManager {
     Transaction openTransaction(Transaction.Type type, Iterable<String> bookmarks);
 
     /**
-     * Rolls back the specified transaction.
-     * The actual job of rolling back the transaction is left to the relevant driver. if
-     * this is successful, the transaction is detached from this thread.
-     * If the specified transaction is not the correct one for this thread, throws an exception
-     *
-     * <strong>Warning</strong>: This method is meant to be called from actual transactions only!!!
-     *
-     * @param transaction the transaction to rollback
+     * A handler that can be called per entity during commit or rollback operations. It will we passed
+     * to the callback of the {@link #close(Transaction, Consumer)} operation. Transactions may
+     * choose to call this or not depending on what actually did cause the closing of a transaction.
      */
-    void rollback(Transaction transaction);
+    @FunctionalInterface
+    interface NewObjectNotifier {
+        /**
+         * Indicate a commit event per entity
+         * @param newsStatus the new status
+         * @param entity The newly registered entity
+         */
+        void onStatusChanged(Transaction.Status newsStatus, Object entity);
+    }
 
     /**
-     * Commits the specified transaction.
-     * The actual job of committing the transaction is left to the relevant driver. if
-     * this is successful, the transaction is detached from this thread.
-     * If the specified transaction is not the correct one for this thread, throws an exception
-     *
-     * <strong>Warning</strong>: This method is meant to be called from actual transactions only!!!
-     *
-     * @param transaction the transaction to commit
+     * Closes the specified transaction if it belongs to the current thread. After the {@code callback} has successfully
+     * been called, the transaction will be detached from this transaction manager and the executing thread.
+     * <p>
+     * The method must throw an exception if the {@code transaction} does not belong to the current thread.
+     * @param transaction The transaction to be closed
+     * @param callback A callback to be executed prior to detaching the transaction from the thread.
      */
-    void commit(Transaction transaction);
+    void close(Transaction transaction, Consumer<NewObjectNotifier> callback);
 
     /**
      * Returns the current transaction for this thread, or null if none exists
@@ -72,10 +75,6 @@ public interface TransactionManager {
      * @return this thread's transaction
      */
     Transaction getCurrentTransaction();
-
-    boolean canCommit();
-
-    boolean canRollback();
 
     void bookmark(String bookmark);
 }

--- a/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
+++ b/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
@@ -21,10 +21,10 @@ package org.neo4j.ogm.session.transaction;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import org.neo4j.ogm.driver.Driver;
 import org.neo4j.ogm.session.Neo4jSession;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.transaction.AbstractTransaction;
@@ -47,10 +47,13 @@ public abstract class AbstractTransactionManager implements TransactionManager {
     private final Session session;
     private final BiFunction<Transaction.Type, Iterable<String>, Transaction> transactionFactory;
 
-    public AbstractTransactionManager(Session session,
-        Function<TransactionManager, BiFunction<Transaction.Type, Iterable<String>, Transaction>> transactionFactorySupplier) {
+    /**
+     * @param driver The driver that will provide native transactions via {@link Driver#getTransactionFactorySupplier()}
+     * @param session The OGM session that requires this transaction manager
+     */
+    protected AbstractTransactionManager(Driver driver, Session session) {
         this.session = session;
-        this.transactionFactory = transactionFactorySupplier.apply(this);
+        this.transactionFactory = driver.getTransactionFactorySupplier().apply(this);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
+++ b/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
@@ -36,7 +36,7 @@ import org.neo4j.ogm.transaction.TransactionManager;
  * the handling of thread local transactions to various scenarios that might not be able to deal with Thread locals or
  * that are keen on not having them for performance reasons.
  * <p>
- * The implemented methods of the interface are intentionally final so that they are guaranteed to work occoring to the
+ * The implemented methods of the interface are intentionally final so that they are guaranteed to work according to the
  * systems' specification.
  *
  * @author Michael J. Simons
@@ -98,7 +98,7 @@ public abstract class AbstractTransactionManager implements TransactionManager {
 
     /**
      * Opens a new transaction if there is no current via the {@code opener} or passes a current transaction to the
-     * {@coode extender}. The latter will try to extend the transaction if it's compatible.
+     * {@code extender}. The latter will try to extend the transaction if it's compatible.
      *
      * @param opener   The opener of new transaction
      * @param extender The extender trying to create sub transactions

--- a/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
+++ b/core/src/main/java/org/neo4j/ogm/session/transaction/AbstractTransactionManager.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002-2022 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.session.transaction;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import org.neo4j.ogm.session.Neo4jSession;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.transaction.AbstractTransaction;
+import org.neo4j.ogm.transaction.Transaction;
+import org.neo4j.ogm.transaction.TransactionManager;
+
+/**
+ * This abstract base class of a Neo4j-OGM {@link org.neo4j.ogm.transaction.TransactionManager} can be used to adapt
+ * the handling of thread local transactions to various scenarios that might not be able to deal with Thread locals or
+ * that are keen on not having them for performance reasons.
+ * <p>
+ * The implemented methods of the interface are intentionally final so that they are guaranteed to work occoring to the
+ * systems' specification.
+ *
+ * @author Michael J. Simons
+ * @since 4.0.3
+ */
+public abstract class AbstractTransactionManager implements TransactionManager {
+
+    private final Session session;
+    private final BiFunction<Transaction.Type, Iterable<String>, Transaction> transactionFactory;
+
+    public AbstractTransactionManager(Session session,
+        Function<TransactionManager, BiFunction<Transaction.Type, Iterable<String>, Transaction>> transactionFactorySupplier) {
+        this.session = session;
+        this.transactionFactory = transactionFactorySupplier.apply(this);
+    }
+
+    @Override
+    public final void bookmark(String bookmark) {
+        if (session != null) {
+            session.withBookmark(bookmark);
+        }
+    }
+
+    /**
+     * Opens a new transaction against a database instance.
+     * Instantiation of the transaction is left to the driver
+     *
+     * @return a new {@link Transaction}
+     */
+    @Override
+    public final Transaction openTransaction() {
+        return openTransaction(null, Set.of());
+    }
+
+    /**
+     * Opens a new transaction against a database instance.
+     * Instantiation of the transaction is left to the driver
+     *
+     * @return a new {@link Transaction}
+     */
+    @Override
+    public final Transaction openTransaction(Transaction.Type type, Iterable<String> bookmarks) {
+        return openOrExtend(
+            () -> transactionFactory.apply(type == null ? Transaction.Type.READ_WRITE : type, bookmarks),
+            transaction -> {
+                if (!(transaction instanceof AbstractTransaction abstractTransaction)) {
+                    throw new IllegalStateException(
+                        "There's already an ongoing transaction for the current thread and it is not extendable.");
+                }
+
+                abstractTransaction.extend(type == null ? abstractTransaction.type() : type);
+                return abstractTransaction;
+            }
+        );
+    }
+
+    /**
+     * Opens a new transaction if there is no current via the {@code opener} or passes a current transaction to the
+     * {@coode extender}. The latter will try to extend the transaction if it's compatible.
+     *
+     * @param opener   The opener of new transaction
+     * @param extender The extender trying to create sub transactions
+     * @return The new current transaction
+     */
+    protected abstract Transaction openOrExtend(Supplier<Transaction> opener, UnaryOperator<Transaction> extender);
+
+    @Override
+    public final void close(Transaction transaction, Consumer<TransactionClosedListener> callback) {
+
+        removeIfCurrent(transaction, () -> {
+            callback.accept((status, entities) -> {
+                if (status == Transaction.Status.ROLLEDBACK) {
+                    var mappingContext = ((Neo4jSession) session).context();
+                    entities.forEach(mappingContext::reset);
+                }
+            });
+        });
+    }
+
+    /**
+     * Check if {@code transaction} is the transaction belonging to this thread, if so, calls the action
+     * and then detach the transaction from the thread.
+     *
+     * @param action The action to be run prior to detaching / unlocking the transaction from the thread.
+     */
+    protected abstract void removeIfCurrent(Transaction transaction, Runnable action);
+}

--- a/core/src/main/java/org/neo4j/ogm/session/transaction/DefaultTransactionManager.java
+++ b/core/src/main/java/org/neo4j/ogm/session/transaction/DefaultTransactionManager.java
@@ -18,11 +18,10 @@
  */
 package org.neo4j.ogm.session.transaction;
 
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import org.neo4j.ogm.driver.Driver;
 import org.neo4j.ogm.exception.core.TransactionManagerException;
 import org.neo4j.ogm.session.Session;
 import org.neo4j.ogm.transaction.Transaction;
@@ -37,9 +36,8 @@ public final class DefaultTransactionManager extends AbstractTransactionManager 
 
     private final ThreadLocal<Transaction> currentThreadLocalTransaction = new ThreadLocal<>();
 
-    public DefaultTransactionManager(Session session,
-        Function<TransactionManager, BiFunction<Transaction.Type, Iterable<String>, Transaction>> transactionFactorySupplier) {
-        super(session, transactionFactorySupplier);
+    public DefaultTransactionManager(Driver driver, Session session) {
+        super(driver, session);
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/transaction/DefaultTransactionManager.java
+++ b/core/src/main/java/org/neo4j/ogm/session/transaction/DefaultTransactionManager.java
@@ -32,7 +32,7 @@ import org.neo4j.ogm.transaction.TransactionManager;
  * @author Luanne Misquitta
  * @author Michael J. Simons
  */
-public final class DefaultTransactionManager extends AbstractTransactionManager implements TransactionManager {
+public final class DefaultTransactionManager extends AbstractTransactionManager {
 
     private final ThreadLocal<Transaction> currentThreadLocalTransaction = new ThreadLocal<>();
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/StubDriver.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/StubDriver.java
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * @author Vince Bickers
  */
-public abstract class StubHttpDriver extends AbstractConfigurableDriver {
+public abstract class StubDriver extends AbstractConfigurableDriver {
 
     private final ObjectMapper mapper = ObjectMapperFactory.objectMapper();
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/transaction/BoltTransactionTest.java
@@ -142,7 +142,7 @@ public class BoltTransactionTest {
     private static TransactionManager transactionManager() {
         var mock = mock(TransactionManager.class);
         doAnswer(i -> {
-            ((Consumer<TransactionManager.NewObjectNotifier>) i.getArgument(1)).accept(
+            ((Consumer<TransactionManager.TransactionClosedListener>) i.getArgument(1)).accept(
                 (status, entity) -> {
                     // Ignored
                 });

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/bike/BikeRequest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/bike/BikeRequest.java
@@ -18,39 +18,117 @@
  */
 package org.neo4j.ogm.persistence.examples.bike;
 
-import org.neo4j.ogm.drivers.StubHttpDriver;
+import org.neo4j.ogm.drivers.StubDriver;
 
 /**
  * @author Vince Bickers
  */
-public class BikeRequest extends StubHttpDriver {
+public class BikeRequest extends StubDriver {
 
     // each element in the array is a row in the response
-    private static String[] jsonModel = {
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"15\",\"labels\" : [ \"Bike\"], \"properties\" : { \"colours\" :[\"red\", \"black\"] } }, " +
-            "{\"id\" : \"16\",\"labels\" : [ \"Wheel\", \"FrontWheel\" ],\"properties\" : {\"spokes\" : 3 } }, " +
-            "{\"id\" : \"17\",\"labels\" : [ \"Wheel\", \"BackWheel\" ],\"properties\" : {\"spokes\" : 5 } }, " +
-            "{\"id\" : \"18\",\"labels\" : [ \"Frame\" ],\"properties\" : {\"size\" : 27 } }, " +
-            "{\"id\" : \"19\",\"labels\" : [ \"Saddle\" ],\"properties\" : {\"price\" : 42.99, \"material\" : \"plastic\" } } "
-            +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"141\",\"type\":\"HAS_WHEEL\",\"startNode\":\"15\",\"endNode\":\"16\",\"properties\":{ \"purchased\" : 20130917 }}, "
-            +
-            "{\"id\":\"142\",\"type\":\"HAS_WHEEL\",\"startNode\":\"15\",\"endNode\":\"17\",\"properties\":{ \"purchased\" : 20130917 }},"
-            +
-            "{\"id\":\"143\",\"type\":\"HAS_FRAME\",\"startNode\":\"15\",\"endNode\":\"18\",\"properties\":{ \"purchased\" : 20130917 }},"
-            +
-            "{\"id\":\"144\",\"type\":\"HAS_SADDLE\",\"startNode\":\"15\",\"endNode\":\"19\",\"properties\":{\"purchased\" : 20130922 }} "
-            +
-            "] " +
-            "} }"
+    // language=json
+    private static final String[] JSON_MODEL = {
+        """
+        {
+          "graph": {
+            "nodes": [
+              {
+                "id": "15",
+                "labels": [
+                  "Bike"
+                ],
+                "properties": {
+                  "colours": [
+                    "red",
+                    "black"
+                  ]
+                }
+              },
+              {
+                "id": "16",
+                "labels": [
+                  "Wheel",
+                  "FrontWheel"
+                ],
+                "properties": {
+                  "spokes": 3
+                }
+              },
+              {
+                "id": "17",
+                "labels": [
+                  "Wheel",
+                  "BackWheel"
+                ],
+                "properties": {
+                  "spokes": 5
+                }
+              },
+              {
+                "id": "18",
+                "labels": [
+                  "Frame"
+                ],
+                "properties": {
+                  "size": 27
+                }
+              },
+              {
+                "id": "19",
+                "labels": [
+                  "Saddle"
+                ],
+                "properties": {
+                  "price": 42.99,
+                  "material": "plastic"
+                }
+              }
+            ],
+            "relationships": [
+              {
+                "id": "141",
+                "type": "HAS_WHEEL",
+                "startNode": "15",
+                "endNode": "16",
+                "properties": {
+                  "purchased": 20130917
+                }
+              },
+              {
+                "id": "142",
+                "type": "HAS_WHEEL",
+                "startNode": "15",
+                "endNode": "17",
+                "properties": {
+                  "purchased": 20130917
+                }
+              },
+              {
+                "id": "143",
+                "type": "HAS_FRAME",
+                "startNode": "15",
+                "endNode": "18",
+                "properties": {
+                  "purchased": 20130917
+                }
+              },
+              {
+                "id": "144",
+                "type": "HAS_SADDLE",
+                "startNode": "15",
+                "endNode": "19",
+                "properties": {
+                  "purchased": 20130922
+                }
+              }
+            ]
+          }
+        }
+                """
     };
 
     public String[] getResponse() {
-        return jsonModel;
+        return JSON_MODEL;
     }
 
     @Override

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/MoviesRequest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/MoviesRequest.java
@@ -18,43 +18,119 @@
  */
 package org.neo4j.ogm.persistence.examples.cineasts.annotated;
 
-import org.neo4j.ogm.drivers.StubHttpDriver;
+import org.neo4j.ogm.drivers.StubDriver;
 
 /**
  * @author Michal Bachman
  * @author Mark Angrish
  */
-public class MoviesRequest extends StubHttpDriver {
+public class MoviesRequest extends StubDriver {
 
-    private static String[] jsonModel = {
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"15\",\"labels\" : [ \"Movie\"],    \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f1\", \"title\" : \"Pulp Fiction\"}}, "
-            +
-            "{\"id\" : \"16\",\"labels\" : [ \"Movie\"],    \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f2\", \"title\" : \"Top Gun\"}}, "
-            +
-            "{\"id\" : \"17\",\"labels\" : [ \"Movie\"],    \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f3\", \"title\" : \"Django Unchained\"}}, "
-            +
-            "{\"id\" : \"18\",\"labels\" : [ \"User\"],     \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f4\", \"name\" : \"Michal\"}}, "
-            +
-            "{\"id\" : \"19\",\"labels\" : [ \"User\"],     \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f5\", \"name\" : \"Vince\"}}, "
-            +
-            "{\"id\" : \"20\",\"labels\" : [ \"User\"],     \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f6\", \"name\" : \"Daniela\"}} "
-            +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"141\",\"type\":\"RATED\",\"startNode\":\"18\",\"endNode\":\"15\",\"properties\":{ \"stars\" : 5, \"comment\" : \"Best Film Ever!\" }}, "
-            +
-            "{\"id\":\"142\",\"type\":\"RATED\",\"startNode\":\"18\",\"endNode\":\"16\",\"properties\":{ \"stars\" : 3, \"comment\" : \"Overrated\" }}, "
-            +
-            "{\"id\":\"143\",\"type\":\"RATED\",\"startNode\":\"19\",\"endNode\":\"16\",\"properties\":{ \"stars\" : 4 }} "
-            +
-            "] " +
-            "} }"
+    // language=json
+    private static final String[] JSON_MODEL = {
+        """
+        {
+          "graph": {
+            "nodes": [
+              {
+                "id": "15",
+                "labels": [
+                  "Movie"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f1",
+                  "title": "Pulp Fiction"
+                }
+              },
+              {
+                "id": "16",
+                "labels": [
+                  "Movie"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f2",
+                  "title": "Top Gun"
+                }
+              },
+              {
+                "id": "17",
+                "labels": [
+                  "Movie"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f3",
+                  "title": "Django Unchained"
+                }
+              },
+              {
+                "id": "18",
+                "labels": [
+                  "User"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f4",
+                  "name": "Michal"
+                }
+              },
+              {
+                "id": "19",
+                "labels": [
+                  "User"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f5",
+                  "name": "Vince"
+                }
+              },
+              {
+                "id": "20",
+                "labels": [
+                  "User"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f6",
+                  "name": "Daniela"
+                }
+              }
+            ],
+            "relationships": [
+              {
+                "id": "141",
+                "type": "RATED",
+                "startNode": "18",
+                "endNode": "15",
+                "properties": {
+                  "stars": 5,
+                  "comment": "Best Film Ever!"
+                }
+              },
+              {
+                "id": "142",
+                "type": "RATED",
+                "startNode": "18",
+                "endNode": "16",
+                "properties": {
+                  "stars": 3,
+                  "comment": "Overrated"
+                }
+              },
+              {
+                "id": "143",
+                "type": "RATED",
+                "startNode": "19",
+                "endNode": "16",
+                "properties": {
+                  "stars": 4
+                }
+              }
+            ]
+          }
+        }
+        """
     };
 
     public String[] getResponse() {
-        return jsonModel;
+        return JSON_MODEL;
     }
 
     @Override

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/UsersRequest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/cineasts/annotated/UsersRequest.java
@@ -18,23 +18,41 @@
  */
 package org.neo4j.ogm.persistence.examples.cineasts.annotated;
 
-import org.neo4j.ogm.drivers.StubHttpDriver;
+import org.neo4j.ogm.drivers.StubDriver;
 
 /**
  * @author Luanne Misquitta
  */
-public class UsersRequest extends StubHttpDriver {
+public class UsersRequest extends StubDriver {
 
-    private static String[] jsonModel = {
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"15\",\"labels\" : [ \"User\"],    \"properties\" : {\"uuid\" : \"38ebe777-bc85-4810-8217-096f29a361f1\", \"login\" : \"luanne\", \"securityRoles\" : [\"USER\",\"ADMIN\"]}}"
-            +
-            "]} }"
+    // language=json
+    private static final String[] JSON_MODEL = {
+        """
+        {
+          "graph": {
+            "nodes": [
+              {
+                "id": "15",
+                "labels": [
+                  "User"
+                ],
+                "properties": {
+                  "uuid": "38ebe777-bc85-4810-8217-096f29a361f1",
+                  "login": "luanne",
+                  "securityRoles": [
+                    "USER",
+                    "ADMIN"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+                """
     };
 
     public String[] getResponse() {
-        return jsonModel;
+        return JSON_MODEL;
     }
 
     @Override

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationRequest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/examples/education/EducationRequest.java
@@ -18,7 +18,7 @@
  */
 package org.neo4j.ogm.persistence.examples.education;
 
-import org.neo4j.ogm.drivers.StubHttpDriver;
+import org.neo4j.ogm.drivers.StubDriver;
 
 /**
  * MATCH p=(t:TEACHER)--(c) return p
@@ -26,411 +26,73 @@ import org.neo4j.ogm.drivers.StubHttpDriver;
  * @author Vince Bickers
  * @author Michael J. Simons
  */
-public class EducationRequest extends StubHttpDriver {
+public class EducationRequest extends StubDriver {
 
-    private static String[] teacherModel = {
+    private static final String[] TEACHER_MODEL = {
 
         // mr thomas results
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"20\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mr Thomas\" } }, " +
-            "{\"id\" : \"2\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"English\" } } " +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"202\",\"type\":\"TEACHES\",\"startNode\":\"20\",\"endNode\":\"2\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"20\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mr Thomas\" } }, " +
-            "{\"id\" : \"3\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"Maths\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"203\",\"type\":\"TEACHES\",\"startNode\":\"20\",\"endNode\":\"3\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"20\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mr Thomas\" } }, " +
-            "{\"id\" : \"4\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"Physics\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"204\",\"type\":\"TEACHES\",\"startNode\":\"20\",\"endNode\":\"4\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "20","labels" : [ "Teacher"], "properties" : { "name" :"Mr Thomas" } }, {"id" : "2","labels" : [ "Course" ],"properties" : {"name" : "English" } } ], "relationships": [{"id":"202","type":"TEACHES","startNode":"20","endNode":"2","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "20","labels" : [ "Teacher"], "properties" : { "name" :"Mr Thomas" } }, {"id" : "3","labels" : [ "Course" ],"properties" : {"name" : "Maths" } }], "relationships": [{"id":"203","type":"TEACHES","startNode":"20","endNode":"3","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "20","labels" : [ "Teacher"], "properties" : { "name" :"Mr Thomas" } }, {"id" : "4","labels" : [ "Course" ],"properties" : {"name" : "Physics" } }], "relationships": [{"id":"204","type":"TEACHES","startNode":"20","endNode":"4","properties":{}} ] } }
+        """,
 
         // mrs roberts results
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"21\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mrs Roberts\" } }, " +
-            "{\"id\" : \"6\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"PE\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"212\",\"type\":\"TEACHES\",\"startNode\":\"21\",\"endNode\":\"2\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"21\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mrs Roberts\" } }, " +
-            "{\"id\" : \"2\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"English\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"216\",\"type\":\"TEACHES\",\"startNode\":\"21\",\"endNode\":\"6\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"21\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Mrs Roberts\" } }, " +
-            "{\"id\" : \"7\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"History\" } } " +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"217\",\"type\":\"TEACHES\",\"startNode\":\"21\",\"endNode\":\"7\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "21","labels" : [ "Teacher"], "properties" : { "name" :"Mrs Roberts" } }, {"id" : "6","labels" : [ "Course" ],"properties" : {"name" : "PE" } }], "relationships": [{"id":"212","type":"TEACHES","startNode":"21","endNode":"2","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "21","labels" : [ "Teacher"], "properties" : { "name" :"Mrs Roberts" } }, {"id" : "2","labels" : [ "Course" ],"properties" : {"name" : "English" } }], "relationships": [{"id":"216","type":"TEACHES","startNode":"21","endNode":"6","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "21","labels" : [ "Teacher"], "properties" : { "name" :"Mrs Roberts" } }, {"id" : "7","labels" : [ "Course" ],"properties" : {"name" : "History" } } ], "relationships": [{"id":"217","type":"TEACHES","startNode":"21","endNode":"7","properties":{}} ] } }
+        """,
 
         // miss young results
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"22\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Miss Young\" } }, " +
-            "{\"id\" : \"5\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"Philosophy and Ethics\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"225\",\"type\":\"TEACHES\",\"startNode\":\"22\",\"endNode\":\"5\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"22\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Miss Young\" } }, " +
-            "{\"id\" : \"7\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"History\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"227\",\"type\":\"TEACHES\",\"startNode\":\"22\",\"endNode\":\"7\",\"properties\":{}}" +
-            "] " +
-            "} }",
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"22\",\"labels\" : [ \"Teacher\"], \"properties\" : { \"name\" :\"Miss Young\" } }, " +
-            "{\"id\" : \"8\",\"labels\" : [ \"Course\" ],\"properties\" : {\"name\" : \"Geography\" } }" +
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"228\",\"type\":\"TEACHES\",\"startNode\":\"22\",\"endNode\":\"8\",\"properties\":{}}" +
-            "] " +
-            "} }"
+        """
+        {"graph": { "nodes" :[ {"id" : "22","labels" : [ "Teacher"], "properties" : { "name" :"Miss Young" } }, {"id" : "5","labels" : [ "Course" ],"properties" : {"name" : "Philosophy and Ethics" } }], "relationships": [{"id":"225","type":"TEACHES","startNode":"22","endNode":"5","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "22","labels" : [ "Teacher"], "properties" : { "name" :"Miss Young" } }, {"id" : "7","labels" : [ "Course" ],"properties" : {"name" : "History" } }], "relationships": [{"id":"227","type":"TEACHES","startNode":"22","endNode":"7","properties":{}}] } }
+        """,
+        """
+        {"graph": { "nodes" :[ {"id" : "22","labels" : [ "Teacher"], "properties" : { "name" :"Miss Young" } }, {"id" : "8","labels" : [ "Course" ],"properties" : {"name" : "Geography" } }], "relationships": [{"id":"228","type":"TEACHES","startNode":"22","endNode":"8","properties":{}}] } }
+        """
     };
 
-    private static String[] coursesModel = {
+    private static final String[] COURSES_MODEL = {
         // English set : all
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"2\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"English\" } }, " +
-
-            "{\"id\" : \"101\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Alex\" } }," +
-            "{\"id\" : \"102\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Barry\" } }," +
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"104\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Daisy\" } }," +
-            "{\"id\" : \"105\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Eloise\" } }," +
-            "{\"id\" : \"106\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Frankie\" } }," +
-            "{\"id\" : \"107\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Gavin\" } }," +
-            "{\"id\" : \"108\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Hannah\" } }," +
-            "{\"id\" : \"109\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ignacio\" } }," +
-            "{\"id\" : \"110\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Jasmin\" } }," +
-            "{\"id\" : \"111\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Kent\" } }," +
-            "{\"id\" : \"112\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Lyra\" } }," +
-            "{\"id\" : \"113\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Maria\" } }," +
-            "{\"id\" : \"114\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Neil\" } }," +
-            "{\"id\" : \"115\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Otto\" } }," +
-            "{\"id\" : \"116\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Peter\" } }," +
-            "{\"id\" : \"117\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Quentin\" } }," +
-            "{\"id\" : \"118\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Rachel\" } }," +
-            "{\"id\" : \"119\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Suzanne\" } }," +
-            "{\"id\" : \"120\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Tom\" } }," +
-            "{\"id\" : \"121\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ulf\" } }," +
-            "{\"id\" : \"122\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Veronica\" } }," +
-            "{\"id\" : \"123\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Will\" } }," +
-            "{\"id\" : \"124\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Xavier\" } }," +
-            "{\"id\" : \"125\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Yvette\" } }," +
-            "{\"id\" : \"126\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Zack\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"2101\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"101\",\"properties\":{}}," +
-            "{\"id\":\"2102\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"102\",\"properties\":{}}," +
-            "{\"id\":\"2103\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"2104\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"104\",\"properties\":{}}," +
-            "{\"id\":\"2105\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"105\",\"properties\":{}}," +
-            "{\"id\":\"2106\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"106\",\"properties\":{}}," +
-            "{\"id\":\"2107\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"107\",\"properties\":{}}," +
-            "{\"id\":\"2108\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"108\",\"properties\":{}}," +
-            "{\"id\":\"2109\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"109\",\"properties\":{}}," +
-            "{\"id\":\"2110\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"110\",\"properties\":{}}," +
-            "{\"id\":\"2111\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"111\",\"properties\":{}}," +
-            "{\"id\":\"2112\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"112\",\"properties\":{}}," +
-            "{\"id\":\"2113\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"113\",\"properties\":{}}," +
-            "{\"id\":\"2114\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"114\",\"properties\":{}}," +
-            "{\"id\":\"2115\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"115\",\"properties\":{}}," +
-            "{\"id\":\"2116\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"116\",\"properties\":{}}," +
-            "{\"id\":\"2117\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"117\",\"properties\":{}}," +
-            "{\"id\":\"2118\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"118\",\"properties\":{}}," +
-            "{\"id\":\"2119\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"119\",\"properties\":{}}," +
-            "{\"id\":\"2120\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"120\",\"properties\":{}}," +
-            "{\"id\":\"2121\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"121\",\"properties\":{}}," +
-            "{\"id\":\"2122\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"122\",\"properties\":{}}," +
-            "{\"id\":\"2123\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"123\",\"properties\":{}}," +
-            "{\"id\":\"2124\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"124\",\"properties\":{}}," +
-            "{\"id\":\"2125\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"125\",\"properties\":{}}," +
-            "{\"id\":\"2126\",\"type\":\"ENROLLED\",\"startNode\":\"2\",\"endNode\":\"126\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "2","labels" : [ "Course"], "properties" : { "name" :"English" } }, {"id" : "101","labels" : [ "Student" ],"properties" : {"name" : "Alex" } },{"id" : "102","labels" : [ "Student" ],"properties" : {"name" : "Barry" } },{"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "104","labels" : [ "Student" ],"properties" : {"name" : "Daisy" } },{"id" : "105","labels" : [ "Student" ],"properties" : {"name" : "Eloise" } },{"id" : "106","labels" : [ "Student" ],"properties" : {"name" : "Frankie" } },{"id" : "107","labels" : [ "Student" ],"properties" : {"name" : "Gavin" } },{"id" : "108","labels" : [ "Student" ],"properties" : {"name" : "Hannah" } },{"id" : "109","labels" : [ "Student" ],"properties" : {"name" : "Ignacio" } },{"id" : "110","labels" : [ "Student" ],"properties" : {"name" : "Jasmin" } },{"id" : "111","labels" : [ "Student" ],"properties" : {"name" : "Kent" } },{"id" : "112","labels" : [ "Student" ],"properties" : {"name" : "Lyra" } },{"id" : "113","labels" : [ "Student" ],"properties" : {"name" : "Maria" } },{"id" : "114","labels" : [ "Student" ],"properties" : {"name" : "Neil" } },{"id" : "115","labels" : [ "Student" ],"properties" : {"name" : "Otto" } },{"id" : "116","labels" : [ "Student" ],"properties" : {"name" : "Peter" } },{"id" : "117","labels" : [ "Student" ],"properties" : {"name" : "Quentin" } },{"id" : "118","labels" : [ "Student" ],"properties" : {"name" : "Rachel" } },{"id" : "119","labels" : [ "Student" ],"properties" : {"name" : "Suzanne" } },{"id" : "120","labels" : [ "Student" ],"properties" : {"name" : "Tom" } },{"id" : "121","labels" : [ "Student" ],"properties" : {"name" : "Ulf" } },{"id" : "122","labels" : [ "Student" ],"properties" : {"name" : "Veronica" } },{"id" : "123","labels" : [ "Student" ],"properties" : {"name" : "Will" } },{"id" : "124","labels" : [ "Student" ],"properties" : {"name" : "Xavier" } },{"id" : "125","labels" : [ "Student" ],"properties" : {"name" : "Yvette" } },{"id" : "126","labels" : [ "Student" ],"properties" : {"name" : "Zack" } }], "relationships": [{"id":"2101","type":"ENROLLED","startNode":"2","endNode":"101","properties":{}},{"id":"2102","type":"ENROLLED","startNode":"2","endNode":"102","properties":{}},{"id":"2103","type":"ENROLLED","startNode":"2","endNode":"103","properties":{}},{"id":"2104","type":"ENROLLED","startNode":"2","endNode":"104","properties":{}},{"id":"2105","type":"ENROLLED","startNode":"2","endNode":"105","properties":{}},{"id":"2106","type":"ENROLLED","startNode":"2","endNode":"106","properties":{}},{"id":"2107","type":"ENROLLED","startNode":"2","endNode":"107","properties":{}},{"id":"2108","type":"ENROLLED","startNode":"2","endNode":"108","properties":{}},{"id":"2109","type":"ENROLLED","startNode":"2","endNode":"109","properties":{}},{"id":"2110","type":"ENROLLED","startNode":"2","endNode":"110","properties":{}},{"id":"2111","type":"ENROLLED","startNode":"2","endNode":"111","properties":{}},{"id":"2112","type":"ENROLLED","startNode":"2","endNode":"112","properties":{}},{"id":"2113","type":"ENROLLED","startNode":"2","endNode":"113","properties":{}},{"id":"2114","type":"ENROLLED","startNode":"2","endNode":"114","properties":{}},{"id":"2115","type":"ENROLLED","startNode":"2","endNode":"115","properties":{}},{"id":"2116","type":"ENROLLED","startNode":"2","endNode":"116","properties":{}},{"id":"2117","type":"ENROLLED","startNode":"2","endNode":"117","properties":{}},{"id":"2118","type":"ENROLLED","startNode":"2","endNode":"118","properties":{}},{"id":"2119","type":"ENROLLED","startNode":"2","endNode":"119","properties":{}},{"id":"2120","type":"ENROLLED","startNode":"2","endNode":"120","properties":{}},{"id":"2121","type":"ENROLLED","startNode":"2","endNode":"121","properties":{}},{"id":"2122","type":"ENROLLED","startNode":"2","endNode":"122","properties":{}},{"id":"2123","type":"ENROLLED","startNode":"2","endNode":"123","properties":{}},{"id":"2124","type":"ENROLLED","startNode":"2","endNode":"124","properties":{}},{"id":"2125","type":"ENROLLED","startNode":"2","endNode":"125","properties":{}},{"id":"2126","type":"ENROLLED","startNode":"2","endNode":"126","properties":{}} ] } }
+        """,
         // Maths set : all
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"3\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"Mathematics\" } }, " +
-
-            "{\"id\" : \"101\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Alex\" } }," +
-            "{\"id\" : \"102\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Barry\" } }," +
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"104\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Daisy\" } }," +
-            "{\"id\" : \"105\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Eloise\" } }," +
-            "{\"id\" : \"106\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Frankie\" } }," +
-            "{\"id\" : \"107\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Gavin\" } }," +
-            "{\"id\" : \"108\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Hannah\" } }," +
-            "{\"id\" : \"109\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ignacio\" } }," +
-            "{\"id\" : \"110\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Jasmin\" } }," +
-            "{\"id\" : \"111\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Kent\" } }," +
-            "{\"id\" : \"112\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Lyra\" } }," +
-            "{\"id\" : \"113\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Maria\" } }," +
-            "{\"id\" : \"114\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Neil\" } }," +
-            "{\"id\" : \"115\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Otto\" } }," +
-            "{\"id\" : \"116\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Peter\" } }," +
-            "{\"id\" : \"117\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Quentin\" } }," +
-            "{\"id\" : \"118\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Rachel\" } }," +
-            "{\"id\" : \"119\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Suzanne\" } }," +
-            "{\"id\" : \"120\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Tom\" } }," +
-            "{\"id\" : \"121\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ulf\" } }," +
-            "{\"id\" : \"122\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Veronica\" } }," +
-            "{\"id\" : \"123\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Will\" } }," +
-            "{\"id\" : \"124\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Xavier\" } }," +
-            "{\"id\" : \"125\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Yvette\" } }," +
-            "{\"id\" : \"126\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Zack\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"3101\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"101\",\"properties\":{}}," +
-            "{\"id\":\"3102\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"102\",\"properties\":{}}," +
-            "{\"id\":\"3103\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"3104\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"104\",\"properties\":{}}," +
-            "{\"id\":\"3105\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"105\",\"properties\":{}}," +
-            "{\"id\":\"3106\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"106\",\"properties\":{}}," +
-            "{\"id\":\"3107\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"107\",\"properties\":{}}," +
-            "{\"id\":\"3108\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"108\",\"properties\":{}}," +
-            "{\"id\":\"3109\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"109\",\"properties\":{}}," +
-            "{\"id\":\"3110\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"110\",\"properties\":{}}," +
-            "{\"id\":\"3111\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"111\",\"properties\":{}}," +
-            "{\"id\":\"3112\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"112\",\"properties\":{}}," +
-            "{\"id\":\"3113\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"113\",\"properties\":{}}," +
-            "{\"id\":\"3114\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"114\",\"properties\":{}}," +
-            "{\"id\":\"3115\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"115\",\"properties\":{}}," +
-            "{\"id\":\"3116\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"116\",\"properties\":{}}," +
-            "{\"id\":\"3117\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"117\",\"properties\":{}}," +
-            "{\"id\":\"3118\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"118\",\"properties\":{}}," +
-            "{\"id\":\"3119\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"119\",\"properties\":{}}," +
-            "{\"id\":\"3120\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"120\",\"properties\":{}}," +
-            "{\"id\":\"3121\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"121\",\"properties\":{}}," +
-            "{\"id\":\"3122\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"122\",\"properties\":{}}," +
-            "{\"id\":\"3123\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"123\",\"properties\":{}}," +
-            "{\"id\":\"3124\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"124\",\"properties\":{}}," +
-            "{\"id\":\"3125\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"125\",\"properties\":{}}," +
-            "{\"id\":\"3126\",\"type\":\"ENROLLED\",\"startNode\":\"3\",\"endNode\":\"126\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "3","labels" : [ "Course"], "properties" : { "name" :"Mathematics" } }, {"id" : "101","labels" : [ "Student" ],"properties" : {"name" : "Alex" } },{"id" : "102","labels" : [ "Student" ],"properties" : {"name" : "Barry" } },{"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "104","labels" : [ "Student" ],"properties" : {"name" : "Daisy" } },{"id" : "105","labels" : [ "Student" ],"properties" : {"name" : "Eloise" } },{"id" : "106","labels" : [ "Student" ],"properties" : {"name" : "Frankie" } },{"id" : "107","labels" : [ "Student" ],"properties" : {"name" : "Gavin" } },{"id" : "108","labels" : [ "Student" ],"properties" : {"name" : "Hannah" } },{"id" : "109","labels" : [ "Student" ],"properties" : {"name" : "Ignacio" } },{"id" : "110","labels" : [ "Student" ],"properties" : {"name" : "Jasmin" } },{"id" : "111","labels" : [ "Student" ],"properties" : {"name" : "Kent" } },{"id" : "112","labels" : [ "Student" ],"properties" : {"name" : "Lyra" } },{"id" : "113","labels" : [ "Student" ],"properties" : {"name" : "Maria" } },{"id" : "114","labels" : [ "Student" ],"properties" : {"name" : "Neil" } },{"id" : "115","labels" : [ "Student" ],"properties" : {"name" : "Otto" } },{"id" : "116","labels" : [ "Student" ],"properties" : {"name" : "Peter" } },{"id" : "117","labels" : [ "Student" ],"properties" : {"name" : "Quentin" } },{"id" : "118","labels" : [ "Student" ],"properties" : {"name" : "Rachel" } },{"id" : "119","labels" : [ "Student" ],"properties" : {"name" : "Suzanne" } },{"id" : "120","labels" : [ "Student" ],"properties" : {"name" : "Tom" } },{"id" : "121","labels" : [ "Student" ],"properties" : {"name" : "Ulf" } },{"id" : "122","labels" : [ "Student" ],"properties" : {"name" : "Veronica" } },{"id" : "123","labels" : [ "Student" ],"properties" : {"name" : "Will" } },{"id" : "124","labels" : [ "Student" ],"properties" : {"name" : "Xavier" } },{"id" : "125","labels" : [ "Student" ],"properties" : {"name" : "Yvette" } },{"id" : "126","labels" : [ "Student" ],"properties" : {"name" : "Zack" } }], "relationships": [{"id":"3101","type":"ENROLLED","startNode":"3","endNode":"101","properties":{}},{"id":"3102","type":"ENROLLED","startNode":"3","endNode":"102","properties":{}},{"id":"3103","type":"ENROLLED","startNode":"3","endNode":"103","properties":{}},{"id":"3104","type":"ENROLLED","startNode":"3","endNode":"104","properties":{}},{"id":"3105","type":"ENROLLED","startNode":"3","endNode":"105","properties":{}},{"id":"3106","type":"ENROLLED","startNode":"3","endNode":"106","properties":{}},{"id":"3107","type":"ENROLLED","startNode":"3","endNode":"107","properties":{}},{"id":"3108","type":"ENROLLED","startNode":"3","endNode":"108","properties":{}},{"id":"3109","type":"ENROLLED","startNode":"3","endNode":"109","properties":{}},{"id":"3110","type":"ENROLLED","startNode":"3","endNode":"110","properties":{}},{"id":"3111","type":"ENROLLED","startNode":"3","endNode":"111","properties":{}},{"id":"3112","type":"ENROLLED","startNode":"3","endNode":"112","properties":{}},{"id":"3113","type":"ENROLLED","startNode":"3","endNode":"113","properties":{}},{"id":"3114","type":"ENROLLED","startNode":"3","endNode":"114","properties":{}},{"id":"3115","type":"ENROLLED","startNode":"3","endNode":"115","properties":{}},{"id":"3116","type":"ENROLLED","startNode":"3","endNode":"116","properties":{}},{"id":"3117","type":"ENROLLED","startNode":"3","endNode":"117","properties":{}},{"id":"3118","type":"ENROLLED","startNode":"3","endNode":"118","properties":{}},{"id":"3119","type":"ENROLLED","startNode":"3","endNode":"119","properties":{}},{"id":"3120","type":"ENROLLED","startNode":"3","endNode":"120","properties":{}},{"id":"3121","type":"ENROLLED","startNode":"3","endNode":"121","properties":{}},{"id":"3122","type":"ENROLLED","startNode":"3","endNode":"122","properties":{}},{"id":"3123","type":"ENROLLED","startNode":"3","endNode":"123","properties":{}},{"id":"3124","type":"ENROLLED","startNode":"3","endNode":"124","properties":{}},{"id":"3125","type":"ENROLLED","startNode":"3","endNode":"125","properties":{}},{"id":"3126","type":"ENROLLED","startNode":"3","endNode":"126","properties":{}} ] } }
+        """,
         // Physics set : odd(id)
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"4\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"Physics\" } }, " +
-
-            "{\"id\" : \"101\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Alex\" } }," +
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"105\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Eloise\" } }," +
-            "{\"id\" : \"107\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Gavin\" } }," +
-            "{\"id\" : \"109\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ignacio\" } }," +
-            "{\"id\" : \"111\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Kent\" } }," +
-            "{\"id\" : \"113\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Maria\" } }," +
-            "{\"id\" : \"115\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Otto\" } }," +
-            "{\"id\" : \"117\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Quentin\" } }," +
-            "{\"id\" : \"119\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Suzanne\" } }," +
-            "{\"id\" : \"121\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ulf\" } }," +
-            "{\"id\" : \"123\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Will\" } }," +
-            "{\"id\" : \"125\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Yvette\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"4101\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"101\",\"properties\":{}}," +
-            "{\"id\":\"4103\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"4106\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"105\",\"properties\":{}}," +
-            "{\"id\":\"4107\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"107\",\"properties\":{}}," +
-            "{\"id\":\"4109\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"109\",\"properties\":{}}," +
-            "{\"id\":\"4111\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"111\",\"properties\":{}}," +
-            "{\"id\":\"4113\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"113\",\"properties\":{}}," +
-            "{\"id\":\"4115\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"115\",\"properties\":{}}," +
-            "{\"id\":\"4117\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"117\",\"properties\":{}}," +
-            "{\"id\":\"4119\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"119\",\"properties\":{}}," +
-            "{\"id\":\"4121\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"121\",\"properties\":{}}," +
-            "{\"id\":\"4123\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"123\",\"properties\":{}}," +
-            "{\"id\":\"4125\",\"type\":\"ENROLLED\",\"startNode\":\"4\",\"endNode\":\"125\",\"properties\":{}}" +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "4","labels" : [ "Course"], "properties" : { "name" :"Physics" } }, {"id" : "101","labels" : [ "Student" ],"properties" : {"name" : "Alex" } },{"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "105","labels" : [ "Student" ],"properties" : {"name" : "Eloise" } },{"id" : "107","labels" : [ "Student" ],"properties" : {"name" : "Gavin" } },{"id" : "109","labels" : [ "Student" ],"properties" : {"name" : "Ignacio" } },{"id" : "111","labels" : [ "Student" ],"properties" : {"name" : "Kent" } },{"id" : "113","labels" : [ "Student" ],"properties" : {"name" : "Maria" } },{"id" : "115","labels" : [ "Student" ],"properties" : {"name" : "Otto" } },{"id" : "117","labels" : [ "Student" ],"properties" : {"name" : "Quentin" } },{"id" : "119","labels" : [ "Student" ],"properties" : {"name" : "Suzanne" } },{"id" : "121","labels" : [ "Student" ],"properties" : {"name" : "Ulf" } },{"id" : "123","labels" : [ "Student" ],"properties" : {"name" : "Will" } },{"id" : "125","labels" : [ "Student" ],"properties" : {"name" : "Yvette" } }], "relationships": [{"id":"4101","type":"ENROLLED","startNode":"4","endNode":"101","properties":{}},{"id":"4103","type":"ENROLLED","startNode":"4","endNode":"103","properties":{}},{"id":"4106","type":"ENROLLED","startNode":"4","endNode":"105","properties":{}},{"id":"4107","type":"ENROLLED","startNode":"4","endNode":"107","properties":{}},{"id":"4109","type":"ENROLLED","startNode":"4","endNode":"109","properties":{}},{"id":"4111","type":"ENROLLED","startNode":"4","endNode":"111","properties":{}},{"id":"4113","type":"ENROLLED","startNode":"4","endNode":"113","properties":{}},{"id":"4115","type":"ENROLLED","startNode":"4","endNode":"115","properties":{}},{"id":"4117","type":"ENROLLED","startNode":"4","endNode":"117","properties":{}},{"id":"4119","type":"ENROLLED","startNode":"4","endNode":"119","properties":{}},{"id":"4121","type":"ENROLLED","startNode":"4","endNode":"121","properties":{}},{"id":"4123","type":"ENROLLED","startNode":"4","endNode":"123","properties":{}},{"id":"4125","type":"ENROLLED","startNode":"4","endNode":"125","properties":{}}] } }
+        """,
         // Philosophy and Ethics set: all
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"5\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"Philosophy and Ethics\" } }, " +
-
-            "{\"id\" : \"101\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Alex\" } }," +
-            "{\"id\" : \"102\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Barry\" } }," +
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"104\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Daisy\" } }," +
-            "{\"id\" : \"105\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Eloise\" } }," +
-            "{\"id\" : \"106\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Frankie\" } }," +
-            "{\"id\" : \"107\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Gavin\" } }," +
-            "{\"id\" : \"108\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Hannah\" } }," +
-            "{\"id\" : \"109\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ignacio\" } }," +
-            "{\"id\" : \"110\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Jasmin\" } }," +
-            "{\"id\" : \"111\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Kent\" } }," +
-            "{\"id\" : \"112\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Lyra\" } }," +
-            "{\"id\" : \"113\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Maria\" } }," +
-            "{\"id\" : \"114\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Neil\" } }," +
-            "{\"id\" : \"115\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Otto\" } }," +
-            "{\"id\" : \"116\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Peter\" } }," +
-            "{\"id\" : \"117\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Quentin\" } }," +
-            "{\"id\" : \"118\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Rachel\" } }," +
-            "{\"id\" : \"119\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Suzanne\" } }," +
-            "{\"id\" : \"120\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Tom\" } }," +
-            "{\"id\" : \"121\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ulf\" } }," +
-            "{\"id\" : \"122\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Veronica\" } }," +
-            "{\"id\" : \"123\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Will\" } }," +
-            "{\"id\" : \"124\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Xavier\" } }," +
-            "{\"id\" : \"125\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Yvette\" } }," +
-            "{\"id\" : \"126\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Zack\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"5101\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"101\",\"properties\":{}}," +
-            "{\"id\":\"5102\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"102\",\"properties\":{}}," +
-            "{\"id\":\"5103\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"5104\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"104\",\"properties\":{}}," +
-            "{\"id\":\"5105\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"105\",\"properties\":{}}," +
-            "{\"id\":\"5106\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"106\",\"properties\":{}}," +
-            "{\"id\":\"5107\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"107\",\"properties\":{}}," +
-            "{\"id\":\"5108\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"108\",\"properties\":{}}," +
-            "{\"id\":\"5109\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"109\",\"properties\":{}}," +
-            "{\"id\":\"5110\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"110\",\"properties\":{}}," +
-            "{\"id\":\"5111\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"111\",\"properties\":{}}," +
-            "{\"id\":\"5112\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"112\",\"properties\":{}}," +
-            "{\"id\":\"5113\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"113\",\"properties\":{}}," +
-            "{\"id\":\"5114\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"114\",\"properties\":{}}," +
-            "{\"id\":\"5115\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"115\",\"properties\":{}}," +
-            "{\"id\":\"5116\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"116\",\"properties\":{}}," +
-            "{\"id\":\"5117\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"117\",\"properties\":{}}," +
-            "{\"id\":\"5118\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"118\",\"properties\":{}}," +
-            "{\"id\":\"5119\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"119\",\"properties\":{}}," +
-            "{\"id\":\"5120\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"120\",\"properties\":{}}," +
-            "{\"id\":\"5121\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"121\",\"properties\":{}}," +
-            "{\"id\":\"5122\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"122\",\"properties\":{}}," +
-            "{\"id\":\"5123\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"123\",\"properties\":{}}," +
-            "{\"id\":\"5124\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"124\",\"properties\":{}}," +
-            "{\"id\":\"5125\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"125\",\"properties\":{}}," +
-            "{\"id\":\"5126\",\"type\":\"ENROLLED\",\"startNode\":\"5\",\"endNode\":\"126\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "5","labels" : [ "Course"], "properties" : { "name" :"Philosophy and Ethics" } }, {"id" : "101","labels" : [ "Student" ],"properties" : {"name" : "Alex" } },{"id" : "102","labels" : [ "Student" ],"properties" : {"name" : "Barry" } },{"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "104","labels" : [ "Student" ],"properties" : {"name" : "Daisy" } },{"id" : "105","labels" : [ "Student" ],"properties" : {"name" : "Eloise" } },{"id" : "106","labels" : [ "Student" ],"properties" : {"name" : "Frankie" } },{"id" : "107","labels" : [ "Student" ],"properties" : {"name" : "Gavin" } },{"id" : "108","labels" : [ "Student" ],"properties" : {"name" : "Hannah" } },{"id" : "109","labels" : [ "Student" ],"properties" : {"name" : "Ignacio" } },{"id" : "110","labels" : [ "Student" ],"properties" : {"name" : "Jasmin" } },{"id" : "111","labels" : [ "Student" ],"properties" : {"name" : "Kent" } },{"id" : "112","labels" : [ "Student" ],"properties" : {"name" : "Lyra" } },{"id" : "113","labels" : [ "Student" ],"properties" : {"name" : "Maria" } },{"id" : "114","labels" : [ "Student" ],"properties" : {"name" : "Neil" } },{"id" : "115","labels" : [ "Student" ],"properties" : {"name" : "Otto" } },{"id" : "116","labels" : [ "Student" ],"properties" : {"name" : "Peter" } },{"id" : "117","labels" : [ "Student" ],"properties" : {"name" : "Quentin" } },{"id" : "118","labels" : [ "Student" ],"properties" : {"name" : "Rachel" } },{"id" : "119","labels" : [ "Student" ],"properties" : {"name" : "Suzanne" } },{"id" : "120","labels" : [ "Student" ],"properties" : {"name" : "Tom" } },{"id" : "121","labels" : [ "Student" ],"properties" : {"name" : "Ulf" } },{"id" : "122","labels" : [ "Student" ],"properties" : {"name" : "Veronica" } },{"id" : "123","labels" : [ "Student" ],"properties" : {"name" : "Will" } },{"id" : "124","labels" : [ "Student" ],"properties" : {"name" : "Xavier" } },{"id" : "125","labels" : [ "Student" ],"properties" : {"name" : "Yvette" } },{"id" : "126","labels" : [ "Student" ],"properties" : {"name" : "Zack" } }], "relationships": [{"id":"5101","type":"ENROLLED","startNode":"5","endNode":"101","properties":{}},{"id":"5102","type":"ENROLLED","startNode":"5","endNode":"102","properties":{}},{"id":"5103","type":"ENROLLED","startNode":"5","endNode":"103","properties":{}},{"id":"5104","type":"ENROLLED","startNode":"5","endNode":"104","properties":{}},{"id":"5105","type":"ENROLLED","startNode":"5","endNode":"105","properties":{}},{"id":"5106","type":"ENROLLED","startNode":"5","endNode":"106","properties":{}},{"id":"5107","type":"ENROLLED","startNode":"5","endNode":"107","properties":{}},{"id":"5108","type":"ENROLLED","startNode":"5","endNode":"108","properties":{}},{"id":"5109","type":"ENROLLED","startNode":"5","endNode":"109","properties":{}},{"id":"5110","type":"ENROLLED","startNode":"5","endNode":"110","properties":{}},{"id":"5111","type":"ENROLLED","startNode":"5","endNode":"111","properties":{}},{"id":"5112","type":"ENROLLED","startNode":"5","endNode":"112","properties":{}},{"id":"5113","type":"ENROLLED","startNode":"5","endNode":"113","properties":{}},{"id":"5114","type":"ENROLLED","startNode":"5","endNode":"114","properties":{}},{"id":"5115","type":"ENROLLED","startNode":"5","endNode":"115","properties":{}},{"id":"5116","type":"ENROLLED","startNode":"5","endNode":"116","properties":{}},{"id":"5117","type":"ENROLLED","startNode":"5","endNode":"117","properties":{}},{"id":"5118","type":"ENROLLED","startNode":"5","endNode":"118","properties":{}},{"id":"5119","type":"ENROLLED","startNode":"5","endNode":"119","properties":{}},{"id":"5120","type":"ENROLLED","startNode":"5","endNode":"120","properties":{}},{"id":"5121","type":"ENROLLED","startNode":"5","endNode":"121","properties":{}},{"id":"5122","type":"ENROLLED","startNode":"5","endNode":"122","properties":{}},{"id":"5123","type":"ENROLLED","startNode":"5","endNode":"123","properties":{}},{"id":"5124","type":"ENROLLED","startNode":"5","endNode":"124","properties":{}},{"id":"5125","type":"ENROLLED","startNode":"5","endNode":"125","properties":{}},{"id":"5126","type":"ENROLLED","startNode":"5","endNode":"126","properties":{}} ] } }
+        """,
         // PE set: isInteger((id modulo 100) / 3)
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"6\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"PE\" } }, " +
-
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"106\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Frankie\" } }," +
-            "{\"id\" : \"109\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ignacio\" } }," +
-            "{\"id\" : \"112\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Lyra\" } }," +
-            "{\"id\" : \"115\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Otto\" } }," +
-            "{\"id\" : \"118\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Rachel\" } }," +
-            "{\"id\" : \"121\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Ulf\" } }," +
-            "{\"id\" : \"124\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Xavier\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"6103\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"6106\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"106\",\"properties\":{}}," +
-            "{\"id\":\"6109\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"109\",\"properties\":{}}," +
-            "{\"id\":\"6112\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"112\",\"properties\":{}}," +
-            "{\"id\":\"6115\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"115\",\"properties\":{}}," +
-            "{\"id\":\"6118\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"118\",\"properties\":{}}," +
-            "{\"id\":\"6121\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"121\",\"properties\":{}}," +
-            "{\"id\":\"6124\",\"type\":\"ENROLLED\",\"startNode\":\"6\",\"endNode\":\"124\",\"properties\":{}}" +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "6","labels" : [ "Course"], "properties" : { "name" :"PE" } }, {"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "106","labels" : [ "Student" ],"properties" : {"name" : "Frankie" } },{"id" : "109","labels" : [ "Student" ],"properties" : {"name" : "Ignacio" } },{"id" : "112","labels" : [ "Student" ],"properties" : {"name" : "Lyra" } },{"id" : "115","labels" : [ "Student" ],"properties" : {"name" : "Otto" } },{"id" : "118","labels" : [ "Student" ],"properties" : {"name" : "Rachel" } },{"id" : "121","labels" : [ "Student" ],"properties" : {"name" : "Ulf" } },{"id" : "124","labels" : [ "Student" ],"properties" : {"name" : "Xavier" } }], "relationships": [{"id":"6103","type":"ENROLLED","startNode":"6","endNode":"103","properties":{}},{"id":"6106","type":"ENROLLED","startNode":"6","endNode":"106","properties":{}},{"id":"6109","type":"ENROLLED","startNode":"6","endNode":"109","properties":{}},{"id":"6112","type":"ENROLLED","startNode":"6","endNode":"112","properties":{}},{"id":"6115","type":"ENROLLED","startNode":"6","endNode":"115","properties":{}},{"id":"6118","type":"ENROLLED","startNode":"6","endNode":"118","properties":{}},{"id":"6121","type":"ENROLLED","startNode":"6","endNode":"121","properties":{}},{"id":"6124","type":"ENROLLED","startNode":"6","endNode":"124","properties":{}}] } }
+        """,
         // History set even(id)
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"7\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"History\" } }, " +
-
-            "{\"id\" : \"102\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Barry\" } }," +
-            "{\"id\" : \"104\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Daisy\" } }," +
-            "{\"id\" : \"106\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Frankie\" } }," +
-            "{\"id\" : \"108\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Hannah\" } }," +
-            "{\"id\" : \"110\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Jasmin\" } }," +
-            "{\"id\" : \"112\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Lyra\" } }," +
-            "{\"id\" : \"114\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Neil\" } }," +
-            "{\"id\" : \"116\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Peter\" } }," +
-            "{\"id\" : \"118\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Rachel\" } }," +
-            "{\"id\" : \"120\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Tom\" } }," +
-            "{\"id\" : \"122\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Veronica\" } }," +
-            "{\"id\" : \"124\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Xavier\" } }," +
-            "{\"id\" : \"126\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Zack\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"7102\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"102\",\"properties\":{}}," +
-            "{\"id\":\"7104\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"104\",\"properties\":{}}," +
-            "{\"id\":\"7106\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"106\",\"properties\":{}}," +
-            "{\"id\":\"7108\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"108\",\"properties\":{}}," +
-            "{\"id\":\"7110\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"110\",\"properties\":{}}," +
-            "{\"id\":\"7112\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"112\",\"properties\":{}}," +
-            "{\"id\":\"7114\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"114\",\"properties\":{}}," +
-            "{\"id\":\"7116\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"116\",\"properties\":{}}," +
-            "{\"id\":\"7118\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"118\",\"properties\":{}}," +
-            "{\"id\":\"7120\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"120\",\"properties\":{}}," +
-            "{\"id\":\"7122\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"122\",\"properties\":{}}," +
-            "{\"id\":\"7124\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"124\",\"properties\":{}}," +
-            "{\"id\":\"7126\",\"type\":\"ENROLLED\",\"startNode\":\"7\",\"endNode\":\"126\",\"properties\":{}} " +
-            "] " +
-            "} }",
+        """
+        {"graph": { "nodes" :[ {"id" : "7","labels" : [ "Course"], "properties" : { "name" :"History" } }, {"id" : "102","labels" : [ "Student" ],"properties" : {"name" : "Barry" } },{"id" : "104","labels" : [ "Student" ],"properties" : {"name" : "Daisy" } },{"id" : "106","labels" : [ "Student" ],"properties" : {"name" : "Frankie" } },{"id" : "108","labels" : [ "Student" ],"properties" : {"name" : "Hannah" } },{"id" : "110","labels" : [ "Student" ],"properties" : {"name" : "Jasmin" } },{"id" : "112","labels" : [ "Student" ],"properties" : {"name" : "Lyra" } },{"id" : "114","labels" : [ "Student" ],"properties" : {"name" : "Neil" } },{"id" : "116","labels" : [ "Student" ],"properties" : {"name" : "Peter" } },{"id" : "118","labels" : [ "Student" ],"properties" : {"name" : "Rachel" } },{"id" : "120","labels" : [ "Student" ],"properties" : {"name" : "Tom" } },{"id" : "122","labels" : [ "Student" ],"properties" : {"name" : "Veronica" } },{"id" : "124","labels" : [ "Student" ],"properties" : {"name" : "Xavier" } },{"id" : "126","labels" : [ "Student" ],"properties" : {"name" : "Zack" } }], "relationships": [{"id":"7102","type":"ENROLLED","startNode":"7","endNode":"102","properties":{}},{"id":"7104","type":"ENROLLED","startNode":"7","endNode":"104","properties":{}},{"id":"7106","type":"ENROLLED","startNode":"7","endNode":"106","properties":{}},{"id":"7108","type":"ENROLLED","startNode":"7","endNode":"108","properties":{}},{"id":"7110","type":"ENROLLED","startNode":"7","endNode":"110","properties":{}},{"id":"7112","type":"ENROLLED","startNode":"7","endNode":"112","properties":{}},{"id":"7114","type":"ENROLLED","startNode":"7","endNode":"114","properties":{}},{"id":"7116","type":"ENROLLED","startNode":"7","endNode":"116","properties":{}},{"id":"7118","type":"ENROLLED","startNode":"7","endNode":"118","properties":{}},{"id":"7120","type":"ENROLLED","startNode":"7","endNode":"120","properties":{}},{"id":"7122","type":"ENROLLED","startNode":"7","endNode":"122","properties":{}},{"id":"7124","type":"ENROLLED","startNode":"7","endNode":"124","properties":{}},{"id":"7126","type":"ENROLLED","startNode":"7","endNode":"126","properties":{}} ] } }
+        """,
         // Geography set : isPrime(id modulo 100)
-        "{\"graph\": { " +
-            "\"nodes\" :[ " +
-            "{\"id\" : \"8\",\"labels\" : [ \"Course\"], \"properties\" : { \"name\" :\"Geography\" } }, " +
-
-            "{\"id\" : \"102\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Barry\" } }," +
-            "{\"id\" : \"103\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Carmen\" } }," +
-            "{\"id\" : \"105\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Eloise\" } }," +
-            "{\"id\" : \"107\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Gavin\" } }," +
-            "{\"id\" : \"111\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Kent\" } }," +
-            "{\"id\" : \"113\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Maria\" } }," +
-            "{\"id\" : \"117\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Quentin\" } }," +
-            "{\"id\" : \"119\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Suzanne\" } }," +
-            "{\"id\" : \"123\",\"labels\" : [ \"Student\" ],\"properties\" : {\"name\" : \"Will\" } }" +
-
-            "], " +
-            "\"relationships\": [" +
-            "{\"id\":\"8102\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"102\",\"properties\":{}}," +
-            "{\"id\":\"8103\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"103\",\"properties\":{}}," +
-            "{\"id\":\"8105\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"105\",\"properties\":{}}," +
-            "{\"id\":\"8107\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"107\",\"properties\":{}}," +
-            "{\"id\":\"8111\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"111\",\"properties\":{}}," +
-            "{\"id\":\"8113\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"113\",\"properties\":{}}," +
-            "{\"id\":\"8117\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"117\",\"properties\":{}}," +
-            "{\"id\":\"8119\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"119\",\"properties\":{}}," +
-            "{\"id\":\"8123\",\"type\":\"ENROLLED\",\"startNode\":\"8\",\"endNode\":\"123\",\"properties\":{}}" +
-            "] " +
-            "} }"
+        """
+        {"graph": { "nodes" :[ {"id" : "8","labels" : [ "Course"], "properties" : { "name" :"Geography" } }, {"id" : "102","labels" : [ "Student" ],"properties" : {"name" : "Barry" } },{"id" : "103","labels" : [ "Student" ],"properties" : {"name" : "Carmen" } },{"id" : "105","labels" : [ "Student" ],"properties" : {"name" : "Eloise" } },{"id" : "107","labels" : [ "Student" ],"properties" : {"name" : "Gavin" } },{"id" : "111","labels" : [ "Student" ],"properties" : {"name" : "Kent" } },{"id" : "113","labels" : [ "Student" ],"properties" : {"name" : "Maria" } },{"id" : "117","labels" : [ "Student" ],"properties" : {"name" : "Quentin" } },{"id" : "119","labels" : [ "Student" ],"properties" : {"name" : "Suzanne" } },{"id" : "123","labels" : [ "Student" ],"properties" : {"name" : "Will" } }], "relationships": [{"id":"8102","type":"ENROLLED","startNode":"8","endNode":"102","properties":{}},{"id":"8103","type":"ENROLLED","startNode":"8","endNode":"103","properties":{}},{"id":"8105","type":"ENROLLED","startNode":"8","endNode":"105","properties":{}},{"id":"8107","type":"ENROLLED","startNode":"8","endNode":"107","properties":{}},{"id":"8111","type":"ENROLLED","startNode":"8","endNode":"111","properties":{}},{"id":"8113","type":"ENROLLED","startNode":"8","endNode":"113","properties":{}},{"id":"8117","type":"ENROLLED","startNode":"8","endNode":"117","properties":{}},{"id":"8119","type":"ENROLLED","startNode":"8","endNode":"119","properties":{}},{"id":"8123","type":"ENROLLED","startNode":"8","endNode":"123","properties":{}}] } }
+        """
     };
 
     public String[] getResponse() {
@@ -441,17 +103,11 @@ public class EducationRequest extends StubHttpDriver {
     @Override
     protected String[] getResponse(String query) {
 
-        // This is tremendously ugly, error prone and what not. But it's way better than
-        // having the test switch drivers in between call.
-        // or even having the #setDriver method in the first place on the session.
-        switch (query) {
-            case "MATCH (n:`Teacher`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p":
-                return teacherModel;
-            case "MATCH (n:`Course`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p":
-                return coursesModel;
-            default:
-                throw new IllegalArgumentException("Unsupported query: " + query);
-        }
+        return switch (query) {
+            case "MATCH (n:`Teacher`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p" -> TEACHER_MODEL;
+            case "MATCH (n:`Course`) WITH n MATCH p=(n)-[*0..1]-(m) RETURN p" -> COURSES_MODEL;
+            default -> throw new IllegalArgumentException("Unsupported query: " + query);
+        };
     }
 
     @Override

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/ClosedTransactionTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/ClosedTransactionTest.java
@@ -61,7 +61,7 @@ public class ClosedTransactionTest extends TestContainersTestBase {
         // The session actually has its own transaction manager, which is btw tied to thread locally to the driver.
         // We could force get the sessions transaction manager or just create a new one here and tie it to the driver.
         // Both feel broken, this here a little less painful, though.
-        transactionManager = new DefaultTransactionManager(session, getDriver().getTransactionFactorySupplier());
+        transactionManager = new DefaultTransactionManager(getDriver(), session);
         tx = transactionManager.openTransaction();
         tx.close();
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/transaction/TransactionManagerTest.java
@@ -66,8 +66,7 @@ public class TransactionManagerTest extends TestContainersTestBase {
 
     @Test
     void shouldBeAbleToCreateManagedTransaction() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(session,
-            getDriver().getTransactionFactorySupplier());
+        DefaultTransactionManager transactionManager = new DefaultTransactionManager(driver, session);
         assertThat(session.getLastBookmark()).isNull();
         try (Transaction tx = transactionManager.openTransaction()) {
             assertThat(tx.status()).isEqualTo(Transaction.Status.OPEN);
@@ -76,8 +75,7 @@ public class TransactionManagerTest extends TestContainersTestBase {
 
     @Test
     void shouldRollbackManagedTransaction() {
-        DefaultTransactionManager transactionManager = new DefaultTransactionManager(session,
-            getDriver().getTransactionFactorySupplier());
+        DefaultTransactionManager transactionManager = new DefaultTransactionManager(driver, session);
         assertThat(session.getLastBookmark()).isNull();
 
         try (Transaction tx = transactionManager.openTransaction()) {

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 
         <assertj.version>3.11.1</assertj.version>
         <caffeine.version>2.6.2</caffeine.version>
-        <checkstyle.version>8.29</checkstyle.version>
+        <checkstyle.version>10.7.0</checkstyle.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
@@ -203,7 +203,7 @@
         <ogm.properties>ogm-bolt.properties</ogm.properties>
         <license-maven-plugin.version>4.2.rc2</license-maven-plugin.version>
         <maven-jar-plugin.version>3.0.1</maven-jar-plugin.version>
-        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>


### PR DESCRIPTION
This change does the following

1. Clean up the Transaction manager api
The previous state mixed responsibilities: whether a transaction could be committed or not, rolled back or not etc. was scattered across the transaction manager and the transaction itself. The same thinking was visible for the actual work of committing or rolling back things. This has been separated. Until this change, the API was not declared in any shape or form a public API. So the change is reasonable safe todo. The transaction interface itself stays stable from a callers perspective (not from an implementors though, but it is only intended to be implemented by us anyhow).

2. Add a base implementation
The transaction managed follows a certain OGM logic in context with the session as well as possible extendibility of sessions (kind of a poor mans nested transaction). While the latter is seldom used, the former is important. Especially clearing of newly registered objects in a session is paramount. For that purpose an abstract base implementation of the transaction manager has been added. The sensible methods are all final. It exposes however `openOrExtend` and `removeIfCurrent` as abstract methods, both parameterised with actions that we provide internally. So all that's left to do for issues like mentioned in #934 that needs different ways than thread locals to attach sessions to threads, those are the entry point

4. Provide extension points on the concrete classes
`SessionFactory` allows now configuration of transaction manager factories and `Neo4jSession` allows access to any transaction manager configured.

This closes #934.