### PR TITLE
Fix missing attribute in docs

### DIFF
--- a/neo4j-ogm-docs/modules/ROOT/pages/introduction.adoc
+++ b/neo4j-ogm-docs/modules/ROOT/pages/introduction.adoc
@@ -76,7 +76,7 @@ Most importantly, it has an active and contributing community surrounding it, bu
 * has a powerful graph query language called Cypher, which allows users to efficiently read/write data by expressing graph patterns.
 * has a powerful traversal framework and query languages for traversing the graph.
 * can be deployed as a standalone server, which is the recommended way of using Neo4j.
-* can be deployed as an embedded (in-process) database, giving developers access to its core Java {neo4j-javadoc-base-uri}[API].
+* can be deployed as an embedded (in-process) database, giving developers access to its core Java {neo4j-docs-base-uri}/java-reference/current/javadocs[API].
 
 In addition, Neo4j provides ACID transactions, durable persistence, concurrency control, transaction recovery, high availability, and more.
 Neo4j is released under a dual free software/commercial licence model.

--- a/neo4j-ogm-docs/preview.yml
+++ b/neo4j-ogm-docs/preview.yml
@@ -34,8 +34,6 @@ asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"
   - "@neo4j-documentation/macros"
-  - "@neo4j-antora/antora-add-notes"
-  - "@neo4j-antora/antora-page-roles"
   - "@neo4j-antora/antora-table-footnotes"
   attributes:
     page-theme: docs


### PR DESCRIPTION
Fixes a build error where this branch uses an attribute, but we now publish all the docs versions from `master`, where the attribute is missing.

The attribute use is updated to a standard now used across all docs.