### PR TITLE
refactor: Throw `IllegalArgumentException` when a non supported `encryptionLevel` is used.

### DIFF
--- a/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
+++ b/bolt-driver/src/main/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriver.java
@@ -102,7 +102,7 @@ public class BoltDriver extends AbstractConfigurableDriver {
     private final ExceptionTranslator exceptionTranslator = new BoltDriverExceptionTranslator();
 
     private volatile Driver boltDriver;
-    private Credentials credentials;
+    private Credentials<?> credentials;
     private Config driverConfig;
     /**
      * The database to use, defaults to {@literal null} (Use Neo4j default).
@@ -271,7 +271,7 @@ public class BoltDriver extends AbstractConfigurableDriver {
     public <T> T unwrap(Class<T> clazz) {
 
         if (clazz == Driver.class) {
-            return (T) boltDriver;
+            return clazz.cast(boltDriver);
         } else {
             return super.unwrap(clazz);
         }
@@ -364,11 +364,21 @@ public class BoltDriver extends AbstractConfigurableDriver {
     }
 
     private void applyEncryptionAndTrustSettings(Config.ConfigBuilder configBuilder) {
-        if (configuration.getEncryptionLevel() != null && "REQUIRED"
-            .equals(configuration.getEncryptionLevel().toUpperCase(Locale.ENGLISH).trim())) {
-            configBuilder.withEncryption();
-        } else {
+        String level = configuration.getEncryptionLevel();
+        if (level == null) {
             configBuilder.withoutEncryption();
+        } else {
+            switch (level.toUpperCase(Locale.ENGLISH).trim()) {
+                case "REQUIRED":
+                    configBuilder.withEncryption();
+                    break;
+                case "NONE":
+                    configBuilder.withoutEncryption();
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid encryptionLevel '" + level
+                        + "'. Supported values are: REQUIRED, NONE.");
+            }
         }
 
         Config.TrustStrategy.Strategy trustStrategy;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/drivers/bolt/driver/BoltDriverTest.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.exception.ConnectionException;
 import org.neo4j.ogm.session.SessionFactory;
 
 /**
@@ -64,6 +65,25 @@ public class BoltDriverTest {
                 .isThrownBy(() -> BoltDriver.isSimpleScheme(invalidScheme))
                 .withMessage("'%s' is not a supported scheme.", invalidScheme);
         }
+    }
+
+    @Test
+    void shouldFailEarlyOnInvalidEncryptionLevel() {
+
+        Configuration configuration = new Configuration.Builder()
+            .uri("bolt://localhost:7687")
+            .encryptionLevel("REQUIRE")
+            .verifyConnection(false)
+            .build();
+
+        BoltDriver boltDriver = new BoltDriver();
+
+        assertThatExceptionOfType(ConnectionException.class)
+            .isThrownBy(() -> boltDriver.configure(configuration))
+            .withCauseInstanceOf(IllegalArgumentException.class)
+            .withRootCauseExactlyInstanceOf(IllegalArgumentException.class)
+            .satisfies(e -> assertThat(e.getCause())
+                .hasMessage("Invalid encryptionLevel 'REQUIRE'. Supported values are: REQUIRED, NONE."));
     }
 
     @Test


### PR DESCRIPTION
This prevents silently disabling encryption due to a small spelling error or similar.

This is F9 of CGE-901.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
