### PR TITLE
Fix: Group entities also by removed / updated properties before multi-statement updates.

### DIFF
--- a/api/src/main/java/org/neo4j/ogm/response/model/AbstractPropertyContainer.java
+++ b/api/src/main/java/org/neo4j/ogm/response/model/AbstractPropertyContainer.java
@@ -53,11 +53,16 @@ abstract class AbstractPropertyContainer implements PropertyContainer {
         this.previousDynamicCompositeProperties = new HashSet<>(previousDynamicCompositeProperties);
     }
 
+    protected Set<String> propertiesToBeRemoved() {
+        Set<String> propertiesToBeRemoved = new HashSet<>(this.previousDynamicCompositeProperties);
+        propertiesToBeRemoved.removeAll(this.currentDynamicCompositeProperties);
+        return propertiesToBeRemoved;
+    }
+
     @Override
     public String createPropertyRemovalFragment(String variable) {
 
-        Set<String> propertiesToBeRemoved = new HashSet<>(this.previousDynamicCompositeProperties);
-        propertiesToBeRemoved.removeAll(this.currentDynamicCompositeProperties);
+        Set<String> propertiesToBeRemoved = propertiesToBeRemoved();
 
         if (propertiesToBeRemoved.isEmpty()) {
             return "";

--- a/api/src/main/java/org/neo4j/ogm/response/model/NodeModel.java
+++ b/api/src/main/java/org/neo4j/ogm/response/model/NodeModel.java
@@ -135,10 +135,10 @@ public class NodeModel extends AbstractPropertyContainer implements Node {
 
     @Override
     public String labelSignature() {
-        return Stream.concat(
+        return Stream.concat(Stream.concat(
             Arrays.stream(labels),
             Optional.ofNullable(previousDynamicLabels).orElseGet(HashSet::new).stream()
-        ).distinct().collect(joining(","));
+        ), propertiesToBeRemoved().stream()).distinct().collect(joining(","));
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/ogm/cypher/compiler/MultiStatementCypherCompiler.java
+++ b/core/src/main/java/org/neo4j/ogm/cypher/compiler/MultiStatementCypherCompiler.java
@@ -326,11 +326,10 @@ public class MultiStatementCypherCompiler implements Compiler {
             if (!relsByType.containsKey(relationshipBuilder.type())) {
                 relsByType.put(relationshipBuilder.type(), new HashSet<>());
             }
-            //Replace the node ids
+            // Replace the node ids
             RelationshipModel edge = (RelationshipModel) relationshipBuilder.edge();
             edge.setStartNode(context.getId(edge.getStartNode()));
             edge.setEndNode(context.getId(edge.getEndNode()));
-            relsByType.get(relationshipBuilder.type()).add(edge);
             relsByType.get(relationshipBuilder.type()).add(edge);
         }
         return relsByType;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Thing.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/domain/escaping/Thing.java
@@ -28,8 +28,12 @@ import org.neo4j.ogm.annotation.Properties;
 
 @NodeEntity
 public class Thing {
-    @Id @GeneratedValue Long id;
-    @Properties Map<String, Object> attrs = new HashMap<>();
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @Properties
+    private final Map<String, Object> attrs = new HashMap<>();
 
     public Long getId() {
         return id;

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/QueryCapabilityTest.java
@@ -1054,8 +1054,7 @@ public class QueryCapabilityTest extends TestContainersTestBase {
     }
 
     private static boolean checkForMichal(Map<String, Object> result) {
-        if (result.get("n") instanceof User) {
-            User u = (User) result.get("n");
+        if (result.get("n") instanceof User u) {
             if (u.getName().equals("Michal")) {
                 assertThat(u.getFriends()).hasSize(1);
                 assertThat(u.getFriends().iterator().next().getName()).isEqualTo("Vince");

--- a/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
+++ b/neo4j-ogm-tests/neo4j-ogm-integration-tests/src/test/java/org/neo4j/ogm/persistence/session/capability/SaveCapabilityTest.java
@@ -21,18 +21,22 @@ package org.neo4j.ogm.persistence.session.capability;
 import static org.assertj.core.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.neo4j.ogm.context.EntityGraphMapper;
 import org.neo4j.ogm.cypher.compiler.CompileContext;
+import org.neo4j.ogm.domain.escaping.Thing;
 import org.neo4j.ogm.domain.gh787.EntityWithCustomIdConverter;
 import org.neo4j.ogm.domain.gh787.MyVeryOwnIdType;
 import org.neo4j.ogm.domain.gh789.Entity;
@@ -59,7 +63,7 @@ public class SaveCapabilityTest extends TestContainersTestBase {
     @BeforeEach
     public void init() throws IOException {
         SessionFactory sessionFactory = new SessionFactory(getDriver(), "org.neo4j.ogm.domain.music",
-            "org.neo4j.ogm.domain.gh787", "org.neo4j.ogm.domain.gh789");
+            "org.neo4j.ogm.domain.gh787", "org.neo4j.ogm.domain.gh789", "org.neo4j.ogm.domain.escaping");
         session = sessionFactory.openSession();
         session.purgeDatabase();
         aerosmith = new Artist("Aerosmith");
@@ -101,7 +105,7 @@ public class SaveCapabilityTest extends TestContainersTestBase {
     // GH-84
     @Test
     void saveCollectionShouldSaveArrays() {
-        Artist[] artists = new Artist[]{aerosmith, bonJovi, defLeppard};
+        Artist[] artists = new Artist[] { aerosmith, bonJovi, defLeppard };
         session.save(artists);
         session.clear();
         assertThat(session.countEntitiesOfType(Artist.class)).isEqualTo(3);
@@ -230,5 +234,44 @@ public class SaveCapabilityTest extends TestContainersTestBase {
 
         entity = session.load(Entity.class, entity.getKey());
         assertThat(entity.getSome()).isEqualTo("Some value");
+    }
+
+    @RepeatedTest(failureThreshold = 1, value = 32)
+    void updateOfRemovedPropertiesMustBeDeterministic() {
+
+        var a = new Thing();
+        a.addAttr("reviewer", "bob");
+        a.addAttr("priority", "high");
+
+        var entities = new ArrayList<Thing>();
+        var random = ThreadLocalRandom.current();
+        var pick = random.nextInt(0, 99);
+        for (int i = 0; i < 100; ++i) {
+            var b = new Thing();
+            b.addAttr("reviewer", "ann");
+            entities.add(b);
+            if (i == pick) {
+                entities.add(a);
+            }
+        }
+
+        session.save(entities);
+        session.clear();
+
+        entities = new ArrayList<>(session.loadAll(Thing.class));
+        var id = a.getId();
+        a = entities.stream().filter(e -> e.getId().equals(id)).findFirst().orElseThrow();
+        for (Thing e : entities) {
+            if (e != a && random.nextInt() % 2 == 0) {
+                e.addAttr("reviewer", "New Bob");
+            }
+        }
+        a.removeAttr("priority");
+
+        session.save(entities);
+        session.clear();
+
+        a = session.load(Thing.class, a.getId());
+        assertThat(a.getAttrs()).doesNotContainKey("priority");
     }
 }


### PR DESCRIPTION
This prevents unwanted deletion of dynamic properties and likewise, missing deletion of dynamic properties. While the
fix could also be done in pure Cypher in 2026, Neo4j-OGM still supports Neo4j version that do not support the necessary
Cypher constructs.

This change addresses L2 of the security report.

Signed-off-by: Michael Simons <michael.simons@neo4j.com>
