### PR TITLE
refactor: Replace variable placeholder `$` in favor of passing the variable down the call stack.

### DIFF
--- a/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/PagingAndSortingQuery.java
@@ -26,6 +26,7 @@ import java.util.Map;
  * just use {@link CypherQuery}
  *
  * @author Vince Bickers
+ * @author Michael J. Simons
  */
 public class PagingAndSortingQuery implements PagingAndSorting {
 
@@ -61,16 +62,16 @@ public class PagingAndSortingQuery implements PagingAndSorting {
     }
 
     public String getStatement() {
-        String sorting = sortOrder().asString();
 
         StringBuilder sb = new StringBuilder();
         sb.append(matchClause);
 
+        String sorting = sortOrder().asString(variable);
         if (!sorting.isEmpty()) {
-            sb.append(sorting.replace("$", variable));
+            sb.append(sorting);
         }
         if (pagination != null) {
-            sb.append(pagination.toString());
+            sb.append(pagination);
         }
         sb.append(this.returnClause);
         if (needsRowResult()) {

--- a/core/src/main/java/org/neo4j/ogm/cypher/query/SortClause.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/SortClause.java
@@ -47,7 +47,7 @@ public class SortClause {
 
     }
 
-    String asString() {
+    String asString(String variable) {
         StringBuilder sb = new StringBuilder();
 
         if (properties.length > 0) {
@@ -55,7 +55,7 @@ public class SortClause {
                 if (ignoreCase) {
                     sb.append("toLower(");
                 }
-                sb.append("$.").append(n);
+                sb.append(variable).append(".").append(n);
                 if (ignoreCase) {
                     sb.append(")");
                 }

--- a/core/src/main/java/org/neo4j/ogm/cypher/query/SortOrder.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/query/SortOrder.java
@@ -147,12 +147,12 @@ public class SortOrder {
         return !sortClauses.isEmpty();
     }
 
-    public String asString() {
+    public String asString(String variable) {
         StringBuilder sb = new StringBuilder();
         if (!sortClauses.isEmpty()) {
             sb.append(" ORDER BY ");
             for (SortClause ordering : sortClauses) {
-                sb.append(ordering.asString());
+                sb.append(ordering.asString(variable));
                 sb.append(",");
             }
             sb.deleteCharAt(sb.length() - 1);

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/f10/Stuff.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/f10/Stuff.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2026 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.ogm.domain.f10;
+
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
+import org.neo4j.ogm.annotation.NodeEntity;
+import org.neo4j.ogm.annotation.Property;
+
+@NodeEntity
+public class Stuff {
+    @Id @GeneratedValue
+    private Long id;
+    private String name;
+    @Property("price$usd") private Double priceUsd;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getPriceUsd() {
+        return priceUsd;
+    }
+
+    public void setPriceUsd(Double priceUsd) {
+        this.priceUsd = priceUsd;
+    }
+}

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
@@ -45,11 +45,14 @@ import org.neo4j.ogm.context.MappingContext;
 import org.neo4j.ogm.cypher.ComparisonOperator;
 import org.neo4j.ogm.cypher.Filter;
 import org.neo4j.ogm.cypher.Filters;
+import org.neo4j.ogm.cypher.query.Pagination;
+import org.neo4j.ogm.cypher.query.SortOrder;
 import org.neo4j.ogm.domain.cineasts.annotated.Actor;
 import org.neo4j.ogm.domain.cineasts.annotated.Movie;
 import org.neo4j.ogm.domain.cineasts.annotated.Pet;
 import org.neo4j.ogm.domain.cineasts.annotated.Rating;
 import org.neo4j.ogm.domain.cineasts.annotated.User;
+import org.neo4j.ogm.domain.f10.Stuff;
 import org.neo4j.ogm.domain.gh726.package_a.SameClass;
 import org.neo4j.ogm.domain.gh851.Airport;
 import org.neo4j.ogm.domain.gh851.Flight;
@@ -105,6 +108,7 @@ public class QueryCapabilityTest extends TestContainersTestBase {
             "org.neo4j.ogm.domain.gh851",
             "org.neo4j.ogm.domain.gh875",
             "org.neo4j.ogm.domain.sdn2306",
+            "org.neo4j.ogm.domain.f10",
             "org.neo4j.ogm.domain.l3"
         );
         session = sessionFactory.openSession();
@@ -1073,5 +1077,24 @@ public class QueryCapabilityTest extends TestContainersTestBase {
         session.clear();
         assertThat(session.count(org.neo4j.ogm.domain.l3.a.Order.class, new Filters())).isOne();
         assertThat(session.count(org.neo4j.ogm.domain.l3.b.Order.class, new Filters())).isZero();
+    }
+
+    @Test // F10
+    void shouldBeAbleToSortOnFunkyPropertyNames() {
+
+        session.query("""
+            WITH range(1, 5) AS r
+            UNWIND r AS v  WITH v ORDER by randomUUID()
+            CREATE (s:Stuff {name: 'Item ' + v, `price$usd`: v*1.10}) RETURN s
+            """, Map.of());
+        session.clear();
+
+        var stuff = session.loadAll(Stuff.class, new SortOrder().asc("priceUsd"), new Pagination(0,20));
+        assertThat(stuff)
+            .hasSize(5)
+            .map(Stuff::getName)
+            .containsExactly("Item 1", "Item 2", "Item 3", "Item 4", "Item 5");
+
+
     }
 }


### PR DESCRIPTION
This avoids a global search and replace in the sort fragment, which would in case of "unusual" property names such as
`price$usd` prevent entities being sorted properly.

This addresses F10 from the security report.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
