### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/neo4j-ogm-docs/publish.yml
+++ b/neo4j-ogm-docs/publish.yml
@@ -30,6 +30,8 @@ asciidoc:
   - "@neo4j-documentation/macros"
   - "@neo4j-antora/antora-table-footnotes"
   attributes:
+    page-tabs: drivers-apis@
+    page-tabs-index: 35
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `neo4j-ogm-docs/publish.yml`:

```yaml
page-tabs: drivers-apis@
page-tabs-index: 35
```

Places this docset in the `drivers-apis` tab of the aggregated tabbed navigation. The
index sits between the Visualization Library (30) and the HTTP API (40), matching the
order of the OGM Library in the Docs menu on neo4j.com/docs.

Set in the publish playbook rather than `antora.yml` because this docset publishes
multiple versions (`3.2.x`, `3.3.x`, `master`) — an `antora.yml` change would have to be
applied to every published branch. `page-tabs` is soft-set with a trailing `@` so it can
be overridden.
