### PR TITLE
fix: Create/Drop a single/composite index for relationships

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
@@ -37,8 +37,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.neo4j.ogm.annotation.CompositeIndex;
+import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.config.AutoIndexMode;
 import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.metadata.AnnotationInfo;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
 import org.neo4j.ogm.metadata.MetaData;
@@ -263,11 +265,16 @@ public class AutoIndexManager {
 
             if (needsToBeIndexed(classInfo)) {
 
+                AnnotationInfo relationshipEntityAnnotation = classInfo.annotationsInfo().get(RelationshipEntity.class);
+                boolean isRelationShip = relationshipEntityAnnotation != null;
+
                 // We build the composite index first, to find out whether an @Id or @Index annotated field
                 // is actually decomposed by a MapCompositeConverter AND has a defined composite index.
                 Set<String> decomposedFields = new HashSet<>();
                 for (CompositeIndex index : classInfo.getCompositeIndexes()) {
-                    IndexType type = index.unique() ? IndexType.NODE_KEY_CONSTRAINT : IndexType.COMPOSITE_INDEX;
+                    IndexType type = index.unique() ?
+                        IndexType.NODE_KEY_CONSTRAINT :
+                        isRelationShip ? IndexType.REL_COMPOSITE_INDEX : IndexType.NODE_COMPOSITE_INDEX;
                     List<String> properties = new ArrayList<>();
                     Stream.of(index.value().length > 0 ? index.value() : index.properties())
                         .forEach(p -> {
@@ -287,7 +294,9 @@ public class AutoIndexManager {
 
                 for (FieldInfo fieldInfo : getIndexFields(classInfo)) {
 
-                    IndexType type = fieldInfo.isConstraint() ? IndexType.UNIQUE_CONSTRAINT : IndexType.SINGLE_INDEX;
+                    IndexType type = fieldInfo.isConstraint() ?
+                        IndexType.UNIQUE_CONSTRAINT :
+                        isRelationShip ? IndexType.REL_SINGLE_INDEX : IndexType.NODE_SINGLE_INDEX;
 
                     if (fieldInfo.hasCompositeConverter()) {
                         if (!decomposedFields.contains(fieldInfo.getName())) {

--- a/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/AutoIndexManager.java
@@ -298,10 +298,14 @@ public class AutoIndexManager {
                 }
 
                 for (FieldInfo fieldInfo : getIndexFields(classInfo)) {
-
-                    IndexType type = fieldInfo.isConstraint() ?
-                        IndexType.UNIQUE_CONSTRAINT :
-                        isRelationship ? IndexType.REL_SINGLE_INDEX : IndexType.NODE_SINGLE_INDEX;
+                    IndexType type;
+                    if (fieldInfo.isConstraint()) {
+                        type = IndexType.UNIQUE_CONSTRAINT;
+                    } else if (isRelationship) {
+                        type = IndexType.REL_SINGLE_INDEX;
+                    } else {
+                        type = IndexType.NODE_SINGLE_INDEX;
+                    }
 
                     if (fieldInfo.hasCompositeConverter()) {
                         if (!decomposedFields.contains(fieldInfo.getName())) {

--- a/core/src/main/java/org/neo4j/ogm/autoindex/IndexType.java
+++ b/core/src/main/java/org/neo4j/ogm/autoindex/IndexType.java
@@ -24,17 +24,27 @@ package org.neo4j.ogm.autoindex;
 enum IndexType {
 
     /**
-     * Single property index
+     * Node single property index
      */
-    SINGLE_INDEX,
+    NODE_SINGLE_INDEX,
 
     /**
-     * Composite index
+     * Relationship single property index
      */
-    COMPOSITE_INDEX,
+    REL_SINGLE_INDEX,
 
     /**
-     * Unique constraint
+     * Node composite index
+     */
+    NODE_COMPOSITE_INDEX,
+
+    /**
+     * Relationship composite index
+     */
+    REL_COMPOSITE_INDEX,
+
+    /**
+     * Node unique constraint
      */
     UNIQUE_CONSTRAINT,
 

--- a/core/src/test/java/org/neo4j/ogm/autoindex/AutoIndexTest.java
+++ b/core/src/test/java/org/neo4j/ogm/autoindex/AutoIndexTest.java
@@ -55,8 +55,22 @@ public class AutoIndexTest {
         AutoIndex index = AutoIndex.parseIndex(indexRow, "3.5").get();
         assertThat(index.getOwningType()).isEqualTo("Person");
         assertThat(index.getProperties()).containsOnly("name");
-        assertThat(index.getType()).isEqualTo(IndexType.SINGLE_INDEX);
+        assertThat(index.getType()).isEqualTo(IndexType.NODE_SINGLE_INDEX);
         assertThat(index.getDescription()).isEqualTo("INDEX ON :`Person`(`name`)");
+    }
+
+    @Test
+    public void parseRelationshipIndex() {
+        indexRow.put("entityType", "RELATIONSHIP");
+        indexRow.put("properties", new String[]{"stars"});
+        indexRow.put("labelsOrTypes", new String[]{"LIKED"});
+
+
+        AutoIndex index = AutoIndex.parseIndex(indexRow, "4.3").get();
+        assertThat(index.getOwningType()).isEqualTo("LIKED");
+        assertThat(index.getProperties()).containsOnly("stars");
+        assertThat(index.getType()).isEqualTo(IndexType.REL_SINGLE_INDEX);
+        assertThat(index.getDescription()).isEqualTo("INDEX FOR ()-[`liked`:`LIKED`]-() ON (`liked`.`stars`)");
     }
 
     @Test
@@ -66,8 +80,22 @@ public class AutoIndexTest {
         AutoIndex index = AutoIndex.parseIndex(indexRow, "3.5").get();
         assertThat(index.getOwningType()).isEqualTo("Person");
         assertThat(index.getProperties()).containsOnly("name", "id");
-        assertThat(index.getType()).isEqualTo(IndexType.COMPOSITE_INDEX);
+        assertThat(index.getType()).isEqualTo(IndexType.NODE_COMPOSITE_INDEX);
         assertThat(index.getDescription()).isEqualTo("INDEX ON :`Person`(`name`,`id`)");
+    }
+
+    @Test
+    public void parseRelationshipCompositeIndex() {
+        indexRow.put("entityType", "RELATIONSHIP");
+        indexRow.put("properties", new String[]{"stars", "movies"});
+        indexRow.put("labelsOrTypes", new String[]{"LIKED"});
+
+
+        AutoIndex index = AutoIndex.parseIndex(indexRow, "4.3").get();
+        assertThat(index.getOwningType()).isEqualTo("LIKED");
+        assertThat(index.getProperties()).contains("stars", "movies");
+        assertThat(index.getType()).isEqualTo(IndexType.REL_COMPOSITE_INDEX);
+        assertThat(index.getDescription()).isEqualTo("INDEX FOR ()-[`liked`:`LIKED`]-() ON (`liked`.`stars`,`liked`.`movies`)");
     }
 
     @Test


### PR DESCRIPTION
Since neo4j supports relationship index in versions above 4.x , it is necessary to distinguish node and relationship index in IndexType.