### PR TITLE
Remove sitemap extension from playbooks

### DIFF
--- a/neo4j-ogm-docs/preview.yml
+++ b/neo4j-ogm-docs/preview.yml
@@ -23,13 +23,6 @@ ui:
 urls:
   html_extension_style: indexify
 
-antora:
-  extensions:
-  - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '4.0'
-    sitemap_loc_version: 'current'
-    move_sitemaps_to_components: true
-
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"

--- a/neo4j-ogm-docs/publish.yml
+++ b/neo4j-ogm-docs/publish.yml
@@ -24,13 +24,6 @@ ui:
 urls:
   html_extension_style: indexify
 
-antora:
-  extensions:
-  - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '4.0'
-    sitemap_loc_version: 'current'
-    move_sitemaps_to_components: true
-
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"


### PR DESCRIPTION
The sitemap extension is automatically applied with default config in docs CI/CD so it no longer needs to be included in the docs playbooks in the repo.