### PR TITLE
Changing internal link from http to https for better indexing

### DIFF
--- a/neo4j-ogm-docs/src/main/asciidoc/reference/configuration.adoc
+++ b/neo4j-ogm-docs/src/main/asciidoc/reference/configuration.adoc
@@ -94,7 +94,7 @@ Configuration configuration = new Configuration.Builder()
 |======================
 
 A timeout to the database with the Bolt driver can be set by updating your Database's `neo4j.conf`.
-The exact setting to change can be http://neo4j.com/docs/operations-manual/current/reference/configuration-settings/#config_dbms.transaction.timeout[found here].
+The exact setting to change can be https://neo4j.com/docs/operations-manual/current/reference/configuration-settings/#config_dbms.transaction.timeout[found here].
 
 
 [[reference:configuration:driver:credentials]]


### PR DESCRIPTION
This has been flagged in the SEMRush report. The change is necessary because "If any link on website points to the old HTTP version of website, search engines can become confused as to which version of the page they should rank."