### PR TITLE
refactor: Use Cypher-DSL Schema Names support to uniformly escape names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build/
 devenv.local
 .vscode/
 build.log
+dependency-reduced-pom.xml
+.flattened-pom.xml

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -64,5 +64,47 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-cypher-dsl-schema-name-support</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.neo4j:neo4j-cypher-dsl-schema-name-support</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.neo4j.cypherdsl.support.schema_name</pattern>
+                                    <shadedPattern>org.neo4j.ogm.internal</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createSourcesJar>true</createSourcesJar>
+                            <filters>
+                                <filter>
+                                    <artifact>org.neo4j:neo4j-cypher-dsl-schema-name-support</artifact>
+                                    <includes>
+                                        <include>**/SchemaNames*class</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/src/main/java/org/neo4j/ogm/response/model/AbstractPropertyContainer.java
+++ b/api/src/main/java/org/neo4j/ogm/response/model/AbstractPropertyContainer.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import org.neo4j.cypherdsl.support.schema_name.SchemaNames;
 import org.neo4j.ogm.model.PropertyContainer;
 
 /**
@@ -63,7 +64,7 @@ abstract class AbstractPropertyContainer implements PropertyContainer {
         }
 
         return propertiesToBeRemoved.stream()
-            .map(s -> String.format("%s.`%s`", variable, s))
+            .map(s -> String.format("%s.%s", variable, SchemaNames.sanitize(s, true).orElseThrow()))
             .collect(Collectors.joining(",", " REMOVE ", " "));
     }
 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/statement/ExistingNodeStatementBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/statement/ExistingNodeStatementBuilder.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.ogm.cypher.compiler.CypherStatementBuilder;
+import org.neo4j.ogm.internal.SchemaNames;
 import org.neo4j.ogm.model.Node;
 import org.neo4j.ogm.request.OptimisticLockingConfig;
 import org.neo4j.ogm.request.Statement;
@@ -53,7 +54,7 @@ public class ExistingNodeStatementBuilder implements CypherStatementBuilder {
         final Map<String, Object> parameters = new HashMap<>();
         final StringBuilder queryBuilder = new StringBuilder();
 
-        if (existingNodes != null && existingNodes.size() > 0) {
+        if (existingNodes != null && !existingNodes.isEmpty()) {
             Node firstNode = existingNodes.iterator().next();
 
             queryBuilder
@@ -65,18 +66,18 @@ public class ExistingNodeStatementBuilder implements CypherStatementBuilder {
 
             Set<String> previousDynamicLabels = firstNode.getPreviousDynamicLabels();
             for (String label : previousDynamicLabels) {
-                queryBuilder.append(String.format(" REMOVE n:`%s` ", label));
+                queryBuilder.append("REMOVE n:").append(SchemaNames.sanitize(label, true).orElseThrow()).append(" ");
             }
 
             queryBuilder.append(firstNode.createPropertyRemovalFragment("n"));
 
             queryBuilder.append("SET n");
             for (String label : firstNode.getLabels()) {
-                queryBuilder.append(":`").append(label).append("`");
+                queryBuilder.append(":").append(SchemaNames.sanitize(label, true).orElseThrow());
             }
 
             queryBuilder.append(" SET n += row.props RETURN row.nodeId as ref, ID(n) as id, $type as type");
-            List<Map> rows = existingNodes.stream().map(node -> node.toRow("nodeId")).collect(toList());
+            List<Map<?, ?>> rows = existingNodes.stream().map(node -> node.toRow("nodeId")).collect(toList());
             parameters.put("type", "node");
             parameters.put("rows", rows);
 

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/statement/NewNodeStatementBuilder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/builders/statement/NewNodeStatementBuilder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.ogm.cypher.compiler.CypherStatementBuilder;
+import org.neo4j.ogm.internal.SchemaNames;
 import org.neo4j.ogm.model.Node;
 import org.neo4j.ogm.request.OptimisticLockingConfig;
 import org.neo4j.ogm.request.Statement;
@@ -56,7 +57,7 @@ public class NewNodeStatementBuilder implements CypherStatementBuilder {
         final Map<String, Object> parameters = new HashMap<>();
         final StringBuilder queryBuilder = new StringBuilder();
 
-        if (newNodes != null && newNodes.size() > 0) {
+        if (newNodes != null && !newNodes.isEmpty()) {
             Node firstNode = newNodes.iterator().next();
 
             queryBuilder.append("UNWIND $rows as row ");
@@ -69,12 +70,15 @@ public class NewNodeStatementBuilder implements CypherStatementBuilder {
             }
 
             for (String label : firstNode.getLabels()) {
-                queryBuilder.append(":`").append(label).append("`");
+                queryBuilder.append(":").append(SchemaNames.sanitize(label, true).orElseThrow());
             }
 
             if (hasPrimaryIndex) {
                 String propertiesToMergeOn = Arrays.stream(firstNode.getPrimaryIndex().split(PROPERTY_SEPARATOR))
-                    .map(p -> p + ": row.props." + p)
+                    .map(p -> {
+                        var pq = SchemaNames.sanitize(p, true).orElseThrow();
+                        return pq + ": row.props." + pq;
+                    })
                     .collect(joining(",", "{", "}"));
                 queryBuilder.append(propertiesToMergeOn);
             }

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/NativeDistanceComparison.java
@@ -24,6 +24,7 @@ import java.util.function.UnaryOperator;
 
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.PropertyValueTransformer;
+import org.neo4j.ogm.internal.SchemaNames;
 
 /**
  * @author Gerrit Meier
@@ -60,7 +61,7 @@ public class NativeDistanceComparison implements FilterFunction<DistanceFromNati
     public String expression(String nodeIdentifier, String filteredProperty,
         UnaryOperator<String> createUniqueParameterName) {
 
-        String pointPropertyOfEntity = nodeIdentifier + "." + filteredProperty;
+        String pointPropertyOfEntity = nodeIdentifier + "." + SchemaNames.sanitize(filteredProperty, true).orElseThrow();
         String comparisonOperator = operator.getValue();
 
         return String.format(

--- a/core/src/main/java/org/neo4j/ogm/cypher/function/PropertyComparison.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/function/PropertyComparison.java
@@ -27,6 +27,7 @@ import java.util.function.UnaryOperator;
 
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.PropertyValueTransformer;
+import org.neo4j.ogm.internal.SchemaNames;
 
 /**
  * @author Jasper Blues
@@ -57,15 +58,17 @@ public class PropertyComparison implements FilterFunction<Object> {
     public String expression(String nodeIdentifier, String filteredProperty,
         UnaryOperator<String> createUniqueParameterName) {
 
+        var safeFilteredProperty = SchemaNames.sanitize(filteredProperty, true).orElseThrow();
+
         if (operator == IS_NULL) {
-            return String.format("%s.`%s` IS NULL ", nodeIdentifier, filteredProperty);
+            return String.format("%s.%s IS NULL ", nodeIdentifier, safeFilteredProperty);
         } else if (operator == EXISTS) {
-            return String.format("%s.`%s` IS NOT NULL ", nodeIdentifier, filteredProperty);
+            return String.format("%s.%s IS NOT NULL ", nodeIdentifier, safeFilteredProperty);
         } else if (operator == IS_TRUE) {
-            return String.format("%s.`%s` = true ", nodeIdentifier, filteredProperty);
+            return String.format("%s.%s = true ", nodeIdentifier, safeFilteredProperty);
         } else {
-            return String.format("%s.`%s` %s $`%s` ", nodeIdentifier, filteredProperty,
-                operator.getValue(), createUniqueParameterName.apply(PARAMETER_NAME));
+            return String.format("%s.%s %s $%s ", nodeIdentifier, safeFilteredProperty,
+                operator.getValue(), SchemaNames.sanitize(createUniqueParameterName.apply(PARAMETER_NAME), true).orElseThrow());
         }
     }
 

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/SessionDelegate.java
@@ -33,6 +33,7 @@ import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.FilterWithRelationship;
 import org.neo4j.ogm.cypher.query.SortClause;
 import org.neo4j.ogm.cypher.query.SortOrder;
+import org.neo4j.ogm.internal.SchemaNames;
 import org.neo4j.ogm.metadata.AnnotationInfo;
 import org.neo4j.ogm.metadata.ClassInfo;
 import org.neo4j.ogm.metadata.FieldInfo;
@@ -51,11 +52,11 @@ abstract class SessionDelegate {
         this.session = session;
     }
 
-    SortOrder sortOrderWithResolvedProperties(Class entityType, SortOrder sortOrder) {
+    SortOrder sortOrderWithResolvedProperties(Class<?> entityType, SortOrder sortOrder) {
         return SortOrder.fromSortClauses(sortClausesWithResolvedProperties(entityType, sortOrder));
     }
 
-    void resolvePropertyAnnotations(Class entityType, Iterable<Filter> filters) {
+    void resolvePropertyAnnotations(Class<?> entityType, Iterable<Filter> filters) {
         for (Filter filter : filters) {
             if (filter.getOwnerEntityType() == null) {
                 filter.setOwnerEntityType(entityType);
@@ -77,10 +78,11 @@ abstract class SessionDelegate {
                     filter.setNestedRelationshipEntity(true);
                 }
             } else if (filter.isDeepNested()) {
-                Class parentOwnerType = filter.getOwnerEntityType();
+                Class<?> parentOwnerType = filter.getOwnerEntityType();
                 for (Filter.NestedPathSegment nestedPathSegment : filter.getNestedPath()) {
                     resolveRelationshipType(parentOwnerType, nestedPathSegment);
-                    ClassInfo nestedClassInfo = session.metaData().classInfo(nestedPathSegment.getPropertyType().getName());
+                    ClassInfo nestedClassInfo = session.metaData()
+                        .classInfo(nestedPathSegment.getPropertyType().getName());
                     nestedPathSegment.setNestedEntityTypeLabel(session.metaData().entityType(nestedClassInfo.name()));
                     if (session.metaData().isRelationshipEntity(nestedClassInfo.name())) {
                         nestedPathSegment.setNestedRelationshipEntity(true);
@@ -92,7 +94,7 @@ abstract class SessionDelegate {
         }
     }
 
-    <X extends Object> X convertIfNeeded(ClassInfo classInfo, X id) {
+    <X> X convertIfNeeded(ClassInfo classInfo, X id) {
         if (classInfo.hasPrimaryIndexField()) {
             FieldInfo primaryIndexField = classInfo.primaryIndexField();
             if (primaryIndexField.hasPropertyConverter()) {
@@ -104,7 +106,7 @@ abstract class SessionDelegate {
         return id;
     }
 
-    <X extends Object> Collection<X> convertIfNeeded(ClassInfo classInfo, Collection<X> ids) {
+    <X> Collection<X> convertIfNeeded(ClassInfo classInfo, Collection<X> ids) {
         if (classInfo.hasPrimaryIndexField()) {
             Function<Object, Object> converter = null;
             if (classInfo.primaryIndexField().hasPropertyConverter()) {
@@ -127,7 +129,7 @@ abstract class SessionDelegate {
         updateRelationship(filter, fieldInfo, defaultRelationshipType);
     }
 
-    private void resolveRelationshipType(Class parentOwnerType, Filter.NestedPathSegment segment) {
+    private void resolveRelationshipType(Class<?> parentOwnerType, Filter.NestedPathSegment segment) {
         ClassInfo classInfo = session.metaData().classInfo(parentOwnerType.getName());
         FieldInfo fieldInfo = classInfo.relationshipFieldByName(segment.getPropertyName());
 
@@ -155,7 +157,7 @@ abstract class SessionDelegate {
         }
     }
 
-    private List<SortClause> sortClausesWithResolvedProperties(Class entityType, SortOrder sortOrder) {
+    private List<SortClause> sortClausesWithResolvedProperties(Class<?> entityType, SortOrder sortOrder) {
 
         List<SortClause> sortClausesWithResolvedProperties = new ArrayList<>();
 
@@ -173,15 +175,11 @@ abstract class SessionDelegate {
         return sortClausesWithResolvedProperties;
     }
 
-    private String escapedResolvedProperty(Class entityType, SortClause sortClause, int i) {
-        final String escapedProperty = "`%s`";
-
-        return String
-            .format(escapedProperty, resolvePropertyName(entityType, sortClause.getProperties()[i])
-            );
+    private String escapedResolvedProperty(Class<?> entityType, SortClause sortClause, int i) {
+        return SchemaNames.sanitize(resolvePropertyName(entityType, sortClause.getProperties()[i]), true).orElseThrow();
     }
 
-    private String resolvePropertyName(Class entityType, String propertyName) {
+    private String resolvePropertyName(Class<?> entityType, String propertyName) {
         ClassInfo classInfo = session.metaData().classInfo(entityType.getName());
         FieldInfo fieldInfo = classInfo.propertyFieldByName(propertyName);
         if (fieldInfo != null && fieldInfo.getAnnotations() != null) {

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/EscapingTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/cypher/EscapingTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.cypher;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.ogm.config.Configuration;
+import org.neo4j.ogm.cypher.function.DistanceFromNativePoint;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.SortOrder;
+import org.neo4j.ogm.domain.escaping.Article;
+import org.neo4j.ogm.domain.escaping.Person;
+import org.neo4j.ogm.domain.escaping.Place;
+import org.neo4j.ogm.domain.escaping.SomeModel;
+import org.neo4j.ogm.domain.escaping.Thing;
+import org.neo4j.ogm.driver.Driver;
+import org.neo4j.ogm.drivers.bolt.driver.BoltDriver;
+import org.neo4j.ogm.session.Session;
+import org.neo4j.ogm.session.SessionFactory;
+import org.neo4j.ogm.testutil.TestContainersTestBase;
+import org.neo4j.ogm.types.spatial.CartesianPoint2d;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.neo4j.ogm.cypher.function.NativeDistanceComparison.*;
+
+public class EscapingTest extends TestContainersTestBase {
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+
+    private static org.neo4j.driver.Driver nativeDriver;
+
+
+    @BeforeAll
+    public static void oneTimeSetUp() {
+
+        Configuration ogmConfiguration = getBaseConfigurationBuilder()
+            .useNativeTypes()
+            .build();
+
+        Driver driver = new BoltDriver();
+        driver.configure(ogmConfiguration);
+
+        sessionFactory = new SessionFactory(driver, "org.neo4j.ogm.domain.escaping");
+        nativeDriver = driver.unwrap(org.neo4j.driver.Driver.class);
+    }
+
+
+    @BeforeEach
+    public void init() throws IOException {
+
+        try(var localSession = nativeDriver.session()) {
+            localSession.run("CREATE (p:Person {name: 'testperson1', `name`` IS NOT NULL WITH n MERGE (u:User) RETURN u.password AS pw //`: 'anything'})").consume();
+            localSession.run("CREATE (p:Person {name: 'testperson2', `name`` DESC WITH n MERGE (u:User) RETURN u.password AS pw //`: '1'})").consume();
+            localSession.run("CREATE (p:Person {name: 'testperson3', `name`` DESC WITH n MERGE (u:User) RETURN u.password AS pw //`: '2'})").consume();
+            localSession.run("CREATE (p:Place {name: 'testplace', `l) < $distanceValue WITH n MERGE (u:User) RETURN u.password AS pw //`:  point({x: 1, y: 1, srid: 7203})})").consume();
+        }
+        session = sessionFactory.openSession();
+
+    }
+
+    @AfterEach
+    public void clear() {
+        session.purgeDatabase();
+    }
+
+    @Test // F3
+    void dynamicLabelsShouldPreventInjection() {
+        var a = new Article();
+        a.setBody("whatever");
+        var tag = "x`) WITH n MERGE (u:User) SET u.role = 'ADMIN' //";
+        a.addTag(tag);
+        session.save(a);
+
+        assertNoUserHasBeenCreated();
+
+        a = session.load(Article.class, a.getId());
+        assertThat(a.getTags()).containsExactly(tag);
+    }
+
+    private static void assertNoUserHasBeenCreated() {
+        try (var localSession = nativeDriver.session()) {
+            var result = localSession.run("MATCH (u:User) RETURN count(u)").single().get(0).asLong();
+            assertThat(result).isZero();
+        }
+    }
+
+    @Test // F1
+    void searchFilterShouldPreventInjection() {
+
+        var field = "name` IS NOT NULL WITH n MERGE (u:User) RETURN u.password AS pw //";
+        var filter = new Filter(field, ComparisonOperator.EQUALS, "anything");
+
+        session.clear();
+        var people = session.loadAll(Person.class, new Filters(filter));
+
+        assertNoUserHasBeenCreated();
+        assertThat(people)
+            .hasSize(1)
+            .first().extracting(Person::getName).isEqualTo("testperson1");
+    }
+
+    @Test // F2
+    void sortFieldsShouldPreventInjection() {
+
+        var sortParam = "name` DESC WITH n MERGE (u:User) RETURN u.password AS pw //";
+        var order = new SortOrder().asc(sortParam);
+
+        session.clear();
+        var people = session.loadAll(Person.class, new Filters(), order, new Pagination(0, 20), 1);
+
+        assertNoUserHasBeenCreated();
+        assertThat(people)
+            .hasSize(3)
+            .first().extracting(Person::getName).isEqualTo("testperson2");
+    }
+
+    @Test // F5
+    void locationFilterShouldPreventInjection() {
+
+        var userField = "l) < $distanceValue WITH n MERGE (u:User) RETURN u.password AS pw //";
+        var filter = new Filter(userField, distanceComparisonFor(new DistanceFromNativePoint(new CartesianPoint2d(0, 0), 2)));
+
+        session.clear();
+        var places = session.loadAll(Place.class, new Filters(filter));
+
+        assertNoUserHasBeenCreated();
+        assertThat(places)
+            .hasSize(1)
+            .first().extracting(Place::getName).isEqualTo("testplace");
+    }
+
+    @Test // F4
+    void customPropertiesShouldPreventInjection() {
+
+        var t = new Thing();
+        var key = "x` WITH n MERGE (u:User) //";
+        t.addAttr(key, "v");
+        session.save(t);
+
+        assertNoUserHasBeenCreated();
+
+        t.removeAttr(key);
+        session.save(t);
+
+        session.clear();
+        t = session.load(Thing.class, t.getId());
+
+        assertNoUserHasBeenCreated();
+        assertThat(t.getAttrs()).doesNotContainKey(key);
+    }
+
+    @Test // F11
+    void shouldSaveEntitiesWithUnusualIds() {
+
+        var someModel = new SomeModel();
+        someModel.setBusinessKey("my key");
+        session.save(someModel);
+
+        session.clear();
+        someModel = session.load(SomeModel.class, "my key");
+        assertThat(someModel).isNotNull();
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Article.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Article.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.escaping;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.Labels;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class Article {
+    @Labels final Set<String> tags = new HashSet<>();
+    @Id @GeneratedValue Long id;
+    private String body;
+
+    public void addTag(String tag) {
+        this.tags.add(tag);
+    }
+
+    public long getId() {
+        return this.id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Set<String> getTags() {
+        return Set.copyOf(this.tags);
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Person.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Person.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.escaping;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class Person {
+    @Id @GeneratedValue Long id;
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Place.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Place.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.escaping;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.types.spatial.CartesianPoint2d;
+
+@NodeEntity
+public class Place {
+    @Id @GeneratedValue Long id;
+    private String name;
+
+    private CartesianPoint2d l;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CartesianPoint2d getL() {
+        return l;
+    }
+
+    public void setL(CartesianPoint2d l) {
+        this.l = l;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/SomeModel.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/SomeModel.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.escaping;
+
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
+
+@NodeEntity
+public class SomeModel {
+
+    @Id @Property("business-key")
+    private String businessKey;
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public void setBusinessKey(String businessKey) {
+        this.businessKey = businessKey;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Thing.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Thing.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.escaping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Properties;
+
+@NodeEntity
+public class Thing {
+    @Id @GeneratedValue Long id;
+    @Properties Map<String, Object> attrs = new HashMap<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void addAttr(String key, String value) {
+        this.attrs.put(key, value);
+    }
+
+    public Map<String, Object> getAttrs() {
+        return Map.copyOf(this.attrs);
+    }
+
+    public void removeAttr(String key) {
+        this.attrs.remove(key);
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/metadata/MergeWithPrimaryIndexTests.java
@@ -78,7 +78,7 @@ public class MergeWithPrimaryIndexTests {
         Compiler compiler = mapAndCompile(newUser);
         assertThat(compiler.hasStatementsDependentOnNewNodes()).isFalse();
         assertThat(compiler.createNodesStatements().get(0).getStatement()).isEqualTo(
-            "UNWIND $rows as row MERGE (n:`User`{login: row.props.login}) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, $type as type");
+            "UNWIND $rows as row MERGE (n:`User`{`login`: row.props.`login`}) SET n=row.props RETURN row.nodeRef as ref, ID(n) as id, $type as type");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,8 @@
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
+        <neo4j-cypher-dsl.version>2025.3.0</neo4j-cypher-dsl.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <mockito.version>5.23.0</mockito.version>
@@ -266,6 +268,14 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-cypher-dsl-bom</artifactId>
+                <version>${neo4j-cypher-dsl.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!--Testing  Dependencies -->
@@ -420,6 +430,11 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${license-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Security audit found that several areas of Neo4j-OGM that have not been touch in close to a decade do not escape names
enough (i.e. the old code paths just used single backticks. Cypher-DSL has now for several years already schema name
support, predating even Neo4js dynamic labels. That helper class has been battle tested in SDN and other projects and is
used now in Neo4j-OGM as well.

This change applies its sanitizer to

- dynamic labels
- property names in filters
- property names in sorting operators
- the location operator
- and the id name generator

The library is shaded into the `neo4j-ogm-api` module as chances are high that pure Neo4j-OGM users already have a
version of Cypher-DSL on their classpath and we don't want to surprise them with conflicting versions.

While most fixes are in `neo4j-ogm-core`, we do shade in `api` as the dependency is `core -> api` (another story, but it
is the way it is), and then use the shaded version from within core.

This addresses the findings F1 to F5 and F11 from the security report.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
