### PR TITLE
fix: Use full classname to lookup class info during query execution and deletion.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
+++ b/core/src/main/java/org/neo4j/ogm/metadata/MetaData.java
@@ -94,13 +94,7 @@ public class MetaData {
             return classInfo;
         }
 
-        classInfo = domainInfo.getClassSimpleName(name);
-        if (classInfo != null) {
-            return classInfo;
-        }
-
-        // not found
-        return null;
+        return domainInfo.getClassSimpleName(name);
     }
 
     /**

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/DeleteDelegate.java
@@ -63,11 +63,11 @@ public class DeleteDelegate extends SessionDelegate {
 
     /**
      * Deletes all nodes of a given type. They will get discovered by using the matching label for that type.
-     * To avoid a delete of every node in the database the method will abort the delete operation if no label
+     * To avoid the deletion of every node in the database the method will abort the delete operation if no label
      * can be determined.
      *
-     * @param type  The type of the nodes/objects to be deleted.
-     * @param <T>   The type to work with
+     * @param type The type of the nodes/objects to be deleted.
+     * @param <T>  The type to work with
      */
     public <T> void deleteAll(Class<T> type) {
         ClassInfo classInfo = session.metaData().classInfo(type.getName());
@@ -83,7 +83,7 @@ public class DeleteDelegate extends SessionDelegate {
             RowModelRequest query = new DefaultRowModelRequest(request.getStatement(), request.getParameters());
             session.notifyListeners(new PersistenceEvent(type, Event.TYPE.PRE_DELETE));
             session.doInTransaction(() -> {
-                try (Response<RowModel> response = session.requestHandler().execute(query)) {
+                try (Response<RowModel> ignored = session.requestHandler().execute(query)) {
                     session.context().removeType(type);
                     if (session.eventsEnabled()) {
                         session.notifyListeners(new PersistenceEvent(type, Event.TYPE.POST_DELETE));
@@ -97,9 +97,16 @@ public class DeleteDelegate extends SessionDelegate {
 
     public <T> Object delete(Class<T> clazz, Iterable<Filter> filters, boolean listResults) {
 
-        ClassInfo classInfo = session.metaData().classInfo(clazz.getSimpleName());
+        ClassInfo classInfo = session.metaData().classInfo(clazz.getName());
 
         if (classInfo != null) {
+
+            String entityLabel = classInfo.neo4jName();
+            if (entityLabel == null) {
+                session.warn("Unable to find database label for entity " + clazz.getName()
+                    + " : aborting delete to avoid an unlabelled, database-wide delete.");
+                return listResults ? Collections.emptyList() : 0L;
+            }
 
             resolvePropertyAnnotations(clazz, filters);
 
@@ -187,9 +194,10 @@ public class DeleteDelegate extends SessionDelegate {
                     .filter(possibleId -> possibleId >= 0)
                     .orElseGet(() -> {
                         session.warn(String.format(
-                                "Instance of class %s has to be reloaded to be deleted. This can happen if the session has " +
+                            "Instance of class %s has to be reloaded to be deleted. This can happen if the session has "
+                                +
                                 "been cleared between loading and deleting or using an object from a different transaction.",
-                                object.getClass())
+                            object.getClass())
                         );
                         return classInfo.getPrimaryIndexOrIdReader().apply(object)
                             .map(primaryIndexOrId -> session.load(object.getClass(), (Serializable) primaryIndexOrId))

--- a/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
+++ b/core/src/main/java/org/neo4j/ogm/session/delegates/ExecuteQueriesDelegate.java
@@ -287,7 +287,7 @@ public class ExecuteQueriesDelegate extends SessionDelegate {
 
     public long count(Class<?> clazz, Iterable<Filter> filters) {
 
-        ClassInfo classInfo = session.metaData().classInfo(clazz.getSimpleName());
+        ClassInfo classInfo = session.metaData().classInfo(clazz.getName());
 
         if (classInfo != null) {
 

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Article.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Article.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.l1;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity
+public class Article extends Content {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Author.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Author.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.l1;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+
+public class Author {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Content.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l1/Content.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.l1;
+
+import org.neo4j.ogm.annotation.Relationship;
+
+public abstract class Content {
+    @Relationship("AUTHORED_BY") Author author;
+
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l3/a/Order.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l3/a/Order.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.l3.a;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+
+public class Order {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l3/b/Order.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/l3/b/Order.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.l3.b;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+
+@NodeEntity(label = "SalesOrder")
+public class Order {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/DeleteCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/DeleteCapabilityTest.java
@@ -22,10 +22,17 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.neo4j.ogm.cypher.ComparisonOperator;
+import org.neo4j.ogm.cypher.Filter;
+import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.domain.l1.Article;
+import org.neo4j.ogm.domain.l1.Author;
+import org.neo4j.ogm.domain.l1.Content;
 import org.neo4j.ogm.domain.music.Album;
 import org.neo4j.ogm.domain.music.Recording;
 import org.neo4j.ogm.session.Session;
@@ -34,6 +41,7 @@ import org.neo4j.ogm.testutil.TestContainersTestBase;
 
 /**
  * @author vince
+ * @author Michael J. Simons
  */
 public class DeleteCapabilityTest extends TestContainersTestBase {
 
@@ -43,7 +51,8 @@ public class DeleteCapabilityTest extends TestContainersTestBase {
 
     @BeforeAll
     public static void oneTimeSetUp() {
-        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.music");
+        sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.music", "org.neo4j.ogm.domain.l1",
+            "org.neo4j.ogm.domain.l3");
     }
 
     @BeforeEach
@@ -110,5 +119,46 @@ public class DeleteCapabilityTest extends TestContainersTestBase {
         long entityCount = session.countEntitiesOfType(Album.class);
         assertThat(entityCount).isEqualTo(count);
         session.clear(); // ...also for the subsequent calls in the test methods
+    }
+
+    @Test // L1
+    void deleteFiltersAreSaveWithoutLabel() {
+        Album album = new Album();
+        session.save(album);
+        assertEntityCount(1);
+
+        session.query(
+            "CREATE (a:Author {name: 'Michael'}) <-[:AUTHORED_BY]- (c:Article {name: 'JSpecify and NullAway: A fresh take on nullsafety in the Java world'})",
+            Map.of());
+        session.query("CREATE (a:Author {name: 'Bob'})",
+            Map.of());
+
+        session.clear();
+        assertThat(session.countEntitiesOfType(Article.class)).isOne();
+        assertThat(session.countEntitiesOfType(Author.class)).isEqualTo(2L);
+
+        Filter filter = new Filter("name", ComparisonOperator.EQUALS, "Bob");
+        filter.setNestedPropertyName("author");
+        filter.setNestedPropertyType(Author.class);
+        filter.setOwnerEntityType(Content.class);
+        session.delete(Content.class, new Filters(filter), false);
+
+        session.clear();
+        assertEntityCount(1);
+        assertThat(session.countEntitiesOfType(Article.class)).isOne();
+        assertThat(session.countEntitiesOfType(Author.class)).isEqualTo(2L);
+    }
+
+    @Test // L3
+    void deletionOfSameClassNameShouldNotDeleteWrongRecords() {
+
+        session.query("CREATE (a:Order {name: 'Order A'}) RETURN id(a) AS id", Map.of());
+        session.query("CREATE (a:SalesOrder {name: 'Order B'}) RETURN id(a) AS id", Map.of());
+
+        session.delete(org.neo4j.ogm.domain.l3.b.Order.class, new Filters(), false);
+
+        session.clear();
+        assertThat(session.countEntitiesOfType(org.neo4j.ogm.domain.l3.a.Order.class)).isOne();
+        assertThat(session.countEntitiesOfType(org.neo4j.ogm.domain.l3.b.Order.class)).isZero();
     }
 }

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
@@ -104,7 +104,8 @@ public class QueryCapabilityTest extends TestContainersTestBase {
             "org.neo4j.ogm.domain.gh726",
             "org.neo4j.ogm.domain.gh851",
             "org.neo4j.ogm.domain.gh875",
-            "org.neo4j.ogm.domain.sdn2306"
+            "org.neo4j.ogm.domain.sdn2306",
+            "org.neo4j.ogm.domain.l3"
         );
         session = sessionFactory.openSession();
         session.purgeDatabase();
@@ -1058,5 +1059,19 @@ public class QueryCapabilityTest extends TestContainersTestBase {
             }
         }
         return false;
+    }
+
+    @Test // L3
+    void countShouldUseCorrectType() {
+
+        session.query("CREATE (a:Order {name: 'Order A'}) RETURN id(a) AS id", Map.of());
+
+        session.clear();
+        assertThat(session.countEntitiesOfType(org.neo4j.ogm.domain.l3.a.Order.class)).isOne();
+        assertThat(session.countEntitiesOfType(org.neo4j.ogm.domain.l3.b.Order.class)).isZero();
+
+        session.clear();
+        assertThat(session.count(org.neo4j.ogm.domain.l3.a.Order.class, new Filters())).isOne();
+        assertThat(session.count(org.neo4j.ogm.domain.l3.b.Order.class, new Filters())).isZero();
     }
 }


### PR DESCRIPTION
This prevents unintended deletes and wrong counts in case of multiple entities sharing the same class name and one of
them without a dedicated label.

That bug only is triggered by the manual use of explicit, nested filters.

This addresses the findings L1 and L3 from the security report.
